### PR TITLE
feat(backend): configure MySQL connection via Doctrine

### DIFF
--- a/web/backend/config/packages/doctrine.yaml
+++ b/web/backend/config/packages/doctrine.yaml
@@ -1,11 +1,6 @@
 doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
-
-        # IMPORTANT: You MUST configure your server version,
-        # either here or in the DATABASE_URL env var (see .env file)
-        #server_version: '16'
-
         profiling_collect_backtrace: '%kernel.debug%'
         use_savepoints: true
     orm:


### PR DESCRIPTION
## Summary

- Nettoyage de `doctrine.yaml` : suppression du commentaire PostgreSQL résiduel
- La `server_version` MySQL est portée par la `DATABASE_URL` (`.env`)
- Connexion validée : `doctrine:schema:validate` retourne OK sur les deux checks

## Test plan

- [ ] `php bin/console doctrine:schema:validate` retourne OK
- [ ] `php bin/console doctrine:database:create` crée la BD sans erreur