### PR TITLE
feat(backend): add API routes with bot authentication

### DIFF
--- a/web/backend/config/packages/security.yaml
+++ b/web/backend/config/packages/security.yaml
@@ -1,39 +1,39 @@
 security:
-    # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
     password_hashers:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
-    # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
+
     providers:
-        users_in_memory: { memory: null }
+        app_user_provider:
+            id: App\Security\UserProvider
+
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
+
+        api:
+            pattern: ^/api
+            stateless: true
+            provider: app_user_provider
+            custom_authenticators:
+                - App\Security\BotAuthenticator
+
         main:
             lazy: true
-            provider: users_in_memory
 
-            # activate different ways to authenticate
-            # https://symfony.com/doc/current/security.html#the-firewall
-
-            # https://symfony.com/doc/current/security/impersonating_user.html
-            # switch_user: true
-
-    # Easy way to control access for large sections of your site
-    # Note: Only the *first* access control that matches will be used
     access_control:
-        # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }
+        - { path: ^/api/profile, roles: ROLE_USER }
+        - { path: ^/api/travel, roles: ROLE_USER }
+        - { path: ^/api/commands, roles: ROLE_USER }
+        - { path: ^/api/shop/purchase, roles: ROLE_USER }
+        - { path: ^/api/leaderboard/me, roles: ROLE_USER }
+        - { path: ^/api, roles: PUBLIC_ACCESS }
 
 when@test:
     security:
         password_hashers:
-            # By default, password hashers are resource intensive and take time. This is
-            # important to generate secure password hashes. In tests however, secure hashes
-            # are not important, waste resources and increase test times. The following
-            # reduces the work factor to the lowest possible values.
             Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
                 algorithm: auto
-                cost: 4 # Lowest possible value for bcrypt
-                time_cost: 3 # Lowest possible value for argon
-                memory_cost: 10 # Lowest possible value for argon
+                cost: 4
+                time_cost: 3
+                memory_cost: 10

--- a/web/backend/src/Controller/API/AbstractApiController.php
+++ b/web/backend/src/Controller/API/AbstractApiController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+abstract class AbstractApiController extends AbstractController
+{
+    protected function getCurrentUser(): ?User
+    {
+        $user = $this->getUser();
+        return $user instanceof User ? $user : null;
+    }
+
+    protected function requireUser(): User
+    {
+        $user = $this->getCurrentUser();
+        if (!$user) {
+            throw new \RuntimeException('User not authenticated');
+        }
+        return $user;
+    }
+
+    protected function errorResponse(string $message, int $statusCode = Response::HTTP_BAD_REQUEST): JsonResponse
+    {
+        return new JsonResponse(['error' => $message], $statusCode);
+    }
+
+    protected function successResponse(array $data, int $statusCode = Response::HTTP_OK): JsonResponse
+    {
+        return new JsonResponse($data, $statusCode);
+    }
+
+    protected function unauthorizedResponse(string $message = 'Not authenticated'): JsonResponse
+    {
+        return $this->errorResponse($message, Response::HTTP_UNAUTHORIZED);
+    }
+
+    protected function notFoundResponse(string $message = 'Resource not found'): JsonResponse
+    {
+        return $this->errorResponse($message, Response::HTTP_NOT_FOUND);
+    }
+}

--- a/web/backend/src/Controller/API/CityController.php
+++ b/web/backend/src/Controller/API/CityController.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Repository\CityRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/cities', name: 'api_cities_')]
+class CityController extends AbstractController
+{
+    public function __construct(
+        private CityRepository $cityRepository
+    ) {}
+
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        $cities = $this->cityRepository->findAll();
+
+        $data = array_map(function ($city) {
+            return [
+                'city_id' => $city->getCityId(),
+                'name' => $city->getName(),
+                'description' => $city->getDescription(),
+                'emoji' => $city->getEmoji(),
+                'theme' => $city->getTheme(),
+                'position_x' => $city->getPositionX(),
+                'position_y' => $city->getPositionY(),
+            ];
+        }, $cities);
+
+        return $this->json($data);
+    }
+
+    #[Route('/{cityId}', name: 'show', methods: ['GET'])]
+    public function show(string $cityId): JsonResponse
+    {
+        $city = $this->cityRepository->findOneWithDetails($cityId);
+
+        if (!$city) {
+            return $this->json(['error' => 'City not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $jobs = array_map(function ($job) {
+            return [
+                'job_id' => $job->getJobId(),
+                'name' => $job->getJobName(),
+                'emoji' => $job->getJobEmoji(),
+                'task_1' => $job->getTask1(),
+                'task_2' => $job->getTask2(),
+                'task_3' => $job->getTask3(),
+            ];
+        }, $city->getJobs()->toArray());
+
+        $routes = array_map(function ($route) {
+            return [
+                'route_id' => $route->getRouteId(),
+                'city_to' => $route->getCityTo()->getCityId(),
+                'destination_name' => $route->getCityTo()->getName(),
+                'destination_emoji' => $route->getCityTo()->getEmoji(),
+                'cost' => $route->getCost(),
+                'duration' => $route->getDuration(),
+            ];
+        }, $city->getRoutesFrom()->toArray());
+
+        return $this->json([
+            'city' => [
+                'city_id' => $city->getCityId(),
+                'name' => $city->getName(),
+                'description' => $city->getDescription(),
+                'emoji' => $city->getEmoji(),
+                'theme' => $city->getTheme(),
+                'position_x' => $city->getPositionX(),
+                'position_y' => $city->getPositionY(),
+            ],
+            'jobs' => $jobs,
+            'routes' => $routes,
+        ]);
+    }
+
+    #[Route('/{cityId}/jobs', name: 'jobs', methods: ['GET'])]
+    public function jobs(string $cityId): JsonResponse
+    {
+        $city = $this->cityRepository->find($cityId);
+
+        if (!$city) {
+            return $this->json(['error' => 'City not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $jobs = array_map(function ($job) {
+            return [
+                'job_id' => $job->getJobId(),
+                'city_id' => $job->getCity()->getCityId(),
+                'name' => $job->getJobName(),
+                'emoji' => $job->getJobEmoji(),
+                'task_1' => $job->getTask1(),
+                'task_2' => $job->getTask2(),
+                'task_3' => $job->getTask3(),
+            ];
+        }, $city->getJobs()->toArray());
+
+        return $this->json($jobs);
+    }
+
+    #[Route('/{cityId}/routes', name: 'routes', methods: ['GET'])]
+    public function routes(string $cityId): JsonResponse
+    {
+        $city = $this->cityRepository->find($cityId);
+
+        if (!$city) {
+            return $this->json(['error' => 'City not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $routes = array_map(function ($route) {
+            return [
+                'route_id' => $route->getRouteId(),
+                'city_from' => $route->getCityFrom()->getCityId(),
+                'city_to' => $route->getCityTo()->getCityId(),
+                'destination_name' => $route->getCityTo()->getName(),
+                'destination_emoji' => $route->getCityTo()->getEmoji(),
+                'cost' => $route->getCost(),
+                'duration' => $route->getDuration(),
+            ];
+        }, $city->getRoutesFrom()->toArray());
+
+        return $this->json($routes);
+    }
+}

--- a/web/backend/src/Controller/API/CommandsController.php
+++ b/web/backend/src/Controller/API/CommandsController.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\CityJob;
+use App\Repository\CityJobRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/commands', name: 'api_commands_')]
+class CommandsController extends AbstractApiController
+{
+    private const DAILY_COOLDOWN = 86400;
+    private const WORK_COOLDOWN = 3600;
+    private const DAILY_REWARD = 5;
+    private const WORK_MIN_REWARD = 20;
+    private const WORK_MAX_REWARD = 30;
+    private const COINFLIP_MIN = 10;
+    private const COINFLIP_MAX = 500;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly CityJobRepository $cityJobRepository
+    ) {}
+
+    #[Route('/daily', name: 'daily', methods: ['POST'])]
+    public function daily(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return $this->unauthorizedResponse();
+        }
+
+        $lastDaily = $user->getLastDaily();
+        $now = time();
+
+        if ($lastDaily > 0) {
+            $timeSince = $now - $lastDaily;
+
+            if ($timeSince < self::DAILY_COOLDOWN) {
+                $remaining = self::DAILY_COOLDOWN - $timeSince;
+
+                return new JsonResponse([
+                    'success' => false,
+                    'message' => sprintf(
+                        '⏱️ Vous avez déjà réclamé votre récompense. Revenez dans %dh %dm.',
+                        floor($remaining / 3600),
+                        floor(($remaining % 3600) / 60)
+                    ),
+                    'next_daily' => $lastDaily + self::DAILY_COOLDOWN,
+                ], Response::HTTP_TOO_MANY_REQUESTS);
+            }
+        }
+
+        $user->setCoins($user->getCoins() + self::DAILY_REWARD);
+        $user->setLastDaily($now);
+        $this->entityManager->flush();
+
+        return new JsonResponse([
+            'success' => true,
+            'message' => '🎁 Vous avez reçu votre récompense quotidienne de ' . self::DAILY_REWARD . '€ !',
+            'coins' => $user->getCoins(),
+        ]);
+    }
+
+    #[Route('/work', name: 'work', methods: ['POST'])]
+    public function work(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return $this->unauthorizedResponse();
+        }
+
+        if ($user->getTravelingTo() !== null && $user->getArrivalTime() !== null && time() < $user->getArrivalTime()) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => '🚂 Vous êtes en voyage ! Vous ne pouvez pas travailler pendant un déplacement.',
+            ], Response::HTTP_CONFLICT);
+        }
+
+        $now = time();
+        $lastWork = $user->getLastWork();
+
+        if ($lastWork > 0) {
+            $timeSince = $now - $lastWork;
+
+            if ($timeSince < self::WORK_COOLDOWN) {
+                $remaining = self::WORK_COOLDOWN - $timeSince;
+
+                return new JsonResponse([
+                    'success' => false,
+                    'message' => sprintf(
+                        '⏱️ Vous êtes fatigué ! Reposez-vous encore %dh %dm avant de retravailler.',
+                        floor($remaining / 3600),
+                        floor(($remaining % 3600) / 60)
+                    ),
+                    'next_work' => $lastWork + self::WORK_COOLDOWN,
+                ], Response::HTTP_TOO_MANY_REQUESTS);
+            }
+        }
+
+        $currentCity = $user->getCurrentCity();
+
+        if (!$currentCity) {
+            return new JsonResponse(['success' => false, 'message' => "❌ Vous n'êtes dans aucune ville."], Response::HTTP_BAD_REQUEST);
+        }
+
+        $jobs = $this->cityJobRepository->findBy(['city' => $currentCity]);
+
+        if (empty($jobs)) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => "❌ Aucun travail n'est disponible à {$currentCity->getEmoji()} {$currentCity->getName()}.",
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        /** @var CityJob $randomJob */
+        $randomJob = $jobs[array_rand($jobs)];
+        $tasks = [$randomJob->getTask1(), $randomJob->getTask2(), $randomJob->getTask3()];
+        $task = $tasks[array_rand($tasks)];
+        $reward = random_int(self::WORK_MIN_REWARD, self::WORK_MAX_REWARD);
+
+        $user->setCoins($user->getCoins() + $reward);
+        $user->setLastWork($now);
+        $this->entityManager->flush();
+
+        return new JsonResponse([
+            'success' => true,
+            'message' => "{$randomJob->getJobEmoji()} Vous avez travaillé comme {$randomJob->getJobName()} et avez gagné {$reward}€ !\n\n📋 Tâche : {$task}",
+            'job_name' => $randomJob->getJobName(),
+            'job_emoji' => $randomJob->getJobEmoji(),
+            'task' => $task,
+            'reward' => $reward,
+            'coins' => $user->getCoins(),
+            'next_work' => $now + self::WORK_COOLDOWN,
+        ]);
+    }
+
+    #[Route('/coinflip', name: 'coinflip', methods: ['POST'])]
+    public function coinflip(Request $request): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return $this->unauthorizedResponse();
+        }
+
+        if ($user->getTravelingTo() !== null && $user->getArrivalTime() !== null && time() < $user->getArrivalTime()) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => '🚂 Vous êtes en voyage ! Vous ne pouvez pas jouer pendant un déplacement.',
+            ], Response::HTTP_CONFLICT);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $choice = $data['choice'] ?? null;
+        $amount = (int)($data['amount'] ?? 0);
+
+        if (!in_array($choice, ['pile', 'face'])) {
+            return new JsonResponse(['success' => false, 'message' => '❌ Choix invalide. Choisissez "pile" ou "face".'], Response::HTTP_BAD_REQUEST);
+        }
+
+        if ($amount < self::COINFLIP_MIN || $amount > self::COINFLIP_MAX) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => sprintf('❌ La mise doit être entre %d€ et %d€.', self::COINFLIP_MIN, self::COINFLIP_MAX),
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $maxBet = (int)min(floor($user->getCoins() / 2), self::COINFLIP_MAX);
+        if ($amount > $maxBet) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => "⚠️ Mise trop élevée ! Vous pouvez parier jusqu'à {$maxBet}€ (50% de votre solde ou 500€ max).",
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        if ($user->getCoins() < $amount) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => "❌ Vous n'avez pas assez d'argent. Solde actuel : {$user->getCoins()}€",
+            ], Response::HTTP_PAYMENT_REQUIRED);
+        }
+
+        $result = random_int(0, 1) === 0 ? 'pile' : 'face';
+        $won = $result === $choice;
+
+        $user->setCoins($won ? $user->getCoins() + $amount : $user->getCoins() - $amount);
+        $this->entityManager->flush();
+
+        return new JsonResponse([
+            'success' => true,
+            'won' => $won,
+            'result' => $result,
+            'amount' => $amount,
+            'message' => $won
+                ? "🎉 La pièce est tombée sur {$result} ! Vous gagnez {$amount}€ !"
+                : "😢 La pièce est tombée sur {$result}. Vous perdez {$amount}€.",
+            'coins' => $user->getCoins(),
+        ]);
+    }
+}

--- a/web/backend/src/Controller/API/JobController.php
+++ b/web/backend/src/Controller/API/JobController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Controller\API;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/jobs', name: 'api_jobs_')]
+class JobController extends AbstractController
+{
+    public function __construct(
+        private Connection $connection
+    ) {}
+
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        $jobs = $this->connection->fetchAllAssociative('
+            SELECT
+                j.job_id,
+                j.city_id,
+                j.job_name as name,
+                j.job_emoji as emoji,
+                j.task_1,
+                j.task_2,
+                j.task_3,
+                c.name as city_name,
+                c.emoji as city_emoji,
+                c.theme as city_theme
+            FROM city_jobs j
+            JOIN cities c ON c.city_id = j.city_id
+            ORDER BY j.city_id, j.job_name
+        ');
+
+        return $this->json($jobs);
+    }
+
+    #[Route('/{jobId}', name: 'show', methods: ['GET'])]
+    public function show(int $jobId): JsonResponse
+    {
+        $job = $this->connection->fetchAssociative('
+            SELECT
+                j.job_id,
+                j.city_id,
+                j.job_name as name,
+                j.job_emoji as emoji,
+                j.task_1,
+                j.task_2,
+                j.task_3,
+                c.name as city_name,
+                c.emoji as city_emoji,
+                c.theme as city_theme,
+                c.description as city_description
+            FROM city_jobs j
+            JOIN cities c ON c.city_id = j.city_id
+            WHERE j.job_id = :jobId
+        ', ['jobId' => $jobId]);
+
+        if (!$job) {
+            return $this->json(['error' => 'Job not found'], 404);
+        }
+
+        return $this->json($job);
+    }
+
+    #[Route('/theme/{theme}', name: 'by_theme', methods: ['GET'])]
+    public function byTheme(string $theme): JsonResponse
+    {
+        $jobs = $this->connection->fetchAllAssociative('
+            SELECT
+                j.job_id,
+                j.city_id,
+                j.job_name as name,
+                j.job_emoji as emoji,
+                j.task_1,
+                j.task_2,
+                j.task_3,
+                c.name as city_name,
+                c.emoji as city_emoji
+            FROM city_jobs j
+            JOIN cities c ON c.city_id = j.city_id
+            WHERE c.theme = :theme
+            ORDER BY c.name, j.job_name
+        ', ['theme' => $theme]);
+
+        return $this->json($jobs);
+    }
+}

--- a/web/backend/src/Controller/API/LeaderboardController.php
+++ b/web/backend/src/Controller/API/LeaderboardController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/leaderboard', name: 'api_leaderboard_')]
+class LeaderboardController extends AbstractApiController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository
+    ) {}
+
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function getLeaderboard(Request $request): JsonResponse
+    {
+        try {
+            $page = max(1, (int)$request->query->get('page', 1));
+            $limit = min(50, max(1, (int)$request->query->get('limit', 20)));
+            $offset = ($page - 1) * $limit;
+
+            $total = (int)$this->entityManager
+                ->createQuery('SELECT COUNT(u.user_id) FROM App\Entity\User u')
+                ->getSingleScalarResult();
+
+            $results = $this->entityManager
+                ->createQueryBuilder()
+                ->select('u')
+                ->from(User::class, 'u')
+                ->orderBy('u.coins', 'DESC')
+                ->setFirstResult($offset)
+                ->setMaxResults($limit)
+                ->getQuery()
+                ->getResult();
+
+            $entries = [];
+            $rank = $offset + 1;
+
+            foreach ($results as $user) {
+                $entries[] = [
+                    'rank' => $rank++,
+                    'discord_id' => $user->getUserId(),
+                    'username' => $user->getUsername(),
+                    'avatar' => $user->getDiscordAvatar(),
+                    'coins' => $user->getCoins(),
+                ];
+            }
+
+            $userRank = null;
+            $currentUser = $this->getCurrentUser();
+            if ($currentUser) {
+                $userRank = $this->getUserRank($currentUser);
+            }
+
+            return new JsonResponse([
+                'entries' => $entries,
+                'total' => $total,
+                'page' => $page,
+                'limit' => $limit,
+                'user_rank' => $userRank,
+            ]);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[Route('/me', name: 'user_rank', methods: ['GET'])]
+    public function getMyRank(): JsonResponse
+    {
+        $currentUser = $this->getCurrentUser();
+        if (!$currentUser) {
+            return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return new JsonResponse(['rank' => $this->getUserRank($currentUser)]);
+    }
+
+    private function getUserRank(User $user): int
+    {
+        return ((int)$this->entityManager
+            ->createQueryBuilder()
+            ->select('COUNT(u.user_id)')
+            ->from(User::class, 'u')
+            ->where('u.coins > :userCoins')
+            ->setParameter('userCoins', $user->getCoins())
+            ->getQuery()
+            ->getSingleScalarResult()) + 1;
+    }
+}

--- a/web/backend/src/Controller/API/ProfileController.php
+++ b/web/backend/src/Controller/API/ProfileController.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\UserEquippedBadge;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/profile', name: 'api_profile_')]
+class ProfileController extends AbstractApiController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {}
+
+    #[Route('/me', name: 'me', methods: ['GET'])]
+    public function getProfile(): JsonResponse
+    {
+        try {
+            $user = $this->getCurrentUser();
+
+            if (!$user) {
+                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            }
+
+            $equippedBadges = [];
+            foreach ($user->getEquippedBadges() as $badge) {
+                $equippedBadges[$badge->getSlotNumber()] = $badge->getBadgeId();
+            }
+            ksort($equippedBadges);
+
+            $currentCity = $user->getCurrentCity();
+
+            return new JsonResponse(['profile' => [
+                'user_id' => $user->getUserId(),
+                'username' => $user->getUsername(),
+                'discord_avatar' => $user->getDiscordAvatar(),
+                'coins' => $user->getCoins(),
+                'equipped_background' => $user->getEquippedBackground(),
+                'equipped_badges' => array_values($equippedBadges),
+                'current_city' => $currentCity?->getCityId(),
+                'current_city_name' => $currentCity?->getName() ?? 'Unknown',
+                'traveling_to' => $user->getTravelingTo()?->getCityId(),
+                'arrival_time' => $user->getArrivalTime(),
+                'created_at' => $user->getCreatedAt()->format('c'),
+                'visited_cities_count' => $user->getVisitedCities()->count(),
+                'inventory_count' => $user->getInventory()->count(),
+            ]]);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[Route('/equip/background', name: 'equip_background', methods: ['POST'])]
+    public function equipBackground(Request $request): JsonResponse
+    {
+        try {
+            $user = $this->getCurrentUser();
+
+            if (!$user) {
+                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            }
+
+            $data = json_decode($request->getContent(), true);
+            $itemId = $data['item_id'] ?? null;
+
+            if (!$itemId) {
+                return new JsonResponse(['success' => false, 'message' => 'Item ID requis'], Response::HTTP_BAD_REQUEST);
+            }
+
+            $ownsItem = false;
+            foreach ($user->getInventory() as $inventoryItem) {
+                if ($inventoryItem->getItemId() === $itemId && $inventoryItem->getItemType() === 'background') {
+                    $ownsItem = true;
+                    break;
+                }
+            }
+
+            if (!$ownsItem) {
+                return new JsonResponse(['success' => false, 'message' => 'Vous ne possédez pas ce background'], Response::HTTP_FORBIDDEN);
+            }
+
+            $user->setEquippedBackground($itemId);
+            $this->entityManager->flush();
+
+            return new JsonResponse(['success' => true, 'message' => 'Background équipé avec succès']);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[Route('/equip/badge', name: 'equip_badge', methods: ['POST'])]
+    public function equipBadge(Request $request): JsonResponse
+    {
+        try {
+            $user = $this->getCurrentUser();
+
+            if (!$user) {
+                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            }
+
+            $data = json_decode($request->getContent(), true);
+            $badgeId = $data['badge_id'] ?? null;
+            $slot = $data['slot'] ?? null;
+
+            if (!$badgeId || $slot === null) {
+                return new JsonResponse(['success' => false, 'message' => 'Badge ID et slot requis'], Response::HTTP_BAD_REQUEST);
+            }
+
+            if ($slot < 0 || $slot > 5) {
+                return new JsonResponse(['success' => false, 'message' => 'Slot invalide (0-5)'], Response::HTTP_BAD_REQUEST);
+            }
+
+            $ownsItem = false;
+            foreach ($user->getInventory() as $inventoryItem) {
+                if ($inventoryItem->getItemId() === $badgeId && $inventoryItem->getItemType() === 'badge') {
+                    $ownsItem = true;
+                    break;
+                }
+            }
+
+            if (!$ownsItem) {
+                return new JsonResponse(['success' => false, 'message' => 'Vous ne possédez pas ce badge'], Response::HTTP_FORBIDDEN);
+            }
+
+            foreach ($user->getEquippedBadges() as $equippedBadge) {
+                if ($equippedBadge->getBadgeId() === $badgeId) {
+                    return new JsonResponse(['success' => false, 'message' => 'Ce badge est déjà équipé'], Response::HTTP_CONFLICT);
+                }
+            }
+
+            foreach ($user->getEquippedBadges() as $equippedBadge) {
+                if ($equippedBadge->getSlotNumber() === $slot) {
+                    $this->entityManager->remove($equippedBadge);
+                    break;
+                }
+            }
+
+            $newEquippedBadge = new UserEquippedBadge();
+            $newEquippedBadge->setUser($user);
+            $newEquippedBadge->setBadgeId($badgeId);
+            $newEquippedBadge->setSlotNumber($slot);
+
+            $this->entityManager->persist($newEquippedBadge);
+            $this->entityManager->flush();
+
+            return new JsonResponse(['success' => true, 'message' => 'Badge équipé avec succès']);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[Route('/unequip/badge', name: 'unequip_badge', methods: ['POST'])]
+    public function unequipBadge(Request $request): JsonResponse
+    {
+        try {
+            $user = $this->getCurrentUser();
+
+            if (!$user) {
+                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            }
+
+            $data = json_decode($request->getContent(), true);
+            $slot = $data['slot'] ?? null;
+
+            if ($slot === null) {
+                return new JsonResponse(['success' => false, 'message' => 'Slot requis'], Response::HTTP_BAD_REQUEST);
+            }
+
+            $found = false;
+            foreach ($user->getEquippedBadges() as $equippedBadge) {
+                if ($equippedBadge->getSlotNumber() === (int)$slot) {
+                    $this->entityManager->remove($equippedBadge);
+                    $found = true;
+                    break;
+                }
+            }
+
+            if (!$found) {
+                return new JsonResponse(['success' => false, 'message' => 'Aucun badge dans ce slot'], Response::HTTP_NOT_FOUND);
+            }
+
+            $this->entityManager->flush();
+
+            return new JsonResponse(['success' => true, 'message' => 'Badge déséquipé avec succès']);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/web/backend/src/Controller/API/RouteController.php
+++ b/web/backend/src/Controller/API/RouteController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Controller\API;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/routes', name: 'api_routes_')]
+class RouteController extends AbstractController
+{
+    public function __construct(
+        private Connection $connection
+    ) {}
+
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        $routes = $this->connection->fetchAllAssociative('
+            SELECT
+                r.route_id,
+                r.city_from_id as city_from,
+                r.city_to_id as city_to,
+                r.cost,
+                r.duration,
+                cf.name as from_name,
+                cf.emoji as from_emoji,
+                ct.name as to_name,
+                ct.emoji as to_emoji
+            FROM routes r
+            JOIN cities cf ON cf.city_id = r.city_from_id
+            JOIN cities ct ON ct.city_id = r.city_to_id
+            ORDER BY r.city_from_id, r.city_to_id
+        ');
+
+        return $this->json($routes);
+    }
+
+    #[Route('/{routeId}', name: 'show', methods: ['GET'])]
+    public function show(int $routeId): JsonResponse
+    {
+        $route = $this->connection->fetchAssociative('
+            SELECT
+                r.route_id,
+                r.city_from_id as city_from,
+                r.city_to_id as city_to,
+                r.cost,
+                r.duration,
+                cf.name as from_name,
+                cf.emoji as from_emoji,
+                cf.theme as from_theme,
+                ct.name as to_name,
+                ct.emoji as to_emoji,
+                ct.theme as to_theme
+            FROM routes r
+            JOIN cities cf ON cf.city_id = r.city_from_id
+            JOIN cities ct ON ct.city_id = r.city_to_id
+            WHERE r.route_id = :routeId
+        ', ['routeId' => $routeId]);
+
+        if (!$route) {
+            return $this->json(['error' => 'Route not found'], 404);
+        }
+
+        return $this->json($route);
+    }
+}

--- a/web/backend/src/Controller/API/ShopController.php
+++ b/web/backend/src/Controller/API/ShopController.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\ShopItem;
+use App\Entity\UserInventory;
+use App\Repository\ShopItemRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/shop', name: 'api_shop_')]
+class ShopController extends AbstractApiController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ShopItemRepository $shopItemRepository
+    ) {}
+
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function getShopItems(Request $request): JsonResponse
+    {
+        try {
+            $user = $this->getCurrentUser();
+            $type = $request->query->get('type');
+
+            $qb = $this->shopItemRepository->createQueryBuilder('s')
+                ->where('s.available = :available')
+                ->setParameter('available', true)
+                ->orderBy('s.item_type', 'ASC')
+                ->addOrderBy('s.price', 'ASC');
+
+            if ($type && in_array($type, ['background', 'badge'])) {
+                $qb->andWhere('s.item_type = :type')->setParameter('type', $type);
+            }
+
+            $shopItems = $qb->getQuery()->getResult();
+
+            $ownedItemIds = [];
+            $equippedBackground = null;
+            $equippedBadgeIds = [];
+
+            if ($user) {
+                foreach ($user->getInventory() as $inventoryItem) {
+                    $ownedItemIds[] = $inventoryItem->getItemId();
+                }
+                $equippedBackground = $user->getEquippedBackground();
+                foreach ($user->getEquippedBadges() as $equippedBadge) {
+                    $equippedBadgeIds[] = $equippedBadge->getBadgeId();
+                }
+            }
+
+            $items = array_map(function (ShopItem $item) use ($ownedItemIds, $equippedBackground, $equippedBadgeIds) {
+                $itemData = $item->toArray();
+                $itemData['owned'] = in_array($item->getItemId(), $ownedItemIds);
+                $itemData['equipped'] = match ($item->getItemType()) {
+                    'background' => $item->getItemId() === $equippedBackground,
+                    'badge' => in_array($item->getItemId(), $equippedBadgeIds),
+                    default => false,
+                };
+                return $itemData;
+            }, $shopItems);
+
+            return new JsonResponse([
+                'items' => $items,
+                'user_coins' => $user?->getCoins() ?? 0,
+            ]);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[Route('/purchase', name: 'purchase', methods: ['POST'])]
+    public function purchaseItem(Request $request): JsonResponse
+    {
+        try {
+            $user = $this->getCurrentUser();
+
+            if (!$user) {
+                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            }
+
+            $data = json_decode($request->getContent(), true);
+            $itemId = $data['item_id'] ?? null;
+
+            if (!$itemId) {
+                return new JsonResponse(['success' => false, 'message' => 'Item ID requis'], Response::HTTP_BAD_REQUEST);
+            }
+
+            $item = $this->shopItemRepository->find($itemId);
+
+            if (!$item) {
+                return new JsonResponse(['success' => false, 'message' => "Cet item n'existe pas"], Response::HTTP_NOT_FOUND);
+            }
+
+            if (!$item->isAvailable()) {
+                return new JsonResponse(['success' => false, 'message' => "Cet item n'est plus disponible"], Response::HTTP_BAD_REQUEST);
+            }
+
+            foreach ($user->getInventory() as $inventoryItem) {
+                if ($inventoryItem->getItemId() === $itemId) {
+                    return new JsonResponse(['success' => false, 'message' => 'Vous possédez déjà cet item'], Response::HTTP_CONFLICT);
+                }
+            }
+
+            if ($user->getCoins() < $item->getPrice()) {
+                return new JsonResponse([
+                    'success' => false,
+                    'message' => sprintf("Vous n'avez pas assez d'argent. (%d€ / %d€)", $user->getCoins(), $item->getPrice()),
+                ], Response::HTTP_PAYMENT_REQUIRED);
+            }
+
+            $this->entityManager->beginTransaction();
+
+            try {
+                $user->setCoins($user->getCoins() - $item->getPrice());
+
+                $inventoryEntry = new UserInventory();
+                $inventoryEntry->setUser($user);
+                $inventoryEntry->setItemType($item->getItemType());
+                $inventoryEntry->setItemId($item->getItemId());
+
+                $this->entityManager->persist($inventoryEntry);
+                $this->entityManager->flush();
+                $this->entityManager->commit();
+
+                return new JsonResponse([
+                    'success' => true,
+                    'message' => sprintf('Vous avez acheté %s pour %d€ !', $item->getName(), $item->getPrice()),
+                    'new_balance' => $user->getCoins(),
+                    'item' => array_merge($item->toArray(), ['owned' => true]),
+                ]);
+            } catch (\Throwable $e) {
+                $this->entityManager->rollback();
+                throw $e;
+            }
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[Route('/{itemId}', name: 'get', methods: ['GET'])]
+    public function getItem(string $itemId): JsonResponse
+    {
+        try {
+            $user = $this->getCurrentUser();
+            $item = $this->shopItemRepository->find($itemId);
+
+            if (!$item) {
+                return new JsonResponse(['error' => 'Item not found'], Response::HTTP_NOT_FOUND);
+            }
+
+            $itemData = $item->toArray();
+
+            if ($user) {
+                $owned = false;
+                foreach ($user->getInventory() as $inventoryItem) {
+                    if ($inventoryItem->getItemId() === $itemId) {
+                        $owned = true;
+                        break;
+                    }
+                }
+                $itemData['owned'] = $owned;
+                $itemData['equipped'] = ($item->getItemType() === 'background' && $item->getItemId() === $user->getEquippedBackground());
+            }
+
+            return new JsonResponse(['item' => $itemData]);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/web/backend/src/Controller/API/StatsController.php
+++ b/web/backend/src/Controller/API/StatsController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\ShopItem;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/stats', name: 'api_stats_')]
+class StatsController extends AbstractController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager
+    ) {}
+
+    #[Route('', name: 'all', methods: ['GET'])]
+    public function getAllStats(): JsonResponse
+    {
+        try {
+            return new JsonResponse([
+                'global' => $this->getGlobalStatsData(),
+                'economy' => $this->getEconomyStatsData(),
+            ]);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[Route('/global', name: 'global', methods: ['GET'])]
+    public function getGlobalStats(): JsonResponse
+    {
+        try {
+            return new JsonResponse($this->getGlobalStatsData());
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private function getGlobalStatsData(): array
+    {
+        $em = $this->entityManager;
+
+        $totalUsers = (int)$em->createQuery('SELECT COUNT(u) FROM App\Entity\User u')->getSingleScalarResult();
+        $totalCities = (int)$em->createQuery('SELECT COUNT(c) FROM App\Entity\City c')->getSingleScalarResult();
+        $totalCoins = (int)$em->createQuery('SELECT COALESCE(SUM(u.coins), 0) FROM App\Entity\User u')->getSingleScalarResult();
+
+        $today = new \DateTime('-24 hours');
+        $activeToday = (int)$em->createQuery('SELECT COUNT(u) FROM App\Entity\User u WHERE u.updated_at >= :today')
+            ->setParameter('today', $today)->getSingleScalarResult();
+
+        $weekAgo = new \DateTime('-7 days');
+        $activeWeek = (int)$em->createQuery('SELECT COUNT(u) FROM App\Entity\User u WHERE u.updated_at >= :weekAgo')
+            ->setParameter('weekAgo', $weekAgo)->getSingleScalarResult();
+
+        return [
+            'total_users' => $totalUsers,
+            'total_cities' => $totalCities,
+            'total_coins_circulation' => $totalCoins,
+            'active_users_today' => $activeToday,
+            'active_users_week' => $activeWeek,
+        ];
+    }
+
+    private function getEconomyStatsData(): array
+    {
+        $em = $this->entityManager;
+
+        $avgCoins = (float)$em->createQuery('SELECT COALESCE(AVG(u.coins), 0) FROM App\Entity\User u')->getSingleScalarResult();
+        $richestCoins = (int)$em->createQuery('SELECT COALESCE(MAX(u.coins), 0) FROM App\Entity\User u')->getSingleScalarResult();
+        $totalPurchases = (int)$em->createQuery('SELECT COUNT(i) FROM App\Entity\UserInventory i')->getSingleScalarResult();
+
+        $mostPopularItem = 'N/A';
+        try {
+            $result = $em->createQuery('
+                SELECT i.item_id, COUNT(i) as purchase_count
+                FROM App\Entity\UserInventory i
+                GROUP BY i.item_id
+                ORDER BY purchase_count DESC
+            ')->setMaxResults(1)->getOneOrNullResult();
+
+            if ($result) {
+                $shopItem = $em->getRepository(ShopItem::class)->findOneBy(['item_id' => $result['item_id']]);
+                if ($shopItem) {
+                    $mostPopularItem = $shopItem->getName();
+                }
+            }
+        } catch (\Throwable) {}
+
+        return [
+            'average_coins_per_user' => (int)round($avgCoins),
+            'richest_user_coins' => $richestCoins,
+            'total_shop_purchases' => $totalPurchases,
+            'most_popular_item' => $mostPopularItem,
+        ];
+    }
+}

--- a/web/backend/src/Controller/API/TravelController.php
+++ b/web/backend/src/Controller/API/TravelController.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\VisitedCity;
+use App\Repository\CityRepository;
+use App\Repository\RouteRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/travel', name: 'api_travel_')]
+class TravelController extends AbstractApiController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly CityRepository $cityRepository,
+        private readonly RouteRepository $routeRepository,
+    ) {}
+
+    #[Route('/status', name: 'status', methods: ['GET'])]
+    public function status(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return $this->unauthorizedResponse();
+        }
+
+        $travelingTo = $user->getTravelingTo();
+        $arrivalTime = $user->getArrivalTime();
+
+        if (!$travelingTo || !$arrivalTime) {
+            return new JsonResponse(['traveling' => false]);
+        }
+
+        if (time() >= $arrivalTime) {
+            $this->completeTravel($user);
+            return new JsonResponse(['traveling' => false]);
+        }
+
+        return new JsonResponse([
+            'traveling' => true,
+            'destination' => $travelingTo->getCityId(),
+            'destination_name' => $travelingTo->getName(),
+            'destination_emoji' => $travelingTo->getEmoji(),
+            'arrival_time' => $arrivalTime,
+        ]);
+    }
+
+    #[Route('/map', name: 'map', methods: ['GET'])]
+    public function map(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return $this->unauthorizedResponse();
+        }
+
+        if ($user->getTravelingTo() && $user->getArrivalTime() && time() >= $user->getArrivalTime()) {
+            $this->completeTravel($user);
+        }
+
+        $city = $user->getCurrentCity();
+
+        $visitedIds = [];
+        foreach ($user->getVisitedCities() as $vc) {
+            $visitedIds[] = $vc->getCity()->getCityId();
+        }
+
+        $routes = array_map(function ($route) use ($visitedIds) {
+            $dest = $route->getCityTo();
+            $visited = in_array($dest->getCityId(), $visitedIds, true);
+            return [
+                'route_id' => $route->getRouteId(),
+                'city_to' => $dest->getCityId(),
+                'destination_name' => $dest->getName(),
+                'destination_emoji' => $dest->getEmoji(),
+                'cost' => $route->getCost(),
+                'duration' => $route->getDuration(),
+                'visited' => $visited,
+                'effective_cost' => $visited ? 0 : $route->getCost(),
+            ];
+        }, $city->getRoutesFrom()->toArray());
+
+        $jobs = array_map(function ($job) {
+            return [
+                'job_id' => $job->getJobId(),
+                'job_name' => $job->getJobName(),
+                'job_emoji' => $job->getJobEmoji(),
+                'task_1' => $job->getTask1(),
+                'task_2' => $job->getTask2(),
+                'task_3' => $job->getTask3(),
+            ];
+        }, $city->getJobs()->toArray());
+
+        return new JsonResponse([
+            'current_city' => [
+                'city_id' => $city->getCityId(),
+                'name' => $city->getName(),
+                'description' => $city->getDescription(),
+                'emoji' => $city->getEmoji(),
+                'theme' => $city->getTheme(),
+            ],
+            'coins' => $user->getCoins(),
+            'routes' => $routes,
+            'jobs' => $jobs,
+        ]);
+    }
+
+    #[Route('/start', name: 'start', methods: ['POST'])]
+    public function start(Request $request): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return $this->unauthorizedResponse();
+        }
+
+        if ($user->getTravelingTo() && $user->getArrivalTime() && time() < $user->getArrivalTime()) {
+            return new JsonResponse(['success' => false, 'message' => '🚂 Vous êtes déjà en voyage !'], Response::HTTP_CONFLICT);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $destinationId = $data['destination_id'] ?? null;
+
+        if (!$destinationId) {
+            return new JsonResponse(['success' => false, 'message' => 'destination_id requis'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $destination = $this->cityRepository->find($destinationId);
+
+        if (!$destination) {
+            return new JsonResponse(['success' => false, 'message' => "Cette ville n'existe pas."], Response::HTTP_NOT_FOUND);
+        }
+
+        $currentCity = $user->getCurrentCity();
+        $route = $this->routeRepository->findOneBy(['city_from' => $currentCity, 'city_to' => $destination]);
+
+        if (!$route) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => "Aucune route vers {$destination->getName()} depuis {$currentCity->getName()}.",
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        $alreadyVisited = false;
+        foreach ($user->getVisitedCities() as $vc) {
+            if ($vc->getCity()->getCityId() === $destinationId) {
+                $alreadyVisited = true;
+                break;
+            }
+        }
+
+        $travelCost = $alreadyVisited ? 0 : $route->getCost();
+
+        if ($travelCost > 0 && $user->getCoins() < $travelCost) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => "❌ Vous n'avez pas assez d'argent. ({$user->getCoins()}€ / {$travelCost}€)",
+            ], Response::HTTP_PAYMENT_REQUIRED);
+        }
+
+        if ($travelCost > 0) {
+            $user->setCoins($user->getCoins() - $travelCost);
+        }
+
+        $arrivalTime = time() + $route->getDuration();
+        $user->setTravelingTo($destination);
+        $user->setArrivalTime($arrivalTime);
+        $this->entityManager->flush();
+
+        return new JsonResponse([
+            'success' => true,
+            'message' => "Voyage commencé !",
+            'arrival_time' => $arrivalTime,
+            'travel_cost' => $travelCost,
+            'coins' => $user->getCoins(),
+        ]);
+    }
+
+    private function completeTravel(\App\Entity\User $user): void
+    {
+        $destination = $user->getTravelingTo();
+        if (!$destination) return;
+
+        $user->setCurrentCity($destination);
+        $user->setTravelingTo(null);
+        $user->setArrivalTime(null);
+
+        $alreadyVisited = false;
+        foreach ($user->getVisitedCities() as $vc) {
+            if ($vc->getCity()->getCityId() === $destination->getCityId()) {
+                $alreadyVisited = true;
+                break;
+            }
+        }
+
+        if (!$alreadyVisited) {
+            $visitedCity = new VisitedCity();
+            $visitedCity->setUser($user);
+            $visitedCity->setCity($destination);
+            $this->entityManager->persist($visitedCity);
+        }
+
+        $this->entityManager->flush();
+    }
+}

--- a/web/backend/src/Security/BotAuthenticator.php
+++ b/web/backend/src/Security/BotAuthenticator.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\City;
+use App\Entity\User;
+use App\Entity\UserInventory;
+use App\Entity\VisitedCity;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+class BotAuthenticator extends AbstractAuthenticator
+{
+    private const DEFAULT_CITY_ID = 'willowbrook';
+    private const DEFAULT_BACKGROUND_ID = 'bg_default';
+
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly EntityManagerInterface $entityManager,
+        #[Autowire(env: 'BOT_API_SECRET')]
+        private readonly string $botApiSecret,
+    ) {}
+
+    public function supports(Request $request): ?bool
+    {
+        return $request->headers->has('X-Bot-Secret');
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $secret = $request->headers->get('X-Bot-Secret');
+        $discordUserId = $request->headers->get('X-Discord-User-Id');
+        $discordUsername = $request->headers->get('X-Discord-Username', 'Unknown');
+
+        if (!$secret || $secret !== $this->botApiSecret) {
+            throw new CustomUserMessageAuthenticationException('Invalid bot secret.');
+        }
+
+        if (!$discordUserId) {
+            throw new CustomUserMessageAuthenticationException('Discord user ID required.');
+        }
+
+        return new SelfValidatingPassport(
+            new UserBadge($discordUserId, function (string $userId) use ($discordUsername) {
+                $user = $this->userRepository->find($userId);
+
+                if (!$user) {
+                    $user = $this->createUserForBot($userId, $discordUsername);
+                }
+
+                return $user;
+            })
+        );
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        return new JsonResponse([
+            'success' => false,
+            'message' => $exception->getMessage(),
+        ], Response::HTTP_UNAUTHORIZED);
+    }
+
+    private function createUserForBot(string $userId, string $username): User
+    {
+        $defaultCity = $this->entityManager->find(City::class, self::DEFAULT_CITY_ID);
+
+        if (!$defaultCity) {
+            throw new \RuntimeException('Default city not found: ' . self::DEFAULT_CITY_ID);
+        }
+
+        $user = new User();
+        $user->setUserId($userId);
+        $user->setUsername($username);
+        $user->setCurrentCity($defaultCity);
+
+        $inventory = new UserInventory();
+        $inventory->setUser($user);
+        $inventory->setItemType('background');
+        $inventory->setItemId(self::DEFAULT_BACKGROUND_ID);
+
+        $visitedCity = new VisitedCity();
+        $visitedCity->setUser($user);
+        $visitedCity->setCity($defaultCity);
+
+        $this->entityManager->persist($user);
+        $this->entityManager->persist($inventory);
+        $this->entityManager->persist($visitedCity);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/web/backend/src/Security/UserProvider.php
+++ b/web/backend/src/Security/UserProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Security;
+
+use App\Repository\UserRepository;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class UserProvider implements UserProviderInterface
+{
+    public function __construct(
+        private UserRepository $userRepository
+    ) {}
+
+    public function refreshUser(UserInterface $user): UserInterface
+    {
+        if (!$user instanceof \App\Entity\User) {
+            throw new UnsupportedUserException(sprintf('Invalid user class "%s".', get_class($user)));
+        }
+
+        $refreshedUser = $this->userRepository->find($user->getUserIdentifier());
+
+        if (!$refreshedUser) {
+            throw new UserNotFoundException(sprintf('User "%s" not found.', $user->getUserIdentifier()));
+        }
+
+        return $refreshedUser;
+    }
+
+    public function supportsClass(string $class): bool
+    {
+        return \App\Entity\User::class === $class || is_subclass_of($class, \App\Entity\User::class);
+    }
+
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        $user = $this->userRepository->find($identifier);
+
+        if (!$user) {
+            throw new UserNotFoundException(sprintf('User "%s" not found.', $identifier));
+        }
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- Authentification bot via `BotAuthenticator` (`X-Bot-Secret`) avec création automatique du profil utilisateur
- Firewall Symfony configuré pour l'API (stateless, access_control par ressource)
- 10 controllers REST : City, Route, Job, Shop, Travel, Commands (daily/work/coinflip), Leaderboard, Stats, Profile

Closes #29