### PR TITLE
SU #44 - OAuth Discord & configuration JWT

### DIFF
--- a/web/backend/config/packages/lexik_jwt_authentication.yaml
+++ b/web/backend/config/packages/lexik_jwt_authentication.yaml
@@ -2,3 +2,5 @@ lexik_jwt_authentication:
     secret_key: '%env(resolve:JWT_SECRET_KEY)%'
     public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
     pass_phrase: '%env(JWT_PASSPHRASE)%'
+    user_id_claim: user_id
+    token_ttl: 604800

--- a/web/backend/config/packages/security.yaml
+++ b/web/backend/config/packages/security.yaml
@@ -11,10 +11,16 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
+        auth:
+            pattern: ^/api/auth/discord
+            stateless: true
+            security: false
+
         api:
             pattern: ^/api
             stateless: true
             provider: app_user_provider
+            jwt: ~
             custom_authenticators:
                 - App\Security\BotAuthenticator
 
@@ -22,6 +28,11 @@ security:
             lazy: true
 
     access_control:
+        - { path: ^/api/auth/discord, roles: PUBLIC_ACCESS }
+        - { path: ^/api/auth/verify, roles: PUBLIC_ACCESS }
+        - { path: ^/api/auth/me, roles: ROLE_USER }
+        - { path: ^/api/auth/refresh, roles: ROLE_USER }
+        - { path: ^/api/auth/logout, roles: ROLE_USER }
         - { path: ^/api/profile, roles: ROLE_USER }
         - { path: ^/api/travel, roles: ROLE_USER }
         - { path: ^/api/commands, roles: ROLE_USER }

--- a/web/backend/config/services.yaml
+++ b/web/backend/config/services.yaml
@@ -20,5 +20,8 @@ services:
             - '../src/Entity/'
             - '../src/Kernel.php'
 
-    # add more service definitions when explicit configuration is needed
-    # please note that last definitions always *replace* previous ones
+    App\Service\Discord\DiscordApiClient:
+        arguments:
+            $clientId: '%env(DISCORD_CLIENT_ID)%'
+            $clientSecret: '%env(DISCORD_CLIENT_SECRET)%'
+            $redirectUri: '%env(DISCORD_REDIRECT_URI)%'

--- a/web/backend/src/Controller/API/AuthController.php
+++ b/web/backend/src/Controller/API/AuthController.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Service\Discord\DiscordOAuthService;
+use App\Service\User\UserService;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/auth', name: 'api_auth_')]
+class AuthController extends AbstractApiController
+{
+    public function __construct(
+        private readonly DiscordOAuthService $discordOAuth,
+        private readonly UserService $userService,
+        private readonly JWTTokenManagerInterface $jwtManager
+    ) {}
+
+    #[Route('/discord/login', name: 'discord_login', methods: ['GET'])]
+    public function discordLogin(Request $request): JsonResponse
+    {
+        $state = bin2hex(random_bytes(16));
+        $request->getSession()->set('oauth_state', $state);
+
+        return new JsonResponse([
+            'authorization_url' => $this->discordOAuth->getAuthorizationUrl($state),
+            'state' => $state,
+        ]);
+    }
+
+    #[Route('/discord/callback', name: 'discord_callback', methods: ['POST'])]
+    public function discordCallback(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $code = $data['code'] ?? null;
+
+        if (!$code) {
+            return new JsonResponse(['error' => 'Missing authorization code'], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $tokens = $this->discordOAuth->exchangeCode($code);
+            $discordUser = $this->discordOAuth->getDiscordUser($tokens->accessToken);
+            $user = $this->userService->findOrCreateFromDiscord($discordUser, $tokens);
+            $jwt = $this->jwtManager->create($user);
+
+            $guilds = $this->discordOAuth->getDiscordUserGuilds($tokens->accessToken);
+
+            return new JsonResponse([
+                'token' => $jwt,
+                'user' => $user->toArray(),
+                'guilds' => array_map(fn($guild) => [
+                    'id' => $guild->id,
+                    'name' => $guild->name,
+                    'icon' => $guild->getIconUrl(),
+                ], array_slice($guilds, 0, 10)),
+            ]);
+        } catch (\Exception $e) {
+            return new JsonResponse([
+                'error' => 'Authentication failed',
+                'message' => $e->getMessage(),
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+    }
+
+    #[Route('/refresh', name: 'refresh', methods: ['POST'])]
+    public function refresh(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        try {
+            if ($user->isAccessTokenExpired() && $user->getOauthRefreshToken()) {
+                $newTokens = $this->discordOAuth->refreshTokens($user->getOauthRefreshToken());
+                $this->userService->updateUserTokens($user, $newTokens);
+
+                $discordUser = $this->discordOAuth->getDiscordUser($newTokens->accessToken);
+                $this->userService->updateUserFromDiscord($user, $discordUser);
+                $this->userService->save($user);
+            }
+
+            return new JsonResponse([
+                'token' => $this->jwtManager->create($user),
+                'user' => $user->toArray(),
+            ]);
+        } catch (\Exception $e) {
+            return new JsonResponse([
+                'error' => 'Token refresh failed',
+                'message' => $e->getMessage(),
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+    }
+
+    #[Route('/logout', name: 'logout', methods: ['POST'])]
+    public function logout(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if ($user && $user->getOauthAccessToken()) {
+            $this->discordOAuth->revokeToken($user->getOauthAccessToken());
+        }
+
+        return new JsonResponse(['message' => 'Logged out successfully']);
+    }
+
+    #[Route('/me', name: 'me', methods: ['GET'])]
+    public function me(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return new JsonResponse(['user' => $user->toArray()]);
+    }
+
+    #[Route('/verify', name: 'verify', methods: ['GET'])]
+    public function verify(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        return new JsonResponse([
+            'valid' => $user !== null,
+            'user' => $user?->toArray(),
+        ]);
+    }
+}

--- a/web/backend/src/Controller/API/ProfileController.php
+++ b/web/backend/src/Controller/API/ProfileController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\API;
 
 use App\Entity\UserEquippedBadge;
+use App\Service\Discord\DiscordOAuthService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -14,6 +15,7 @@ class ProfileController extends AbstractApiController
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
+        private readonly DiscordOAuthService $discordOAuth,
     ) {}
 
     #[Route('/me', name: 'me', methods: ['GET'])]
@@ -51,6 +53,51 @@ class ProfileController extends AbstractApiController
             ]]);
         } catch (\Throwable $e) {
             return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[Route('/guilds', name: 'guilds', methods: ['GET'])]
+    public function getAdminGuilds(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $accessToken = $user->getOauthAccessToken();
+
+        if (!$accessToken) {
+            return new JsonResponse(['guilds' => []]);
+        }
+
+        try {
+            if ($user->isAccessTokenExpired() && $user->getOauthRefreshToken()) {
+                $newTokens = $this->discordOAuth->refreshTokens($user->getOauthRefreshToken());
+                $user->setOauthAccessToken($newTokens->accessToken);
+                $user->setOauthRefreshToken($newTokens->refreshToken);
+                $user->setOauthTokenExpiresAt($newTokens->getExpiresAt());
+                $this->entityManager->flush();
+
+                $accessToken = $newTokens->accessToken;
+            }
+
+            $allGuilds = $this->discordOAuth->getDiscordUserGuilds($accessToken, true);
+
+            $adminGuilds = array_filter($allGuilds, fn($guild) => $guild->owner || (((int)$guild->permissions & 0x8) === 0x8));
+
+            return new JsonResponse(['guilds' => array_values(array_map(fn($guild) => [
+                'id' => $guild->id,
+                'name' => $guild->name,
+                'icon' => $guild->icon,
+                'owner' => $guild->owner,
+                'permissions' => $guild->permissions,
+                'member_count' => $guild->approximate_member_count,
+                'presence_count' => $guild->approximate_presence_count,
+                'has_bot' => $this->discordOAuth->isBotInGuild($guild->id),
+            ], $adminGuilds))]);
+        } catch (\Exception $e) {
+            return new JsonResponse(['error' => 'Failed to fetch guilds', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/web/backend/src/Service/Discord/DTO/DiscordGuildDTO.php
+++ b/web/backend/src/Service/Discord/DTO/DiscordGuildDTO.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Service\Discord\DTO;
+
+readonly class DiscordGuildDTO
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public ?string $icon,
+        public bool $owner,
+        public int $permissions,
+        public ?int $approximate_member_count = null,
+        public ?int $approximate_presence_count = null
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            name: $data['name'],
+            icon: $data['icon'] ?? null,
+            owner: $data['owner'] ?? false,
+            permissions: (int) ($data['permissions'] ?? 0),
+            approximate_member_count: $data['approximate_member_count'] ?? null,
+            approximate_presence_count: $data['approximate_presence_count'] ?? null
+        );
+    }
+
+    public static function fromArrayList(array $guilds): array
+    {
+        return array_map(fn(array $guild) => self::fromArray($guild), $guilds);
+    }
+
+    public function getIconUrl(?int $size = 64): ?string
+    {
+        if (!$this->icon) {
+            return null;
+        }
+
+        $extension = str_starts_with($this->icon, 'a_') ? 'gif' : 'png';
+        return "https://cdn.discordapp.com/icons/{$this->id}/{$this->icon}.{$extension}?size={$size}";
+    }
+}

--- a/web/backend/src/Service/Discord/DTO/DiscordTokenDTO.php
+++ b/web/backend/src/Service/Discord/DTO/DiscordTokenDTO.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Service\Discord\DTO;
+
+readonly class DiscordTokenDTO
+{
+    public function __construct(
+        public string $accessToken,
+        public string $refreshToken,
+        public int $expiresIn,
+        public string $tokenType,
+        public string $scope
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            accessToken: $data['access_token'],
+            refreshToken: $data['refresh_token'],
+            expiresIn: $data['expires_in'],
+            tokenType: $data['token_type'] ?? 'Bearer',
+            scope: $data['scope'] ?? ''
+        );
+    }
+
+    public function getExpiresAt(): int
+    {
+        return time() + $this->expiresIn;
+    }
+}

--- a/web/backend/src/Service/Discord/DTO/DiscordUserDTO.php
+++ b/web/backend/src/Service/Discord/DTO/DiscordUserDTO.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Service\Discord\DTO;
+
+readonly class DiscordUserDTO
+{
+    public function __construct(
+        public string $id,
+        public string $username,
+        public ?string $discriminator,
+        public ?string $email,
+        public ?string $avatar,
+        public bool $verified,
+        public ?string $globalName
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            username: $data['username'],
+            discriminator: $data['discriminator'] ?? null,
+            email: $data['email'] ?? null,
+            avatar: $data['avatar'] ?? null,
+            verified: $data['verified'] ?? false,
+            globalName: $data['global_name'] ?? null
+        );
+    }
+
+    public function getDisplayName(): string
+    {
+        return $this->globalName ?? $this->username;
+    }
+}

--- a/web/backend/src/Service/Discord/DiscordApiClient.php
+++ b/web/backend/src/Service/Discord/DiscordApiClient.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Service\Discord;
+
+use App\Service\Discord\DTO\DiscordGuildDTO;
+use App\Service\Discord\DTO\DiscordTokenDTO;
+use App\Service\Discord\DTO\DiscordUserDTO;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class DiscordApiClient
+{
+    private const API_URL = 'https://discord.com/api/v10';
+    private const OAUTH_URL = 'https://discord.com/api/oauth2';
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $clientId,
+        private readonly string $clientSecret,
+        private readonly string $redirectUri
+    ) {}
+
+    public function getAuthorizationUrl(string $state, array $scopes = ['identify', 'email', 'guilds']): string
+    {
+        $params = [
+            'client_id' => $this->clientId,
+            'redirect_uri' => $this->redirectUri,
+            'response_type' => 'code',
+            'scope' => implode(' ', $scopes),
+            'state' => $state,
+            'prompt' => 'consent',
+        ];
+
+        return self::OAUTH_URL . '/authorize?' . http_build_query($params);
+    }
+
+    public function exchangeCodeForTokens(string $code): DiscordTokenDTO
+    {
+        $response = $this->httpClient->request('POST', self::OAUTH_URL . '/token', [
+            'headers' => ['Content-Type' => 'application/x-www-form-urlencoded'],
+            'body' => [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+                'grant_type' => 'authorization_code',
+                'code' => $code,
+                'redirect_uri' => $this->redirectUri,
+            ],
+        ]);
+
+        $this->assertSuccess($response, 'Failed to exchange code for tokens');
+
+        return DiscordTokenDTO::fromArray($response->toArray());
+    }
+
+    public function refreshTokens(string $refreshToken): DiscordTokenDTO
+    {
+        $response = $this->httpClient->request('POST', self::OAUTH_URL . '/token', [
+            'headers' => ['Content-Type' => 'application/x-www-form-urlencoded'],
+            'body' => [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+                'grant_type' => 'refresh_token',
+                'refresh_token' => $refreshToken,
+            ],
+        ]);
+
+        $this->assertSuccess($response, 'Failed to refresh tokens');
+
+        return DiscordTokenDTO::fromArray($response->toArray());
+    }
+
+    public function getCurrentUser(string $accessToken): DiscordUserDTO
+    {
+        $response = $this->httpClient->request('GET', self::API_URL . '/users/@me', [
+            'headers' => ['Authorization' => 'Bearer ' . $accessToken],
+        ]);
+
+        $this->assertSuccess($response, 'Failed to fetch Discord user');
+
+        return DiscordUserDTO::fromArray($response->toArray());
+    }
+
+    public function getCurrentUserGuilds(string $accessToken, bool $withCounts = true): array
+    {
+        $url = self::API_URL . '/users/@me/guilds';
+        if ($withCounts) {
+            $url .= '?with_counts=true';
+        }
+
+        $response = $this->httpClient->request('GET', $url, [
+            'headers' => ['Authorization' => 'Bearer ' . $accessToken],
+        ]);
+
+        if ($response->getStatusCode() !== 200) {
+            return [];
+        }
+
+        return DiscordGuildDTO::fromArrayList($response->toArray());
+    }
+
+    public function isBotInGuild(string $botToken, string $guildId): bool
+    {
+        try {
+            $response = $this->httpClient->request('GET', self::API_URL . '/guilds/' . $guildId, [
+                'headers' => ['Authorization' => 'Bot ' . $botToken],
+            ]);
+
+            return $response->getStatusCode() === 200;
+        } catch (\Exception) {
+            return false;
+        }
+    }
+
+    public function revokeToken(string $token): bool
+    {
+        try {
+            $response = $this->httpClient->request('POST', self::OAUTH_URL . '/token/revoke', [
+                'headers' => ['Content-Type' => 'application/x-www-form-urlencoded'],
+                'body' => [
+                    'client_id' => $this->clientId,
+                    'client_secret' => $this->clientSecret,
+                    'token' => $token,
+                ],
+            ]);
+
+            return $response->getStatusCode() === 200;
+        } catch (\Exception) {
+            return false;
+        }
+    }
+
+    private function assertSuccess($response, string $errorMessage): void
+    {
+        if ($response->getStatusCode() !== 200) {
+            throw new \RuntimeException($errorMessage . ': ' . $response->getContent(false));
+        }
+    }
+}

--- a/web/backend/src/Service/Discord/DiscordOAuthService.php
+++ b/web/backend/src/Service/Discord/DiscordOAuthService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Service\Discord;
+
+use App\Service\Discord\DTO\DiscordGuildDTO;
+use App\Service\Discord\DTO\DiscordTokenDTO;
+use App\Service\Discord\DTO\DiscordUserDTO;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+class DiscordOAuthService
+{
+    public function __construct(
+        private readonly DiscordApiClient $apiClient,
+        #[Autowire('%env(DISCORD_BOT_TOKEN)%')]
+        private readonly ?string $botToken = null
+    ) {}
+
+    public function getAuthorizationUrl(string $state): string
+    {
+        return $this->apiClient->getAuthorizationUrl($state);
+    }
+
+    public function exchangeCode(string $code): DiscordTokenDTO
+    {
+        return $this->apiClient->exchangeCodeForTokens($code);
+    }
+
+    public function refreshTokens(string $refreshToken): DiscordTokenDTO
+    {
+        return $this->apiClient->refreshTokens($refreshToken);
+    }
+
+    public function getDiscordUser(string $accessToken): DiscordUserDTO
+    {
+        return $this->apiClient->getCurrentUser($accessToken);
+    }
+
+    public function getDiscordUserGuilds(string $accessToken, bool $withCounts = true): array
+    {
+        return $this->apiClient->getCurrentUserGuilds($accessToken, $withCounts);
+    }
+
+    public function isBotInGuild(string $guildId): bool
+    {
+        if (!$this->botToken) {
+            return false;
+        }
+        return $this->apiClient->isBotInGuild($this->botToken, $guildId);
+    }
+
+    public function revokeToken(string $token): bool
+    {
+        return $this->apiClient->revokeToken($token);
+    }
+}

--- a/web/backend/src/Service/User/UserService.php
+++ b/web/backend/src/Service/User/UserService.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Service\User;
+
+use App\Entity\City;
+use App\Entity\User;
+use App\Entity\VisitedCity;
+use App\Repository\UserRepository;
+use App\Service\Discord\DTO\DiscordTokenDTO;
+use App\Service\Discord\DTO\DiscordUserDTO;
+use Doctrine\ORM\EntityManagerInterface;
+
+class UserService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository
+    ) {}
+
+    public function findOrCreateFromDiscord(DiscordUserDTO $discordUser, DiscordTokenDTO $tokens): User
+    {
+        $user = $this->userRepository->find($discordUser->id);
+
+        if (!$user) {
+            $user = $this->createNewUser($discordUser);
+        }
+
+        $this->updateUserFromDiscord($user, $discordUser);
+        $this->updateUserTokens($user, $tokens);
+        $user->recordLogin();
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    private function createNewUser(DiscordUserDTO $discordUser): User
+    {
+        $user = new User();
+        $user->setUserId($discordUser->id);
+
+        $defaultCity = $this->getDefaultCity();
+        if (!$defaultCity) {
+            throw new \RuntimeException('Aucune ville par défaut trouvée. Veuillez exécuter les fixtures.');
+        }
+        $user->setCurrentCity($defaultCity);
+
+        $visitedCity = new VisitedCity();
+        $visitedCity->setUser($user);
+        $visitedCity->setCity($defaultCity);
+
+        $user->addVisitedCity($visitedCity);
+        $this->entityManager->persist($visitedCity);
+
+        return $user;
+    }
+
+    public function updateUserFromDiscord(User $user, DiscordUserDTO $discordUser): void
+    {
+        $user->setUsername($discordUser->username);
+        $user->setDiscordAvatar($discordUser->avatar);
+        $user->setDiscordEmail($discordUser->email);
+    }
+
+    public function updateUserTokens(User $user, DiscordTokenDTO $tokens): void
+    {
+        $user->setOauthAccessToken($tokens->accessToken);
+        $user->setOauthRefreshToken($tokens->refreshToken);
+        $user->setOauthTokenExpiresAt($tokens->getExpiresAt());
+    }
+
+    public function save(User $user): void
+    {
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+    }
+
+    private function getDefaultCity(): ?City
+    {
+        $repo = $this->entityManager->getRepository(City::class);
+        return $repo->find('willowbrook') ?? $repo->findOneBy([]);
+    }
+}


### PR DESCRIPTION
## Résumé

- Couche Service/Discord : DiscordApiClient, DiscordOAuthService, 3 DTOs
- Service/User/UserService : création/mise à jour utilisateur depuis Discord OAuth
- AuthController : routes /api/auth/discord/login, /callback, /refresh, /logout, /me, /verify
- ProfileController : restauration de getAdminGuilds() avec refresh token automatique
- security.yaml : firewall auth (public) + firewall api avec jwt + BotAuthenticator, access_control complet
- services.yaml : binding DiscordApiClient avec env vars Discord
- lexik_jwt_authentication.yaml : user_id_claim user_id, token_ttl 604800 (7 jours)
- Clés JWT RSA générées (ignorées par .gitignore)

## Test plan

- [ ] GET /api/auth/discord/login retourne authorization_url + state
- [ ] POST /api/auth/discord/callback avec code valide retourne JWT + user + guilds
- [ ] GET /api/auth/verify sans token : valid false
- [ ] GET /api/auth/verify avec JWT valide : valid true
- [ ] POST /api/auth/logout avec JWT : révocation token Discord
- [ ] GET /api/profile/guilds avec JWT : liste des serveurs admin

Closes #44