### PR TITLE
SU #49-54 - Slash commands MazWorld

### DIFF
--- a/bot/src/commands/mazworld/cityinfo.ts
+++ b/bot/src/commands/mazworld/cityinfo.ts
@@ -1,0 +1,57 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { TravelStatus, MapResponse } from "./data";
+import { buildCityinfoEmbed } from "./utils/embeds";
+
+const cityinfo: Command = {
+  data: new SlashCommandBuilder()
+    .setName("cityinfo")
+    .setDescription("Découvrez les détails de votre ville actuelle"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const userId    = interaction.user.id;
+    const username  = interaction.user.username;
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      const travelStatus = await api.get<TravelStatus>("/api/travel/status", userId, username);
+
+      if (travelStatus.traveling && travelStatus.arrival_time) {
+        const timeLeft = travelStatus.arrival_time - Math.floor(Date.now() / 1000);
+        const hours    = Math.floor(timeLeft / 3600);
+        const minutes  = Math.floor((timeLeft % 3600) / 60);
+
+        await interaction.reply({
+          content:
+            `🚂 Vous êtes en voyage vers **${travelStatus.destination_emoji ?? ""} ${travelStatus.destination_name ?? ""}**\n` +
+            `⏱️ Arrivée dans ${hours}h ${minutes}m\n\n` +
+            `💡 Utilisez \`/cityinfo\` une fois arrivé pour découvrir la ville !`,
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      const mapData = await api.get<MapResponse>("/api/travel/map", userId, username);
+      await interaction.reply({ embeds: [buildCityinfoEmbed(mapData, avatarURL)] });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        await interaction.reply({ content: `❌ ${error.message}`, flags: MessageFlags.Ephemeral });
+        return;
+      }
+      console.error("Erreur dans /cityinfo:", error);
+      const errorMessage = "❌ Une erreur est survenue lors de l'affichage des informations de la ville.";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: errorMessage });
+      } else {
+        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default cityinfo;

--- a/bot/src/commands/mazworld/coinflip.ts
+++ b/bot/src/commands/mazworld/coinflip.ts
@@ -1,0 +1,72 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { CoinflipResponse } from "./data";
+import { buildCoinflipLoadingEmbed, buildCoinflipResultEmbed } from "./utils/embeds";
+
+const coinflip: Command = {
+  data: new SlashCommandBuilder()
+    .setName("coinflip")
+    .setDescription("Pariez vos coins sur pile ou face !")
+    .addStringOption(option =>
+      option
+        .setName("choix")
+        .setDescription("Choisissez 'pile' ou 'face'")
+        .setRequired(true)
+        .addChoices(
+          { name: "🪙 Pile", value: "pile" },
+          { name: "🎴 Face", value: "face" },
+        ),
+    )
+    .addIntegerOption(option =>
+      option
+        .setName("mise")
+        .setDescription("Montant à parier (10€ minimum)")
+        .setRequired(true)
+        .setMinValue(10)
+        .setMaxValue(500),
+    ),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const choix     = interaction.options.getString("choix", true) as "pile" | "face";
+    const mise      = interaction.options.getInteger("mise", true);
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      await interaction.reply({ embeds: [buildCoinflipLoadingEmbed(mise, choix, avatarURL)] });
+
+      const result = await api.post<CoinflipResponse>(
+        "/api/commands/coinflip",
+        interaction.user.id,
+        interaction.user.username,
+        { choice: choix, amount: mise },
+      );
+
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      await interaction.editReply({ embeds: [buildCoinflipResultEmbed(result, avatarURL)] });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        const content = `❌ ${error.message}`;
+        if (interaction.deferred || interaction.replied) {
+          await interaction.editReply({ content, embeds: [] });
+        } else {
+          await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+        }
+        return;
+      }
+      console.error("Erreur dans /coinflip:", error);
+      const errorMessage = "❌ Une erreur est survenue lors du lancement de la pièce.";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: errorMessage, embeds: [] });
+      } else {
+        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default coinflip;

--- a/bot/src/commands/mazworld/daily.ts
+++ b/bot/src/commands/mazworld/daily.ts
@@ -1,0 +1,45 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { DailyResponse } from "./data";
+import { buildDailySuccessEmbed, buildDailyAlreadyClaimedEmbed } from "./utils/embeds";
+
+const daily: Command = {
+  data: new SlashCommandBuilder()
+    .setName("daily")
+    .setDescription("Réclamez votre récompense quotidienne de 5€"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      const result = await api.post<DailyResponse>(
+        "/api/commands/daily",
+        interaction.user.id,
+        interaction.user.username,
+      );
+
+      if (result.success) {
+        await interaction.reply({ embeds: [buildDailySuccessEmbed(result, avatarURL)] });
+      } else {
+        await interaction.reply({ embeds: [buildDailyAlreadyClaimedEmbed(result, avatarURL)], flags: MessageFlags.Ephemeral });
+      }
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 429) {
+        await interaction.reply({ content: `⏰ ${error.message}`, flags: MessageFlags.Ephemeral });
+        return;
+      }
+      console.error("Erreur dans /daily:", error);
+      await interaction.reply({
+        content: "❌ Une erreur est survenue lors de la réclamation de votre récompense quotidienne.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  },
+};
+
+export default daily;

--- a/bot/src/commands/mazworld/inventory.ts
+++ b/bot/src/commands/mazworld/inventory.ts
@@ -1,0 +1,138 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  StringSelectMenuInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { ProfileResponse, ShopListResponse, EquipResponse } from "./data";
+import {
+  buildInventoryEmbed,
+  buildInventoryActionResultEmbed,
+  buildBackgroundMenuEmbed,
+  buildBadgeMenuEmbed,
+  buildSlotMenuEmbed,
+  buildUnequipMenuEmbed,
+} from "./utils/embeds";
+import {
+  buildInventoryButtons,
+  buildBackgroundSelectMenu,
+  buildBadgeSelectMenu,
+  buildSlotSelectMenu,
+  buildUnequipSelectMenu,
+} from "./utils/components";
+
+const inventory: Command = {
+  data: new SlashCommandBuilder()
+    .setName("inventory")
+    .setDescription("Consultez votre inventaire et gérez vos équipements"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const userId    = interaction.user.id;
+    const username  = interaction.user.username;
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      await interaction.deferReply();
+
+      const [profileRes, bgRes, badgeRes] = await Promise.all([
+        api.get<ProfileResponse>("/api/profile/me", userId, username),
+        api.get<ShopListResponse>("/api/shop?type=background", userId, username),
+        api.get<ShopListResponse>("/api/shop?type=badge", userId, username),
+      ]);
+
+      const profile     = profileRes.profile;
+      const backgrounds = bgRes.items.filter(i => i.owned);
+      const badges      = badgeRes.items.filter(i => i.owned);
+      const allItems    = [...bgRes.items, ...badgeRes.items];
+
+      const response = await interaction.editReply({
+        embeds: [buildInventoryEmbed(profile, backgrounds, badges, allItems, interaction.user.username, avatarURL)],
+        components: buildInventoryButtons(backgrounds.length > 0, badges.length > 0),
+      });
+
+      const collector = response.createMessageComponentCollector({
+        filter: (i) => i.user.id === userId,
+        time: 120_000,
+      });
+
+      collector.on("collect", async (i) => {
+        try {
+          await i.deferUpdate();
+
+          if (i.customId === "equip_background") {
+            if (backgrounds.length === 0) {
+              await i.editReply({ content: "❌ Vous ne possédez aucun background.", components: [] });
+              return;
+            }
+            await i.editReply({
+              embeds: [buildBackgroundMenuEmbed()],
+              components: [buildBackgroundSelectMenu(backgrounds, profile.equipped_background)],
+            });
+          } else if (i.customId === "equip_badge") {
+            if (badges.length === 0) {
+              await i.editReply({ content: "❌ Vous ne possédez aucun badge.", components: [] });
+              return;
+            }
+            await i.editReply({
+              embeds: [buildBadgeMenuEmbed()],
+              components: [buildBadgeSelectMenu(badges, allItems, profile.equipped_badges)],
+            });
+          } else if (i.customId === "unequip_badge") {
+            if (!profile.equipped_badges.some(Boolean)) {
+              await i.editReply({ content: "❌ Vous n'avez aucun badge équipé.", components: [] });
+              return;
+            }
+            await i.editReply({
+              embeds: [buildUnequipMenuEmbed()],
+              components: [buildUnequipSelectMenu(profile.equipped_badges, allItems)],
+            });
+          } else if (i.customId === "select_background") {
+            const bgId   = (i as StringSelectMenuInteraction).values[0];
+            const result = await api.post<EquipResponse>("/api/profile/equip/background", userId, username, { item_id: bgId });
+            await i.editReply({ embeds: [buildInventoryActionResultEmbed(result.success, result.message)], components: [] });
+            collector.stop("equipped");
+          } else if (i.customId === "select_badge") {
+            const badgeId  = (i as StringSelectMenuInteraction).values[0];
+            const shopItem = allItems.find(it => it.item_id === badgeId);
+            await i.editReply({
+              embeds: [buildSlotMenuEmbed(shopItem, badgeId)],
+              components: [buildSlotSelectMenu(badgeId, allItems, profile.equipped_badges)],
+            });
+          } else if (i.customId === "select_slot") {
+            const [badgeId, slotStr] = (i as StringSelectMenuInteraction).values[0].split(":");
+            const slot   = parseInt(slotStr, 10);
+            const result = await api.post<EquipResponse>("/api/profile/equip/badge", userId, username, { badge_id: badgeId, slot });
+            await i.editReply({ embeds: [buildInventoryActionResultEmbed(result.success, result.message)], components: [] });
+            collector.stop("equipped");
+          } else if (i.customId === "select_unequip_slot") {
+            const slot   = parseInt((i as StringSelectMenuInteraction).values[0], 10);
+            const result = await api.post<EquipResponse>("/api/profile/unequip/badge", userId, username, { slot });
+            await i.editReply({ embeds: [buildInventoryActionResultEmbed(result.success, result.message)], components: [] });
+            collector.stop("equipped");
+          }
+        } catch (error) {
+          const msg = error instanceof ApiError ? error.message : "Erreur lors du traitement.";
+          await i.editReply({ content: `❌ ${msg}`, embeds: [], components: [] });
+        }
+      });
+
+      collector.on("end", (_collected, reason) => {
+        if (reason === "time") {
+          interaction.editReply({ content: "⌛ Temps écoulé.", components: [] }).catch(console.error);
+        }
+      });
+    } catch (error) {
+      console.error("Erreur dans /inventory:", error);
+      const msg = "❌ Une erreur est survenue lors de la consultation de votre inventaire.";
+      if (interaction.deferred) {
+        await interaction.editReply({ content: msg });
+      } else {
+        await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default inventory;

--- a/bot/src/commands/mazworld/map.ts
+++ b/bot/src/commands/mazworld/map.ts
@@ -1,0 +1,125 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  ComponentType,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { TravelStatus, MapResponse, TravelStartResponse } from "./data";
+import {
+  buildTravelInProgressEmbed,
+  buildMapEmbed,
+  buildTravelConfirmEmbed,
+  buildTravelSuccessEmbed,
+} from "./utils/embeds";
+import { buildMapButtons, buildTravelConfirmRow } from "./utils/components";
+
+const map: Command = {
+  data: new SlashCommandBuilder()
+    .setName("map")
+    .setDescription("Consultez la carte et voyagez entre les villes"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const userId    = interaction.user.id;
+    const username  = interaction.user.username;
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      const travelStatus = await api.get<TravelStatus>("/api/travel/status", userId, username);
+
+      if (travelStatus.traveling && travelStatus.arrival_time) {
+        await interaction.reply({ embeds: [buildTravelInProgressEmbed(travelStatus, avatarURL)] });
+        return;
+      }
+
+      const mapData = await api.get<MapResponse>("/api/travel/map", userId, username);
+      const { routes } = mapData;
+      const rows = buildMapButtons(routes);
+
+      const { resource } = await interaction.reply({
+        embeds: [buildMapEmbed(mapData, avatarURL)],
+        components: rows,
+        withResponse: true,
+      });
+      const response = resource?.message;
+      if (rows.length === 0 || !response) return;
+
+      const collector = response.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        filter: (i) => i.user.id === userId && i.customId.startsWith("travel_"),
+        time: 60_000,
+      });
+
+      collector.on("collect", async (i) => {
+        collector.stop("destination_selected");
+        await i.deferUpdate();
+
+        const destinationId = i.customId.replace("travel_", "");
+        const route = routes.find(r => r.city_to === destinationId);
+
+        if (!route) {
+          await i.editReply({ content: "❌ Cette destination n'existe plus.", embeds: [], components: [] });
+          return;
+        }
+
+        await i.editReply({ embeds: [buildTravelConfirmEmbed(route)], components: [buildTravelConfirmRow()] });
+
+        const confirmCollector = response.createMessageComponentCollector({
+          componentType: ComponentType.Button,
+          filter: (btn) => btn.user.id === userId && ["confirm_travel", "cancel_travel"].includes(btn.customId),
+          time: 30_000,
+        });
+
+        confirmCollector.on("collect", async (btn) => {
+          await btn.deferUpdate();
+
+          if (btn.customId === "confirm_travel") {
+            try {
+              const result = await api.post<TravelStartResponse>(
+                "/api/travel/start",
+                userId,
+                username,
+                { destination_id: destinationId },
+              );
+              if (!result.success) {
+                await btn.editReply({ content: `❌ ${result.message}`, embeds: [], components: [] });
+                return;
+              }
+              await btn.editReply({ embeds: [buildTravelSuccessEmbed(route, result, avatarURL)], components: [] });
+            } catch (error) {
+              const msg = error instanceof ApiError ? error.message : "Erreur lors du départ.";
+              await btn.editReply({ content: `❌ ${msg}`, embeds: [], components: [] });
+            }
+            confirmCollector.stop();
+          } else {
+            await btn.editReply({ content: "❌ Voyage annulé. Vous êtes resté à votre position actuelle.", embeds: [], components: [] });
+            confirmCollector.stop();
+          }
+        });
+
+        confirmCollector.on("end", (_collected, reason) => {
+          if (reason === "time") {
+            i.editReply({ content: "⏱️ Temps écoulé. Voyage annulé.", components: [] }).catch(console.error);
+          }
+        });
+      });
+
+      collector.on("end", (_collected, reason) => {
+        if (reason === "time") {
+          interaction.editReply({ components: [] }).catch(console.error);
+        }
+      });
+    } catch (error) {
+      console.error("Erreur dans /map:", error);
+      const errorMessage = "❌ Une erreur est survenue lors de l'affichage de la carte.";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: errorMessage });
+      } else {
+        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default map;

--- a/bot/src/commands/mazworld/shop.ts
+++ b/bot/src/commands/mazworld/shop.ts
@@ -1,0 +1,154 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  StringSelectMenuInteraction,
+  ComponentType,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { ShopListResponse, PurchaseResponse } from "./data";
+import {
+  buildShopHomeEmbed,
+  buildShopCategoryEmbed,
+  buildShopItemConfirmEmbed,
+  buildShopPurchaseResultEmbed,
+} from "./utils/embeds";
+import {
+  buildShopCategorySelect,
+  buildShopItemSelect,
+  buildPurchaseConfirmRow,
+} from "./utils/components";
+
+const shop: Command = {
+  data: new SlashCommandBuilder()
+    .setName("shop")
+    .setDescription("Accéder au magasin pour acheter des backgrounds et badges"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const userId   = interaction.user.id;
+    const username = interaction.user.username;
+
+    let userCoins = 0;
+    try {
+      const data = await api.get<ShopListResponse>("/api/shop", userId, username);
+      userCoins = data.user_coins;
+    } catch {
+      await interaction.reply({ content: "❌ Impossible de charger le magasin.", flags: 64 });
+      return;
+    }
+
+    await interaction.reply({ embeds: [buildShopHomeEmbed(userCoins)], components: [buildShopCategorySelect()] });
+    const response = await interaction.fetchReply();
+
+    const collector = response.createMessageComponentCollector({
+      componentType: ComponentType.StringSelect,
+      filter: (i) => i.customId === "shop_category" && i.user.id === userId,
+      time: 120_000,
+    });
+
+    collector.on("collect", async (i: StringSelectMenuInteraction) => {
+      await i.deferUpdate();
+
+      const category = i.values[0] as "background" | "badge";
+      let shopData: ShopListResponse;
+      try {
+        shopData = await api.get<ShopListResponse>(`/api/shop?type=${category}`, userId, username);
+      } catch {
+        await i.editReply({ content: "❌ Impossible de charger les items.", embeds: [], components: [] });
+        return;
+      }
+
+      const items = shopData.items;
+      if (items.length === 0) {
+        await i.editReply({
+          content: `❌ Aucun ${category === "background" ? "background" : "badge"} disponible.`,
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      await i.editReply({
+        embeds: [buildShopCategoryEmbed(category, shopData.user_coins)],
+        components: [buildShopItemSelect(items)],
+      });
+
+      const itemCollector = response.createMessageComponentCollector({
+        componentType: ComponentType.StringSelect,
+        filter: (itemInt) => itemInt.customId === "shop_item" && itemInt.user.id === userId,
+        time: 120_000,
+      });
+
+      itemCollector.on("collect", async (itemInt: StringSelectMenuInteraction) => {
+        await itemInt.deferUpdate();
+
+        const itemId = itemInt.values[0];
+        const item   = items.find(it => it.item_id === itemId);
+
+        if (!item) {
+          await itemInt.editReply({ content: "❌ Item introuvable.", embeds: [], components: [] });
+          return;
+        }
+
+        await itemInt.editReply({
+          embeds: [buildShopItemConfirmEmbed(item, shopData.user_coins)],
+          components: [buildPurchaseConfirmRow(item.owned, shopData.user_coins >= item.price)],
+        });
+
+        const buttonCollector = response.createMessageComponentCollector({
+          componentType: ComponentType.Button,
+          filter: (btn) => btn.user.id === userId,
+          time: 30_000,
+        });
+
+        buttonCollector.on("collect", async (btn) => {
+          await btn.deferUpdate();
+
+          if (btn.customId === "confirm_purchase") {
+            let purchaseResult: PurchaseResponse;
+            try {
+              purchaseResult = await api.post<PurchaseResponse>(
+                "/api/shop/purchase",
+                userId,
+                username,
+                { item_id: itemId },
+              );
+            } catch (error) {
+              const msg = error instanceof ApiError ? error.message : "Erreur lors de l'achat.";
+              await btn.editReply({ content: `❌ ${msg}`, embeds: [], components: [] });
+              buttonCollector.stop();
+              return;
+            }
+            await btn.editReply({ embeds: [buildShopPurchaseResultEmbed(purchaseResult)], components: [] });
+            buttonCollector.stop();
+            itemCollector.stop();
+            collector.stop();
+          } else {
+            await btn.editReply({ content: "❌ Achat annulé.", embeds: [], components: [] });
+            buttonCollector.stop();
+          }
+        });
+
+        buttonCollector.on("end", (_collected, reason) => {
+          if (reason === "time") {
+            itemInt.editReply({ content: "⏱️ Temps écoulé. Achat annulé.", components: [] }).catch(console.error);
+          }
+        });
+      });
+
+      itemCollector.on("end", (_collected, reason) => {
+        if (reason === "time") {
+          i.editReply({ content: "⏱️ Temps écoulé.", components: [] }).catch(console.error);
+        }
+      });
+    });
+
+    collector.on("end", (_collected, reason) => {
+      if (reason === "time") {
+        interaction.editReply({ content: "⏱️ Temps écoulé.", components: [] }).catch(console.error);
+      }
+    });
+  },
+};
+
+export default shop;

--- a/bot/src/commands/mazworld/work.ts
+++ b/bot/src/commands/mazworld/work.ts
@@ -1,0 +1,58 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { WorkResponse } from "./data";
+import { buildWorkLoadingEmbed, buildWorkResultEmbed } from "./utils/embeds";
+
+const work: Command = {
+  data: new SlashCommandBuilder()
+    .setName("work")
+    .setDescription("Travaillez dans votre ville actuelle pour gagner de l'argent ! 💼"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      await interaction.reply({ embeds: [buildWorkLoadingEmbed(avatarURL)] });
+
+      const result = await api.post<WorkResponse>(
+        "/api/commands/work",
+        interaction.user.id,
+        interaction.user.username,
+      );
+
+      if (!result.success) {
+        await interaction.editReply({ content: `❌ ${result.message}`, embeds: [] });
+        return;
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      await interaction.editReply({ embeds: [buildWorkResultEmbed(result, avatarURL)] });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        const content = error.status === 429 || error.status === 409
+          ? `⏱️ ${error.message}`
+          : `❌ ${error.message}`;
+        if (interaction.deferred || interaction.replied) {
+          await interaction.editReply({ content, embeds: [] });
+        } else {
+          await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+        }
+        return;
+      }
+      console.error("Erreur dans /work:", error);
+      const errorMessage = "❌ Une erreur est survenue pendant votre travail.";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: errorMessage, embeds: [] });
+      } else {
+        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default work;


### PR DESCRIPTION
## Résumé

- daily.ts : /daily -> POST /api/commands/daily (embed succès ou cooldown)
- work.ts : /work -> POST /api/commands/work (embed chargement 2s puis résultat)
- coinflip.ts : /coinflip <choix> <mise> -> POST /api/commands/coinflip (10-500€)
- shop.ts : /shop -> GET /api/shop -> menu catégorie -> items -> achat avec confirmation
- inventory.ts : /inventory -> gestion équipement backgrounds (1 slot) et badges (6 slots)
- map.ts : /map -> carte interactive boutons de destination + confirmation voyage
- cityinfo.ts : /cityinfo -> détails ville actuelle (thème, connexions, métiers)

Closes #49
Closes #50
Closes #51
Closes #52
Closes #53
Closes #54