### PR TITLE
feat(bot): slash commands MazWorld (/profile /shop /daily /coinflip /inventory /work /map /cityinfo)

### DIFF
--- a/bot/src/commands/mazworld/cityinfo.ts
+++ b/bot/src/commands/mazworld/cityinfo.ts
@@ -1,0 +1,57 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { TravelStatus, MapResponse } from "./data";
+import { buildCityinfoEmbed } from "./utils/embeds";
+
+const cityinfo: Command = {
+  data: new SlashCommandBuilder()
+    .setName("cityinfo")
+    .setDescription("Découvrez les détails de votre ville actuelle"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const userId    = interaction.user.id;
+    const username  = interaction.user.username;
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      const travelStatus = await api.get<TravelStatus>("/api/travel/status", userId, username);
+
+      if (travelStatus.traveling && travelStatus.arrival_time) {
+        const timeLeft = travelStatus.arrival_time - Math.floor(Date.now() / 1000);
+        const hours    = Math.floor(timeLeft / 3600);
+        const minutes  = Math.floor((timeLeft % 3600) / 60);
+
+        await interaction.reply({
+          content:
+            `🚂 Vous êtes en voyage vers **${travelStatus.destination_emoji ?? ""} ${travelStatus.destination_name ?? ""}**\n` +
+            `⏱️ Arrivée dans ${hours}h ${minutes}m\n\n` +
+            `💡 Utilisez \`/cityinfo\` une fois arrivé pour découvrir la ville !`,
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      const mapData = await api.get<MapResponse>("/api/travel/map", userId, username);
+      await interaction.reply({ embeds: [buildCityinfoEmbed(mapData, avatarURL)] });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        await interaction.reply({ content: `❌ ${error.message}`, flags: MessageFlags.Ephemeral });
+        return;
+      }
+      console.error("Erreur dans /cityinfo:", error);
+      const errorMessage = "❌ Une erreur est survenue lors de l'affichage des informations de la ville.";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: errorMessage });
+      } else {
+        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default cityinfo;

--- a/bot/src/commands/mazworld/coinflip.ts
+++ b/bot/src/commands/mazworld/coinflip.ts
@@ -1,0 +1,72 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { CoinflipResponse } from "./data";
+import { buildCoinflipLoadingEmbed, buildCoinflipResultEmbed } from "./utils/embeds";
+
+const coinflip: Command = {
+  data: new SlashCommandBuilder()
+    .setName("coinflip")
+    .setDescription("Pariez vos coins sur pile ou face !")
+    .addStringOption(option =>
+      option
+        .setName("choix")
+        .setDescription("Choisissez 'pile' ou 'face'")
+        .setRequired(true)
+        .addChoices(
+          { name: "🪙 Pile", value: "pile" },
+          { name: "🎴 Face", value: "face" },
+        ),
+    )
+    .addIntegerOption(option =>
+      option
+        .setName("mise")
+        .setDescription("Montant à parier (10€ minimum)")
+        .setRequired(true)
+        .setMinValue(10)
+        .setMaxValue(500),
+    ),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const choix     = interaction.options.getString("choix", true) as "pile" | "face";
+    const mise      = interaction.options.getInteger("mise", true);
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      await interaction.reply({ embeds: [buildCoinflipLoadingEmbed(mise, choix, avatarURL)] });
+
+      const result = await api.post<CoinflipResponse>(
+        "/api/commands/coinflip",
+        interaction.user.id,
+        interaction.user.username,
+        { choice: choix, amount: mise },
+      );
+
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      await interaction.editReply({ embeds: [buildCoinflipResultEmbed(result, avatarURL)] });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        const content = `❌ ${error.message}`;
+        if (interaction.deferred || interaction.replied) {
+          await interaction.editReply({ content, embeds: [] });
+        } else {
+          await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+        }
+        return;
+      }
+      console.error("Erreur dans /coinflip:", error);
+      const errorMessage = "❌ Une erreur est survenue lors du lancement de la pièce.";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: errorMessage, embeds: [] });
+      } else {
+        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default coinflip;

--- a/bot/src/commands/mazworld/daily.ts
+++ b/bot/src/commands/mazworld/daily.ts
@@ -1,0 +1,45 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { DailyResponse } from "./data";
+import { buildDailySuccessEmbed, buildDailyAlreadyClaimedEmbed } from "./utils/embeds";
+
+const daily: Command = {
+  data: new SlashCommandBuilder()
+    .setName("daily")
+    .setDescription("Réclamez votre récompense quotidienne de 5€"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      const result = await api.post<DailyResponse>(
+        "/api/commands/daily",
+        interaction.user.id,
+        interaction.user.username,
+      );
+
+      if (result.success) {
+        await interaction.reply({ embeds: [buildDailySuccessEmbed(result, avatarURL)] });
+      } else {
+        await interaction.reply({ embeds: [buildDailyAlreadyClaimedEmbed(result, avatarURL)], flags: MessageFlags.Ephemeral });
+      }
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 429) {
+        await interaction.reply({ content: `⏰ ${error.message}`, flags: MessageFlags.Ephemeral });
+        return;
+      }
+      console.error("Erreur dans /daily:", error);
+      await interaction.reply({
+        content: "❌ Une erreur est survenue lors de la réclamation de votre récompense quotidienne.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  },
+};
+
+export default daily;

--- a/bot/src/commands/mazworld/data/index.ts
+++ b/bot/src/commands/mazworld/data/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/bot/src/commands/mazworld/data/types.ts
+++ b/bot/src/commands/mazworld/data/types.ts
@@ -1,0 +1,117 @@
+export interface TravelStatus {
+  traveling: boolean;
+  destination?: string;
+  destination_name?: string;
+  destination_emoji?: string;
+  arrival_time?: number;
+}
+
+export interface MapRoute {
+  route_id?: number;
+  city_to: string;
+  destination_name: string;
+  destination_emoji: string;
+  cost: number;
+  duration: number;
+  visited: boolean;
+  effective_cost: number;
+}
+
+export interface MapJob {
+  job_id: number;
+  job_name: string;
+  job_emoji: string;
+  task_1: string;
+  task_2: string;
+  task_3: string;
+}
+
+export interface MapResponse {
+  current_city: {
+    city_id: string;
+    name: string;
+    description: string;
+    emoji: string;
+    theme: string;
+  };
+  coins: number;
+  routes: MapRoute[];
+  jobs?: MapJob[];
+}
+
+export interface TravelStartResponse {
+  success: boolean;
+  message: string;
+  arrival_time?: number;
+  travel_cost?: number;
+  coins?: number;
+}
+
+export interface ProfileData {
+  user_id: string;
+  username: string;
+  coins: number;
+  equipped_background: string;
+  equipped_badges: string[];
+  created_at?: string;
+}
+
+export interface ProfileResponse {
+  profile: ProfileData;
+}
+
+export interface ShopItem {
+  item_id: string;
+  item_type: string;
+  name: string;
+  description?: string;
+  price: number;
+  emoji?: string;
+  available?: boolean;
+  owned: boolean;
+  equipped: boolean;
+}
+
+export interface ShopListResponse {
+  items: ShopItem[];
+  user_coins: number;
+}
+
+export interface PurchaseResponse {
+  success: boolean;
+  message: string;
+  new_balance?: number;
+  item?: ShopItem;
+}
+
+export interface EquipResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface WorkResponse {
+  success: boolean;
+  message: string;
+  job_name?: string;
+  job_emoji?: string;
+  task?: string;
+  reward?: number;
+  coins?: number;
+  next_work?: number;
+}
+
+export interface DailyResponse {
+  success: boolean;
+  message: string;
+  coins?: number;
+  next_daily?: number;
+}
+
+export interface CoinflipResponse {
+  success: boolean;
+  won?: boolean;
+  result?: string;
+  amount?: number;
+  message: string;
+  coins?: number;
+}

--- a/bot/src/commands/mazworld/inventory.ts
+++ b/bot/src/commands/mazworld/inventory.ts
@@ -1,0 +1,138 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  StringSelectMenuInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { ProfileResponse, ShopListResponse, EquipResponse } from "./data";
+import {
+  buildInventoryEmbed,
+  buildInventoryActionResultEmbed,
+  buildBackgroundMenuEmbed,
+  buildBadgeMenuEmbed,
+  buildSlotMenuEmbed,
+  buildUnequipMenuEmbed,
+} from "./utils/embeds";
+import {
+  buildInventoryButtons,
+  buildBackgroundSelectMenu,
+  buildBadgeSelectMenu,
+  buildSlotSelectMenu,
+  buildUnequipSelectMenu,
+} from "./utils/components";
+
+const inventory: Command = {
+  data: new SlashCommandBuilder()
+    .setName("inventory")
+    .setDescription("Consultez votre inventaire et gérez vos équipements"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const userId    = interaction.user.id;
+    const username  = interaction.user.username;
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      await interaction.deferReply();
+
+      const [profileRes, bgRes, badgeRes] = await Promise.all([
+        api.get<ProfileResponse>("/api/profile/me", userId, username),
+        api.get<ShopListResponse>("/api/shop?type=background", userId, username),
+        api.get<ShopListResponse>("/api/shop?type=badge", userId, username),
+      ]);
+
+      const profile     = profileRes.profile;
+      const backgrounds = bgRes.items.filter(i => i.owned);
+      const badges      = badgeRes.items.filter(i => i.owned);
+      const allItems    = [...bgRes.items, ...badgeRes.items];
+
+      const response = await interaction.editReply({
+        embeds: [buildInventoryEmbed(profile, backgrounds, badges, allItems, interaction.user.username, avatarURL)],
+        components: buildInventoryButtons(backgrounds.length > 0, badges.length > 0),
+      });
+
+      const collector = response.createMessageComponentCollector({
+        filter: (i) => i.user.id === userId,
+        time: 120_000,
+      });
+
+      collector.on("collect", async (i) => {
+        try {
+          await i.deferUpdate();
+
+          if (i.customId === "equip_background") {
+            if (backgrounds.length === 0) {
+              await i.editReply({ content: "❌ Vous ne possédez aucun background.", components: [] });
+              return;
+            }
+            await i.editReply({
+              embeds: [buildBackgroundMenuEmbed()],
+              components: [buildBackgroundSelectMenu(backgrounds, profile.equipped_background)],
+            });
+          } else if (i.customId === "equip_badge") {
+            if (badges.length === 0) {
+              await i.editReply({ content: "❌ Vous ne possédez aucun badge.", components: [] });
+              return;
+            }
+            await i.editReply({
+              embeds: [buildBadgeMenuEmbed()],
+              components: [buildBadgeSelectMenu(badges, allItems, profile.equipped_badges)],
+            });
+          } else if (i.customId === "unequip_badge") {
+            if (!profile.equipped_badges.some(Boolean)) {
+              await i.editReply({ content: "❌ Vous n'avez aucun badge équipé.", components: [] });
+              return;
+            }
+            await i.editReply({
+              embeds: [buildUnequipMenuEmbed()],
+              components: [buildUnequipSelectMenu(profile.equipped_badges, allItems)],
+            });
+          } else if (i.customId === "select_background") {
+            const bgId   = (i as StringSelectMenuInteraction).values[0];
+            const result = await api.post<EquipResponse>("/api/profile/equip/background", userId, username, { item_id: bgId });
+            await i.editReply({ embeds: [buildInventoryActionResultEmbed(result.success, result.message)], components: [] });
+            collector.stop("equipped");
+          } else if (i.customId === "select_badge") {
+            const badgeId  = (i as StringSelectMenuInteraction).values[0];
+            const shopItem = allItems.find(it => it.item_id === badgeId);
+            await i.editReply({
+              embeds: [buildSlotMenuEmbed(shopItem, badgeId)],
+              components: [buildSlotSelectMenu(badgeId, allItems, profile.equipped_badges)],
+            });
+          } else if (i.customId === "select_slot") {
+            const [badgeId, slotStr] = (i as StringSelectMenuInteraction).values[0].split(":");
+            const slot   = parseInt(slotStr, 10);
+            const result = await api.post<EquipResponse>("/api/profile/equip/badge", userId, username, { badge_id: badgeId, slot });
+            await i.editReply({ embeds: [buildInventoryActionResultEmbed(result.success, result.message)], components: [] });
+            collector.stop("equipped");
+          } else if (i.customId === "select_unequip_slot") {
+            const slot   = parseInt((i as StringSelectMenuInteraction).values[0], 10);
+            const result = await api.post<EquipResponse>("/api/profile/unequip/badge", userId, username, { slot });
+            await i.editReply({ embeds: [buildInventoryActionResultEmbed(result.success, result.message)], components: [] });
+            collector.stop("equipped");
+          }
+        } catch (error) {
+          const msg = error instanceof ApiError ? error.message : "Erreur lors du traitement.";
+          await i.editReply({ content: `❌ ${msg}`, embeds: [], components: [] });
+        }
+      });
+
+      collector.on("end", (_collected, reason) => {
+        if (reason === "time") {
+          interaction.editReply({ content: "⌛ Temps écoulé.", components: [] }).catch(console.error);
+        }
+      });
+    } catch (error) {
+      console.error("Erreur dans /inventory:", error);
+      const msg = "❌ Une erreur est survenue lors de la consultation de votre inventaire.";
+      if (interaction.deferred) {
+        await interaction.editReply({ content: msg });
+      } else {
+        await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default inventory;

--- a/bot/src/commands/mazworld/map.ts
+++ b/bot/src/commands/mazworld/map.ts
@@ -1,0 +1,125 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  ComponentType,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { TravelStatus, MapResponse, TravelStartResponse } from "./data";
+import {
+  buildTravelInProgressEmbed,
+  buildMapEmbed,
+  buildTravelConfirmEmbed,
+  buildTravelSuccessEmbed,
+} from "./utils/embeds";
+import { buildMapButtons, buildTravelConfirmRow } from "./utils/components";
+
+const map: Command = {
+  data: new SlashCommandBuilder()
+    .setName("map")
+    .setDescription("Consultez la carte et voyagez entre les villes"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const userId    = interaction.user.id;
+    const username  = interaction.user.username;
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      const travelStatus = await api.get<TravelStatus>("/api/travel/status", userId, username);
+
+      if (travelStatus.traveling && travelStatus.arrival_time) {
+        await interaction.reply({ embeds: [buildTravelInProgressEmbed(travelStatus, avatarURL)] });
+        return;
+      }
+
+      const mapData = await api.get<MapResponse>("/api/travel/map", userId, username);
+      const { routes } = mapData;
+      const rows = buildMapButtons(routes);
+
+      const { resource } = await interaction.reply({
+        embeds: [buildMapEmbed(mapData, avatarURL)],
+        components: rows,
+        withResponse: true,
+      });
+      const response = resource?.message;
+      if (rows.length === 0 || !response) return;
+
+      const collector = response.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        filter: (i) => i.user.id === userId && i.customId.startsWith("travel_"),
+        time: 60_000,
+      });
+
+      collector.on("collect", async (i) => {
+        collector.stop("destination_selected");
+        await i.deferUpdate();
+
+        const destinationId = i.customId.replace("travel_", "");
+        const route = routes.find(r => r.city_to === destinationId);
+
+        if (!route) {
+          await i.editReply({ content: "❌ Cette destination n'existe plus.", embeds: [], components: [] });
+          return;
+        }
+
+        await i.editReply({ embeds: [buildTravelConfirmEmbed(route)], components: [buildTravelConfirmRow()] });
+
+        const confirmCollector = response.createMessageComponentCollector({
+          componentType: ComponentType.Button,
+          filter: (btn) => btn.user.id === userId && ["confirm_travel", "cancel_travel"].includes(btn.customId),
+          time: 30_000,
+        });
+
+        confirmCollector.on("collect", async (btn) => {
+          await btn.deferUpdate();
+
+          if (btn.customId === "confirm_travel") {
+            try {
+              const result = await api.post<TravelStartResponse>(
+                "/api/travel/start",
+                userId,
+                username,
+                { destination_id: destinationId },
+              );
+              if (!result.success) {
+                await btn.editReply({ content: `❌ ${result.message}`, embeds: [], components: [] });
+                return;
+              }
+              await btn.editReply({ embeds: [buildTravelSuccessEmbed(route, result, avatarURL)], components: [] });
+            } catch (error) {
+              const msg = error instanceof ApiError ? error.message : "Erreur lors du départ.";
+              await btn.editReply({ content: `❌ ${msg}`, embeds: [], components: [] });
+            }
+            confirmCollector.stop();
+          } else {
+            await btn.editReply({ content: "❌ Voyage annulé. Vous êtes resté à votre position actuelle.", embeds: [], components: [] });
+            confirmCollector.stop();
+          }
+        });
+
+        confirmCollector.on("end", (_collected, reason) => {
+          if (reason === "time") {
+            i.editReply({ content: "⏱️ Temps écoulé. Voyage annulé.", components: [] }).catch(console.error);
+          }
+        });
+      });
+
+      collector.on("end", (_collected, reason) => {
+        if (reason === "time") {
+          interaction.editReply({ components: [] }).catch(console.error);
+        }
+      });
+    } catch (error) {
+      console.error("Erreur dans /map:", error);
+      const errorMessage = "❌ Une erreur est survenue lors de l'affichage de la carte.";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: errorMessage });
+      } else {
+        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default map;

--- a/bot/src/commands/mazworld/profile.ts
+++ b/bot/src/commands/mazworld/profile.ts
@@ -1,0 +1,66 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { generateProfileCard } from "./utils/profileCard";
+import { Command } from "../../models/Command";
+import type { ProfileResponse } from "./data";
+import { buildProfileEmbed } from "./utils/embeds";
+
+const profile: Command = {
+  data: new SlashCommandBuilder()
+    .setName("profile")
+    .setDescription("Affiche votre carte de profil personnalisée")
+    .addUserOption(option =>
+      option
+        .setName("utilisateur")
+        .setDescription("Voir le profil d'un autre utilisateur (optionnel)")
+        .setRequired(false),
+    ),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const targetUser = interaction.options.getUser("utilisateur") || interaction.user;
+
+    if (targetUser.bot) {
+      await interaction.reply({ content: "❌ Les bots n'ont pas de profil !", flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    try {
+      await interaction.deferReply();
+
+      const { profile: profileData } = await api.get<ProfileResponse>(
+        "/api/profile/me",
+        targetUser.id,
+        targetUser.username,
+      );
+
+      const profileCard = await generateProfileCard({
+        username:   targetUser.username,
+        avatarURL:  targetUser.displayAvatarURL({ extension: "png", size: 256 }),
+        background: profileData.equipped_background,
+        badges:     profileData.equipped_badges,
+        coins:      profileData.coins,
+      });
+
+      await interaction.editReply({
+        embeds: [buildProfileEmbed(targetUser.username, profileData)],
+        files: [profileCard],
+      });
+    } catch (error) {
+      console.error("Erreur lors de la génération du profil:", error);
+      const msg = error instanceof ApiError
+        ? `❌ ${error.message}`
+        : "❌ Une erreur est survenue lors de la génération de votre profil.";
+      if (interaction.deferred) {
+        await interaction.editReply({ content: msg });
+      } else {
+        await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default profile;

--- a/bot/src/commands/mazworld/shop.ts
+++ b/bot/src/commands/mazworld/shop.ts
@@ -1,0 +1,154 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  StringSelectMenuInteraction,
+  ComponentType,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { ShopListResponse, PurchaseResponse } from "./data";
+import {
+  buildShopHomeEmbed,
+  buildShopCategoryEmbed,
+  buildShopItemConfirmEmbed,
+  buildShopPurchaseResultEmbed,
+} from "./utils/embeds";
+import {
+  buildShopCategorySelect,
+  buildShopItemSelect,
+  buildPurchaseConfirmRow,
+} from "./utils/components";
+
+const shop: Command = {
+  data: new SlashCommandBuilder()
+    .setName("shop")
+    .setDescription("Accéder au magasin pour acheter des backgrounds et badges"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const userId   = interaction.user.id;
+    const username = interaction.user.username;
+
+    let userCoins = 0;
+    try {
+      const data = await api.get<ShopListResponse>("/api/shop", userId, username);
+      userCoins = data.user_coins;
+    } catch {
+      await interaction.reply({ content: "❌ Impossible de charger le magasin.", flags: 64 });
+      return;
+    }
+
+    await interaction.reply({ embeds: [buildShopHomeEmbed(userCoins)], components: [buildShopCategorySelect()] });
+    const response = await interaction.fetchReply();
+
+    const collector = response.createMessageComponentCollector({
+      componentType: ComponentType.StringSelect,
+      filter: (i) => i.customId === "shop_category" && i.user.id === userId,
+      time: 120_000,
+    });
+
+    collector.on("collect", async (i: StringSelectMenuInteraction) => {
+      await i.deferUpdate();
+
+      const category = i.values[0] as "background" | "badge";
+      let shopData: ShopListResponse;
+      try {
+        shopData = await api.get<ShopListResponse>(`/api/shop?type=${category}`, userId, username);
+      } catch {
+        await i.editReply({ content: "❌ Impossible de charger les items.", embeds: [], components: [] });
+        return;
+      }
+
+      const items = shopData.items;
+      if (items.length === 0) {
+        await i.editReply({
+          content: `❌ Aucun ${category === "background" ? "background" : "badge"} disponible.`,
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      await i.editReply({
+        embeds: [buildShopCategoryEmbed(category, shopData.user_coins)],
+        components: [buildShopItemSelect(items)],
+      });
+
+      const itemCollector = response.createMessageComponentCollector({
+        componentType: ComponentType.StringSelect,
+        filter: (itemInt) => itemInt.customId === "shop_item" && itemInt.user.id === userId,
+        time: 120_000,
+      });
+
+      itemCollector.on("collect", async (itemInt: StringSelectMenuInteraction) => {
+        await itemInt.deferUpdate();
+
+        const itemId = itemInt.values[0];
+        const item   = items.find(it => it.item_id === itemId);
+
+        if (!item) {
+          await itemInt.editReply({ content: "❌ Item introuvable.", embeds: [], components: [] });
+          return;
+        }
+
+        await itemInt.editReply({
+          embeds: [buildShopItemConfirmEmbed(item, shopData.user_coins)],
+          components: [buildPurchaseConfirmRow(item.owned, shopData.user_coins >= item.price)],
+        });
+
+        const buttonCollector = response.createMessageComponentCollector({
+          componentType: ComponentType.Button,
+          filter: (btn) => btn.user.id === userId,
+          time: 30_000,
+        });
+
+        buttonCollector.on("collect", async (btn) => {
+          await btn.deferUpdate();
+
+          if (btn.customId === "confirm_purchase") {
+            let purchaseResult: PurchaseResponse;
+            try {
+              purchaseResult = await api.post<PurchaseResponse>(
+                "/api/shop/purchase",
+                userId,
+                username,
+                { item_id: itemId },
+              );
+            } catch (error) {
+              const msg = error instanceof ApiError ? error.message : "Erreur lors de l'achat.";
+              await btn.editReply({ content: `❌ ${msg}`, embeds: [], components: [] });
+              buttonCollector.stop();
+              return;
+            }
+            await btn.editReply({ embeds: [buildShopPurchaseResultEmbed(purchaseResult)], components: [] });
+            buttonCollector.stop();
+            itemCollector.stop();
+            collector.stop();
+          } else {
+            await btn.editReply({ content: "❌ Achat annulé.", embeds: [], components: [] });
+            buttonCollector.stop();
+          }
+        });
+
+        buttonCollector.on("end", (_collected, reason) => {
+          if (reason === "time") {
+            itemInt.editReply({ content: "⏱️ Temps écoulé. Achat annulé.", components: [] }).catch(console.error);
+          }
+        });
+      });
+
+      itemCollector.on("end", (_collected, reason) => {
+        if (reason === "time") {
+          i.editReply({ content: "⏱️ Temps écoulé.", components: [] }).catch(console.error);
+        }
+      });
+    });
+
+    collector.on("end", (_collected, reason) => {
+      if (reason === "time") {
+        interaction.editReply({ content: "⏱️ Temps écoulé.", components: [] }).catch(console.error);
+      }
+    });
+  },
+};
+
+export default shop;

--- a/bot/src/commands/mazworld/utils/components.ts
+++ b/bot/src/commands/mazworld/utils/components.ts
@@ -1,0 +1,168 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  StringSelectMenuBuilder,
+} from "discord.js";
+import type { MapRoute, ShopItem } from "../data";
+
+// ===== MAP =====
+
+export function buildMapButtons(routes: MapRoute[]): ActionRowBuilder<ButtonBuilder>[] {
+  const buttons = routes.slice(0, 5).map(r =>
+    new ButtonBuilder()
+      .setCustomId(`travel_${r.city_to}`)
+      .setLabel(`${r.destination_emoji} ${r.destination_name}`)
+      .setStyle(ButtonStyle.Primary),
+  );
+  return buttons.length > 0
+    ? [new ActionRowBuilder<ButtonBuilder>().addComponents(buttons)]
+    : [];
+}
+
+export function buildTravelConfirmRow(): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder().setCustomId("confirm_travel").setLabel("✅ Confirmer le voyage").setStyle(ButtonStyle.Success),
+    new ButtonBuilder().setCustomId("cancel_travel").setLabel("❌ Annuler").setStyle(ButtonStyle.Danger),
+  );
+}
+
+// ===== SHOP =====
+
+export function buildShopCategorySelect(): ActionRowBuilder<StringSelectMenuBuilder> {
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId("shop_category")
+      .setPlaceholder("Sélectionnez une catégorie")
+      .addOptions([
+        { label: "Backgrounds", description: "Personnalisez le fond de votre profil", value: "background", emoji: "🎨" },
+        { label: "Badges", description: "Collectionnez des badges uniques", value: "badge", emoji: "🏅" },
+      ]),
+  );
+}
+
+export function buildShopItemSelect(items: ShopItem[]): ActionRowBuilder<StringSelectMenuBuilder> {
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId("shop_item")
+    .setPlaceholder("Choisissez un item");
+  for (const item of items.slice(0, 25)) {
+    menu.addOptions({
+      label: `${item.name} - ${item.price}€`,
+      description: item.owned ? "✅ Déjà possédé" : (item.description?.substring(0, 100) || "Aucune description"),
+      value: item.item_id,
+      emoji: item.emoji || undefined,
+    });
+  }
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+}
+
+export function buildPurchaseConfirmRow(alreadyOwned: boolean, canAfford: boolean): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId("confirm_purchase")
+      .setLabel("Acheter")
+      .setStyle(ButtonStyle.Success)
+      .setDisabled(alreadyOwned || !canAfford),
+    new ButtonBuilder()
+      .setCustomId("cancel_purchase")
+      .setLabel("Annuler")
+      .setStyle(ButtonStyle.Secondary),
+  );
+}
+
+// ===== INVENTORY =====
+
+export function buildInventoryButtons(hasBackgrounds: boolean, hasBadges: boolean): ActionRowBuilder<ButtonBuilder>[] {
+  const rows: ActionRowBuilder<ButtonBuilder>[] = [];
+
+  if (hasBackgrounds) {
+    rows.push(new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId("equip_background").setLabel("Équiper un background").setEmoji("🎨").setStyle(ButtonStyle.Primary),
+    ));
+  }
+
+  if (hasBadges) {
+    rows.push(new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId("equip_badge").setLabel("Équiper un badge").setEmoji("🏅").setStyle(ButtonStyle.Success),
+      new ButtonBuilder().setCustomId("unequip_badge").setLabel("Retirer un badge").setEmoji("🗑️").setStyle(ButtonStyle.Danger),
+    ));
+  }
+
+  if (!hasBackgrounds && !hasBadges) {
+    rows.push(new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId("goto_shop").setLabel("Visiter le shop").setEmoji("🏪").setStyle(ButtonStyle.Primary).setDisabled(true),
+    ));
+  }
+
+  return rows;
+}
+
+export function buildBackgroundSelectMenu(backgrounds: ShopItem[], equippedBgId: string): ActionRowBuilder<StringSelectMenuBuilder> {
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId("select_background")
+    .setPlaceholder("Choisissez un background à équiper");
+  for (const bg of backgrounds) {
+    const isEquipped = equippedBgId === bg.item_id;
+    menu.addOptions({
+      label: bg.name + (isEquipped ? " (équipé)" : ""),
+      value: bg.item_id,
+      emoji: bg.emoji || undefined,
+      description: isEquipped ? "✅ Actuellement équipé" : bg.description?.substring(0, 100),
+    });
+  }
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+}
+
+export function buildBadgeSelectMenu(badges: ShopItem[], allItems: ShopItem[], equippedBadges: string[]): ActionRowBuilder<StringSelectMenuBuilder> {
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId("select_badge")
+    .setPlaceholder("Choisissez un badge à équiper");
+  for (const badge of badges) {
+    const item         = allItems.find(it => it.item_id === badge.item_id);
+    const equippedSlot = equippedBadges.indexOf(badge.item_id);
+    const isEquipped   = equippedSlot !== -1;
+    menu.addOptions({
+      label: (item?.name ?? badge.item_id) + (isEquipped ? ` (Slot ${equippedSlot + 1})` : ""),
+      value: badge.item_id,
+      emoji: item?.emoji || undefined,
+      description: isEquipped ? `✅ Équipé dans le slot ${equippedSlot + 1}` : item?.description?.substring(0, 100),
+    });
+  }
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+}
+
+export function buildSlotSelectMenu(badgeId: string, allItems: ShopItem[], equippedBadges: string[]): ActionRowBuilder<StringSelectMenuBuilder> {
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId("select_slot")
+    .setPlaceholder("Choisissez un slot (1-6)");
+  for (let slot = 0; slot < 6; slot++) {
+    const occupiedId = equippedBadges[slot];
+    const occupied   = occupiedId ? allItems.find(it => it.item_id === occupiedId) : null;
+    menu.addOptions({
+      label: `Slot ${slot + 1}`,
+      value: `${badgeId}:${slot}`,
+      description: occupied ? `${occupied.emoji ?? ""} ${occupied.name} (sera remplacé)` : "Vide",
+      emoji: occupied ? "🔄" : "⚫",
+    });
+  }
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+}
+
+export function buildUnequipSelectMenu(equippedBadges: string[], allItems: ShopItem[]): ActionRowBuilder<StringSelectMenuBuilder> {
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId("select_unequip_slot")
+    .setPlaceholder("Choisissez un slot à vider");
+  for (let idx = 0; idx < 6; idx++) {
+    const badgeId = equippedBadges[idx];
+    if (badgeId) {
+      const item = allItems.find(it => it.item_id === badgeId);
+      menu.addOptions({
+        label: `Slot ${idx + 1} : ${item?.name ?? "Badge"}`,
+        value: idx.toString(),
+        emoji: item?.emoji || "❓",
+        description: "Retirer ce badge",
+      });
+    }
+  }
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+}

--- a/bot/src/commands/mazworld/utils/cooldownManager.ts
+++ b/bot/src/commands/mazworld/utils/cooldownManager.ts
@@ -1,0 +1,55 @@
+const cooldownMaps = new Map<string, Map<string, number>>();
+
+function getCooldownMap(commandType: string): Map<string, number> {
+  if (!cooldownMaps.has(commandType)) {
+    cooldownMaps.set(commandType, new Map<string, number>());
+  }
+  return cooldownMaps.get(commandType)!;
+}
+
+export function checkCooldown(
+  commandType: string,
+  userId: string,
+  cooldownMs: number,
+): { isOnCooldown: boolean; timeLeft: number; formattedTime: string } {
+  const cooldowns = getCooldownMap(commandType);
+  const now = Date.now();
+  const lastUsed = cooldowns.get(userId);
+
+  if (lastUsed) {
+    const expirationTime = lastUsed + cooldownMs;
+    if (now < expirationTime) {
+      const timeLeft = expirationTime - now;
+      return { isOnCooldown: true, timeLeft, formattedTime: formatTimeRemaining(timeLeft) };
+    }
+  }
+
+  return { isOnCooldown: false, timeLeft: 0, formattedTime: '' };
+}
+
+export function setCooldown(commandType: string, userId: string): void {
+  getCooldownMap(commandType).set(userId, Date.now());
+}
+
+export function resetCooldown(commandType: string, userId: string): void {
+  getCooldownMap(commandType).delete(userId);
+}
+
+export function formatTimeRemaining(ms: number): string {
+  const hours   = Math.floor(ms / 3600000);
+  const minutes = Math.floor((ms % 3600000) / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+
+  return parts.join(' ');
+}
+
+export const COOLDOWN_DURATIONS = {
+  WORK:     3600000,
+  COINFLIP: 30000,
+  DAILY:    86400000,
+} as const;

--- a/bot/src/commands/mazworld/utils/embeds.ts
+++ b/bot/src/commands/mazworld/utils/embeds.ts
@@ -1,0 +1,357 @@
+import { EmbedBuilder } from "discord.js";
+import type {
+  TravelStatus,
+  MapRoute,
+  MapResponse,
+  TravelStartResponse,
+  ProfileData,
+  ShopItem,
+  PurchaseResponse,
+  WorkResponse,
+  DailyResponse,
+  CoinflipResponse,
+} from "../data";
+
+const FOOTER_ICON = "https://i.pinimg.com/564x/4d/73/9f/4d739fa55c3465cadc171fdcc75c01d9.jpg";
+const FOOTER_TEXT = "MazWorld";
+
+const CITY_COLORS: Record<string, number> = {
+  Village:  0x8bc34a,
+  Commerce: 0xffc107,
+  "Forêt":  0x4caf50,
+  "Côte":   0x03a9f4,
+  Montagne: 0x9e9e9e,
+  "Désert": 0xff9800,
+  Capitale: 0x9c27b0,
+};
+
+// ===== MAP =====
+
+export function buildTravelInProgressEmbed(status: TravelStatus, avatarURL: string): EmbedBuilder {
+  const timeLeft = (status.arrival_time ?? 0) - Math.floor(Date.now() / 1000);
+  const hours    = Math.floor(timeLeft / 3600);
+  const minutes  = Math.floor((timeLeft % 3600) / 60);
+  return new EmbedBuilder()
+    .setTitle("🚂 Voyage en cours...")
+    .setDescription(`Vous voyagez vers **${status.destination_emoji} ${status.destination_name}**`)
+    .setColor(0xffaa00)
+    .addFields({ name: "⏱️ Arrivée prévue", value: `<t:${status.arrival_time}:R> (${hours}h ${minutes}m)`, inline: false })
+    .setThumbnail(avatarURL)
+    .setFooter({ text: "Bon voyage ! Profitez du paysage 🌄", iconURL: FOOTER_ICON });
+}
+
+export function buildMapEmbed(data: MapResponse, avatarURL: string): EmbedBuilder {
+  const { current_city: city, coins, routes } = data;
+  const destinationsText = routes.length > 0
+    ? routes.map(r =>
+        r.visited
+          ? `${r.destination_emoji} **${r.destination_name}** - ✅ Gratuit (${Math.floor(r.duration / 60)}min)`
+          : `${r.destination_emoji} **${r.destination_name}** - ${r.effective_cost}€ (${Math.floor(r.duration / 60)}min)`,
+      ).join("\n")
+    : "Aucune route disponible depuis cette ville.";
+
+  return new EmbedBuilder()
+    .setTitle("🗺️ Carte du Monde")
+    .setDescription(
+      `📍 **Position actuelle :** ${city.emoji} **${city.name}**\n` +
+      `*${city.description}*\n\n` +
+      `💰 **Solde :** ${coins}€`,
+    )
+    .setColor(0x5865f2)
+    .setThumbnail(avatarURL)
+    .addFields({ name: "🧭 Destinations disponibles", value: destinationsText, inline: false })
+    .setFooter({ text: "💡 Les villes déjà visitées sont gratuites !", iconURL: FOOTER_ICON });
+}
+
+export function buildTravelConfirmEmbed(route: MapRoute): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle(`🎫 Voyage vers ${route.destination_emoji} ${route.destination_name}`)
+    .setColor(route.visited ? 0x00ff00 : 0x5865f2)
+    .addFields(
+      { name: "💰 Coût", value: route.visited ? "**Gratuit** ✅ (déjà visité)" : `${route.effective_cost}€`, inline: true },
+      { name: "⏱️ Durée", value: `${Math.floor(route.duration / 60)} minutes`, inline: true },
+      {
+        name: "⚠️ Pendant le voyage",
+        value: "❌ Vous ne pourrez pas travailler, jouer ou acheter\n✅ Vous pourrez consulter votre profil et inventaire",
+        inline: false,
+      },
+    );
+}
+
+export function buildTravelSuccessEmbed(route: MapRoute, result: TravelStartResponse, avatarURL: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("🚂 Voyage commencé !")
+    .setDescription(
+      `Vous êtes en route vers **${route.destination_emoji} ${route.destination_name}** !\n\n` +
+      (result.travel_cost ? `💸 Vous avez payé **${result.travel_cost}€**\n` : `✅ Voyage gratuit (ville déjà visitée)\n`) +
+      `💰 Solde restant : **${result.coins}€**`,
+    )
+    .setColor(0x00ff00)
+    .addFields({ name: "⏱️ Arrivée prévue", value: `<t:${result.arrival_time}:R>`, inline: false })
+    .setThumbnail(avatarURL)
+    .setFooter({ text: "Bon voyage ! 🌍", iconURL: FOOTER_ICON });
+}
+
+// ===== CITYINFO =====
+
+export function buildCityinfoEmbed(data: MapResponse, avatarURL: string): EmbedBuilder {
+  const { current_city: city, routes, jobs = [] } = data;
+
+  const embed = new EmbedBuilder()
+    .setTitle(`🏙️ Infos sur ${city.emoji} ${city.name}`)
+    .setDescription(city.description)
+    .setColor(CITY_COLORS[city.theme] ?? 0x5865f2)
+    .setThumbnail(avatarURL)
+    .addFields(
+      { name: "🏷️ Thème", value: city.theme || "Village", inline: true },
+      { name: "🔗 Connexions", value: `${routes.length} ville(s) connectée(s)`, inline: true },
+      { name: "🗺️ Statut de visite", value: "Ville visitée", inline: true },
+    );
+
+  const jobsText = jobs.length > 0
+    ? jobs.map(j => `${j.job_emoji} **${j.job_name}**\n   • ${j.task_1}\n   • ${j.task_2}\n   • ${j.task_3}`).join("\n\n")
+    : null;
+  embed.addFields({
+    name: `💼 Métiers disponibles${jobs.length > 0 ? ` (${jobs.length})` : ""}`,
+    value: jobsText ?? "Aucun métier disponible dans cette ville.",
+    inline: false,
+  });
+
+  if (routes.length > 0) {
+    embed.addFields({
+      name: "🗺️ Destinations depuis cette ville",
+      value: routes.map(r => {
+        const cost = r.visited ? "Gratuit ✅" : `${r.effective_cost}€`;
+        return `${r.destination_emoji} **${r.destination_name}** - ${cost} (${Math.floor(r.duration / 60)}min)`;
+      }).join("\n"),
+      inline: false,
+    });
+  }
+
+  embed
+    .addFields({
+      name: "💡 Informations",
+      value: "• Utilisez `/work` pour travailler dans cette ville\n• Utilisez `/map` pour voyager vers une autre ville",
+      inline: false,
+    })
+    .setFooter({ text: `${city.name} vous souhaite la bienvenue !`, iconURL: FOOTER_ICON })
+    .setTimestamp();
+
+  return embed;
+}
+
+// ===== DAILY =====
+
+export function buildDailySuccessEmbed(result: DailyResponse, avatarURL: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("🎁 Récompense Quotidienne")
+    .setDescription(result.message)
+    .setColor(0x00ff00)
+    .addFields({ name: "💰 Nouveau solde", value: `${result.coins}€`, inline: true })
+    .setThumbnail(avatarURL)
+    .setTimestamp()
+    .setFooter({ text: "Revenez demain pour une nouvelle récompense !", iconURL: FOOTER_ICON });
+}
+
+export function buildDailyAlreadyClaimedEmbed(result: DailyResponse, avatarURL: string): EmbedBuilder {
+  const embed = new EmbedBuilder()
+    .setTitle("⏰ Récompense Déjà Réclamée")
+    .setDescription(result.message)
+    .setColor(0xff9900)
+    .setThumbnail(avatarURL)
+    .setTimestamp();
+  if (result.next_daily) {
+    embed.addFields({ name: "📅 Prochaine récompense", value: `<t:${result.next_daily}:R>`, inline: true });
+  }
+  return embed;
+}
+
+// ===== WORK =====
+
+export function buildWorkLoadingEmbed(avatarURL: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("💼 Au travail...")
+    .setDescription("Recherche d'un emploi dans la ville...")
+    .setColor(0xffaa00)
+    .setThumbnail(avatarURL);
+}
+
+export function buildWorkResultEmbed(result: WorkResponse, avatarURL: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle(`${result.job_emoji} Travail terminé !`)
+    .setDescription(`💼 **${result.job_name}**\n\n*${result.task}*`)
+    .setColor(0x00ff00)
+    .setThumbnail(avatarURL)
+    .addFields(
+      { name: "💰 Gains", value: `+${result.reward}€`, inline: true },
+      { name: "💼 Nouveau solde", value: `${result.coins}€`, inline: true },
+      { name: "⏱️ Prochain travail", value: `<t:${result.next_work}:R>`, inline: false },
+    )
+    .setFooter({ text: "Bon travail ! Revenez dans 1 heure", iconURL: FOOTER_ICON })
+    .setTimestamp();
+}
+
+// ===== COINFLIP =====
+
+export function buildCoinflipLoadingEmbed(mise: number, choix: string, avatarURL: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("🪙 Lancement de la pièce...")
+    .setDescription(`Vous avez parié **${mise}€** sur **${choix}** !`)
+    .setColor(0xffaa00)
+    .setThumbnail(avatarURL);
+}
+
+export function buildCoinflipResultEmbed(result: CoinflipResponse, avatarURL: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle(result.won ? "🎉 VICTOIRE !" : "💔 DÉFAITE")
+    .setDescription(result.message)
+    .setColor(result.won ? 0x00ff00 : 0xff0000)
+    .setThumbnail(avatarURL)
+    .addFields(
+      { name: "🎲 Résultat", value: result.result === "pile" ? "🪙 **PILE**" : "🎴 **FACE**", inline: true },
+      { name: "💸 Résultat", value: result.won ? `+${result.amount}€` : `-${result.amount}€`, inline: true },
+      { name: "💰 Nouveau solde", value: `${result.coins}€`, inline: true },
+    )
+    .setFooter({ text: result.won ? "Bien joué !" : "Retentez votre chance !", iconURL: FOOTER_ICON })
+    .setTimestamp();
+}
+
+// ===== SHOP =====
+
+export function buildShopHomeEmbed(userCoins: number): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("🏪 Magasin MazWorld")
+    .setDescription(`💰 Votre argent : **${userCoins}€**\n\nChoisissez une catégorie ci-dessous :`)
+    .setColor(0x5865f2)
+    .setThumbnail("https://i.pinimg.com/564x/a7/26/5c/a7265ce5384476970886fd1ded1807bb.jpg")
+    .setTimestamp()
+    .setFooter({ text: FOOTER_TEXT, iconURL: FOOTER_ICON });
+}
+
+export function buildShopCategoryEmbed(category: "background" | "badge", userCoins: number): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle(`🏪 ${category === "background" ? "Backgrounds" : "Badges"}`)
+    .setDescription(`💰 Votre argent : **${userCoins}€**\n\nSélectionnez un item à acheter :`)
+    .setColor(0x5865f2)
+    .setTimestamp();
+}
+
+export function buildShopItemConfirmEmbed(item: ShopItem, userCoins: number): EmbedBuilder {
+  const alreadyOwned = item.owned;
+  return new EmbedBuilder()
+    .setTitle(`${item.emoji ?? ""} ${item.name}`)
+    .setDescription(item.description || "Aucune description")
+    .addFields(
+      { name: "💰 Prix", value: `${item.price}€`, inline: true },
+      { name: "👛 Votre argent", value: `${userCoins}€`, inline: true },
+      {
+        name: "📊 Statut",
+        value: alreadyOwned
+          ? "✅ Déjà possédé"
+          : userCoins >= item.price ? "✅ Vous pouvez acheter" : "❌ Pas assez d'argent",
+        inline: false,
+      },
+    )
+    .setColor(alreadyOwned ? 0xffaa00 : userCoins >= item.price ? 0x00ff00 : 0xff0000);
+}
+
+export function buildShopPurchaseResultEmbed(result: PurchaseResponse): EmbedBuilder {
+  const embed = new EmbedBuilder()
+    .setTitle(result.success ? "✅ Achat réussi !" : "❌ Achat échoué")
+    .setDescription(result.message)
+    .setColor(result.success ? 0x00ff00 : 0xff0000);
+  if (result.success && result.new_balance !== undefined) {
+    embed.addFields({ name: "💰 Nouveau solde", value: `${result.new_balance}€`, inline: true });
+  }
+  return embed;
+}
+
+// ===== INVENTORY =====
+
+export function buildInventoryEmbed(
+  profile: ProfileData,
+  backgrounds: ShopItem[],
+  badges: ShopItem[],
+  allItems: ShopItem[],
+  username: string,
+  avatarURL: string,
+): EmbedBuilder {
+  const totalSpent = [...backgrounds, ...badges].reduce((sum, i) => sum + i.price, 0);
+  const equippedBg = allItems.find(i => i.item_id === profile.equipped_background);
+  const bgName     = equippedBg ? `${equippedBg.emoji ?? ""} ${equippedBg.name}` : "⬜ Défaut";
+
+  let badgesText = "";
+  for (let i = 0; i < 6; i++) {
+    const badgeId = profile.equipped_badges[i];
+    const badge   = badgeId ? allItems.find(it => it.item_id === badgeId) : null;
+    badgesText += badgeId
+      ? `**[${i + 1}]** ${badge?.emoji ?? "❓"} ${badge?.name ?? "Inconnu"}\n`
+      : `**[${i + 1}]** ⚫ Vide\n`;
+  }
+
+  return new EmbedBuilder()
+    .setTitle(`🎒 Inventaire de ${username}`)
+    .setColor(0x5865f2)
+    .setThumbnail(avatarURL)
+    .setTimestamp()
+    .setFooter({ text: FOOTER_TEXT, iconURL: FOOTER_ICON })
+    .addFields(
+      { name: "💰 Solde", value: `**${profile.coins}€**`, inline: true },
+      { name: "🖼️ Backgrounds", value: `${backgrounds.length}`, inline: true },
+      { name: "🏅 Badges", value: `${badges.length}`, inline: true },
+      { name: "💸 Dépenses totales", value: `**${totalSpent}€**`, inline: true },
+      { name: "🎨 Background actuel", value: bgName, inline: false },
+      { name: "🏅 Badges équipés", value: badgesText || "Aucun badge équipé", inline: false },
+    );
+}
+
+export function buildInventoryActionResultEmbed(success: boolean, message: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle(success ? "✅ Succès !" : "❌ Erreur")
+    .setDescription(message)
+    .setColor(success ? 0x00ff00 : 0xff0000);
+}
+
+export function buildBackgroundMenuEmbed(): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("🎨 Équiper un Background")
+    .setDescription("Sélectionnez le background à équiper :")
+    .setColor(0x5865f2);
+}
+
+export function buildBadgeMenuEmbed(): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("🏅 Équiper un Badge")
+    .setDescription("Sélectionnez le badge à équiper :")
+    .setColor(0x00ff00);
+}
+
+export function buildSlotMenuEmbed(shopItem: ShopItem | undefined, badgeId: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle(`🏅 ${shopItem?.emoji ?? ""} ${shopItem?.name ?? badgeId}`)
+    .setDescription("Choisissez le slot où équiper ce badge :")
+    .setColor(0x00ff00);
+}
+
+export function buildUnequipMenuEmbed(): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("🗑️ Retirer un Badge")
+    .setDescription("Sélectionnez le badge à retirer :")
+    .setColor(0xff0000);
+}
+
+// ===== PROFILE =====
+
+export function buildProfileEmbed(username: string, profileData: ProfileData): EmbedBuilder {
+  const createdTimestamp = Math.floor(new Date(profileData.created_at!).getTime() / 1000);
+  return new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle(`🎴 Profil de ${username}`)
+    .setDescription(
+      `💰 **${profileData.coins}€**\n` +
+      `📅 Membre depuis <t:${createdTimestamp}:R>`,
+    )
+    .setImage("attachment://profile.png")
+    .setTimestamp()
+    .setFooter({ text: FOOTER_TEXT, iconURL: FOOTER_ICON });
+}

--- a/bot/src/commands/mazworld/utils/profileCard.ts
+++ b/bot/src/commands/mazworld/utils/profileCard.ts
@@ -1,0 +1,139 @@
+import {
+  createCanvas,
+  loadImage,
+} from 'canvas';
+import { AttachmentBuilder } from 'discord.js';
+
+export interface ProfileCardOptions {
+  username: string;
+  avatarURL: string;
+  background: string;
+  badges: string[];
+  coins: number;
+}
+
+const BACKGROUNDS: Record<string, string> = {
+  bg_default: '#2f3136',
+  default:    '#2f3136',
+  bg_blue:    '#5865f2',
+  bg_purple:  '#9b59b6',
+  bg_green:   '#2ecc71',
+  bg_red:     '#e74c3c',
+  bg_orange:  '#e67e22',
+};
+
+const BADGES: Record<string, string> = {
+  badge_founder:  '👑',
+  badge_verified: '✅',
+  badge_star:     '⭐',
+  badge_heart:    '❤️',
+  badge_fire:     '🔥',
+  badge_diamond:  '💎',
+};
+
+export async function generateProfileCard(options: ProfileCardOptions): Promise<AttachmentBuilder> {
+  const canvas = createCanvas(800, 400);
+  const ctx = canvas.getContext('2d');
+
+  const bgColor = BACKGROUNDS[options.background] || BACKGROUNDS['bg_default'];
+  ctx.fillStyle = bgColor;
+  ctx.fillRect(0, 0, 800, 400);
+
+  const gradient = ctx.createLinearGradient(0, 0, 800, 400);
+  gradient.addColorStop(0, 'rgba(0, 0, 0, 0.2)');
+  gradient.addColorStop(1, 'rgba(0, 0, 0, 0.5)');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, 800, 400);
+
+  ctx.strokeStyle = '#ffffff';
+  ctx.lineWidth = 5;
+  ctx.strokeRect(10, 10, 780, 380);
+
+  try {
+    const avatar = await loadImage(options.avatarURL);
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(150, 200, 100, 0, Math.PI * 2);
+    ctx.closePath();
+    ctx.clip();
+    ctx.drawImage(avatar, 50, 100, 200, 200);
+    ctx.restore();
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = 8;
+    ctx.beginPath();
+    ctx.arc(150, 200, 100, 0, Math.PI * 2);
+    ctx.stroke();
+  } catch {
+    ctx.fillStyle = '#7289da';
+    ctx.beginPath();
+    ctx.arc(150, 200, 100, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = 8;
+    ctx.beginPath();
+    ctx.arc(150, 200, 100, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = '#ffffff';
+  ctx.font = 'bold 48px Arial';
+  ctx.fillText(options.username, 300, 150);
+
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.3)';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(300, 180);
+  ctx.lineTo(750, 180);
+  ctx.stroke();
+
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.7)';
+  ctx.font = '20px Arial';
+  ctx.fillText('Badges', 300, 210);
+
+  for (let i = 0; i < 6; i++) {
+    const x = 300 + (i * 80);
+    const y = 220;
+
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.1)';
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.3)';
+    ctx.lineWidth = 2;
+    ctx.fillRect(x, y, 60, 60);
+    ctx.strokeRect(x, y, 60, 60);
+
+    const badgeId = options.badges[i];
+    if (badgeId) {
+      const emoji = BADGES[badgeId];
+      if (emoji) {
+        ctx.font = '40px Arial';
+        ctx.fillStyle = '#ffffff';
+        const metrics = ctx.measureText(emoji);
+        ctx.fillText(emoji, x + (60 - metrics.width) / 2, y + 60 / 2 + 14);
+      } else {
+        ctx.font = '30px Arial';
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+        const metrics = ctx.measureText('?');
+        ctx.fillText('?', x + (60 - metrics.width) / 2, y + 60 / 2 + 10);
+      }
+    }
+  }
+
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+  ctx.fillRect(620, 310, 150, 60);
+  ctx.strokeStyle = 'rgba(255, 215, 0, 0.8)';
+  ctx.lineWidth = 3;
+  ctx.strokeRect(620, 310, 150, 60);
+  ctx.fillStyle = '#FFD700';
+  ctx.font = 'bold 32px Arial';
+  ctx.fillText('💰', 630, 350);
+  ctx.fillStyle = '#ffffff';
+  ctx.font = 'bold 24px Arial';
+  ctx.fillText(`${options.coins}€`, 670, 350);
+
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+  ctx.font = '16px Arial';
+  const bgName = options.background.replace('bg_', '');
+  ctx.fillText(`Background: ${bgName.charAt(0).toUpperCase() + bgName.slice(1)}`, 300, 320);
+  ctx.fillText(`Badges équipés: ${options.badges.filter(Boolean).length}/6`, 300, 345);
+
+  return new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'profile.png' });
+}

--- a/bot/src/commands/mazworld/utils/travelMiddleware.ts
+++ b/bot/src/commands/mazworld/utils/travelMiddleware.ts
@@ -1,0 +1,37 @@
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { api } from "../../../api/client";
+
+interface TravelStatus {
+  traveling: boolean;
+  destination?: string;
+  destination_name?: string;
+  destination_emoji?: string;
+  arrival_time?: number;
+}
+
+export async function checkTravelingStatus(interaction: ChatInputCommandInteraction): Promise<boolean> {
+  const status = await api.get<TravelStatus>(
+    "/api/travel/status",
+    interaction.user.id,
+    interaction.user.username,
+  );
+
+  if (!status.traveling) return false;
+
+  const timeLeft = (status.arrival_time ?? 0) - Math.floor(Date.now() / 1000);
+  const hours    = Math.floor(timeLeft / 3600);
+  const minutes  = Math.floor((timeLeft % 3600) / 60);
+  const timeStr  = [hours > 0 && `${hours}h`, minutes > 0 && `${minutes}m`].filter(Boolean).join(" ");
+
+  await interaction.reply({
+    content:
+      `🚂 **Vous êtes en voyage !**\n\n` +
+      `📍 Destination : **${status.destination_emoji ?? ""} ${status.destination_name ?? ""}**\n` +
+      `⏱️ Arrivée dans : **${timeStr || "moins d'une minute"}**\n\n` +
+      `❌ Vous ne pouvez pas utiliser cette commande pendant le trajet.\n` +
+      `✅ Vous pouvez consulter votre \`/profile\` et \`/inventory\``,
+    flags: MessageFlags.Ephemeral,
+  });
+
+  return true;
+}

--- a/bot/src/commands/mazworld/work.ts
+++ b/bot/src/commands/mazworld/work.ts
@@ -1,0 +1,58 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import { api, ApiError } from "../../api/client";
+import { Command } from "../../models/Command";
+import type { WorkResponse } from "./data";
+import { buildWorkLoadingEmbed, buildWorkResultEmbed } from "./utils/embeds";
+
+const work: Command = {
+  data: new SlashCommandBuilder()
+    .setName("work")
+    .setDescription("Travaillez dans votre ville actuelle pour gagner de l'argent ! 💼"),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const avatarURL = interaction.user.displayAvatarURL();
+
+    try {
+      await interaction.reply({ embeds: [buildWorkLoadingEmbed(avatarURL)] });
+
+      const result = await api.post<WorkResponse>(
+        "/api/commands/work",
+        interaction.user.id,
+        interaction.user.username,
+      );
+
+      if (!result.success) {
+        await interaction.editReply({ content: `❌ ${result.message}`, embeds: [] });
+        return;
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      await interaction.editReply({ embeds: [buildWorkResultEmbed(result, avatarURL)] });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        const content = error.status === 429 || error.status === 409
+          ? `⏱️ ${error.message}`
+          : `❌ ${error.message}`;
+        if (interaction.deferred || interaction.replied) {
+          await interaction.editReply({ content, embeds: [] });
+        } else {
+          await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+        }
+        return;
+      }
+      console.error("Erreur dans /work:", error);
+      const errorMessage = "❌ Une erreur est survenue pendant votre travail.";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: errorMessage, embeds: [] });
+      } else {
+        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};
+
+export default work;


### PR DESCRIPTION
## Résumé

Feature #43 - Toutes les slash commands MazWorld

**SU #48 - /profile :** canvas 800x400 avec avatar, background, badges, coins

**SU #49 - /shop :** boutique interactive (categories → items → confirmation achat)

**SU #50 - /daily :** récompense quotidienne 5€ avec embed cooldown

**SU #51 - /coinflip :** pari pile/face 10-500€

**SU #52 - /inventory :** gestion équipement backgrounds et 6 slots badges

**SU #53 - /work :** travail avec animation chargement 2s

**SU #54 - /map + /cityinfo :** carte interactive voyage + détails ville

Fichiers utilitaires communs : embeds.ts, components.ts, profileCard.ts, cooldownManager.ts, travelMiddleware.ts, data/types.ts

Closes #48
Closes #49
Closes #50
Closes #51
Closes #52
Closes #53
Closes #54