### PR TITLE
feat(frontend): liaison front/back - auth Discord + HTTP client

### DIFF
--- a/web/frontend/angular.json
+++ b/web/frontend/angular.json
@@ -52,7 +52,13 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.development.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"
@@ -64,7 +70,8 @@
               "buildTarget": "frontend:build:production"
             },
             "development": {
-              "buildTarget": "frontend:build:development"
+              "buildTarget": "frontend:build:development",
+              "proxyConfig": "proxy.conf.json"
             }
           },
           "defaultConfiguration": "development"

--- a/web/frontend/proxy.conf.json
+++ b/web/frontend/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api": {
+    "target": "http://localhost:8000",
+    "secure": false,
+    "changeOrigin": true
+  }
+}

--- a/web/frontend/src/app/app.config.ts
+++ b/web/frontend/src/app/app.config.ts
@@ -1,11 +1,13 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes)
-  ]
+    provideRouter(routes),
+    provideHttpClient(),
+  ],
 };

--- a/web/frontend/src/app/app.config.ts
+++ b/web/frontend/src/app/app.config.ts
@@ -1,13 +1,14 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
+import { jwtInterceptor } from './core/interceptors/jwt.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([jwtInterceptor])),
   ],
 };

--- a/web/frontend/src/app/app.routes.ts
+++ b/web/frontend/src/app/app.routes.ts
@@ -1,3 +1,13 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './core/guards/auth.guard';
+import { LoginComponent } from './pages/login/login.component';
+import { CallbackComponent } from './pages/callback/callback.component';
+import { DashboardComponent } from './pages/dashboard/dashboard.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
+  { path: 'login', component: LoginComponent },
+  { path: 'auth/callback', component: CallbackComponent },
+  { path: 'dashboard', component: DashboardComponent, canActivate: [authGuard] },
+  { path: '**', redirectTo: 'dashboard' },
+];

--- a/web/frontend/src/app/app.ts
+++ b/web/frontend/src/app/app.ts
@@ -1,12 +1,16 @@
-import { Component, signal } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { AuthService } from './core/services/auth.service';
 
 @Component({
   selector: 'app-root',
   imports: [RouterOutlet],
-  templateUrl: './app.html',
-  styleUrl: './app.scss'
+  template: '<router-outlet />',
 })
-export class App {
-  protected readonly title = signal('frontend');
+export class App implements OnInit {
+  constructor(private readonly auth: AuthService) {}
+
+  async ngOnInit(): Promise<void> {
+    await this.auth.init();
+  }
 }

--- a/web/frontend/src/app/core/guards/auth.guard.ts
+++ b/web/frontend/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,9 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  if (auth.isAuthenticated()) return true;
+  return inject(Router).createUrlTree(['/login']);
+};

--- a/web/frontend/src/app/core/interceptors/jwt.interceptor.ts
+++ b/web/frontend/src/app/core/interceptors/jwt.interceptor.ts
@@ -1,0 +1,12 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+export const jwtInterceptor: HttpInterceptorFn = (req, next) => {
+  const token = inject(AuthService).getToken();
+  if (!token) return next(req);
+
+  return next(
+    req.clone({ setHeaders: { Authorization: `Bearer ${token}` } }),
+  );
+};

--- a/web/frontend/src/app/core/models/user.model.ts
+++ b/web/frontend/src/app/core/models/user.model.ts
@@ -1,0 +1,25 @@
+export interface User {
+  id: number;
+  user_id: string;
+  username: string;
+  discord_avatar: string | null;
+  discord_email: string | null;
+  city: string;
+  coins: number;
+  roles: string[];
+}
+
+export interface AuthResponse {
+  token: string;
+  user: User;
+  guilds: Guild[];
+}
+
+export interface Guild {
+  id: string;
+  name: string;
+  icon: string | null;
+  owner: boolean;
+  permissions: number;
+  approximate_member_count?: number;
+}

--- a/web/frontend/src/app/core/services/auth.service.ts
+++ b/web/frontend/src/app/core/services/auth.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, signal, computed } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import type { AuthResponse, User } from '../models/user.model';
+
+const TOKEN_KEY = 'mw_token';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly _user = signal<User | null>(null);
+  readonly user = this._user.asReadonly();
+  readonly isAuthenticated = computed(() => this._user() !== null);
+
+  constructor(
+    private readonly http: HttpClient,
+    private readonly router: Router,
+  ) {}
+
+  getToken(): string | null {
+    return localStorage.getItem(TOKEN_KEY);
+  }
+
+  async init(): Promise<void> {
+    const token = this.getToken();
+    if (!token) return;
+    try {
+      const res = await firstValueFrom(
+        this.http.get<{ valid: boolean; user: User | null }>(`${environment.apiUrl}/api/auth/verify`),
+      );
+      if (res.valid && res.user) {
+        this._user.set(res.user);
+      } else {
+        this.clearSession();
+      }
+    } catch {
+      this.clearSession();
+    }
+  }
+
+  async login(): Promise<void> {
+    const res = await firstValueFrom(
+      this.http.get<{ authorization_url: string }>(`${environment.apiUrl}/api/auth/discord/login`),
+    );
+    window.location.href = res.authorization_url;
+  }
+
+  async handleCallback(code: string, state: string): Promise<void> {
+    const res = await firstValueFrom(
+      this.http.post<AuthResponse>(`${environment.apiUrl}/api/auth/discord/callback`, { code, state }),
+    );
+    localStorage.setItem(TOKEN_KEY, res.token);
+    this._user.set(res.user);
+  }
+
+  async logout(): Promise<void> {
+    try {
+      await firstValueFrom(this.http.post(`${environment.apiUrl}/api/auth/logout`, {}));
+    } finally {
+      this.clearSession();
+      this.router.navigate(['/login']);
+    }
+  }
+
+  async refreshToken(): Promise<void> {
+    const res = await firstValueFrom(
+      this.http.post<{ token: string }>(`${environment.apiUrl}/api/auth/refresh`, {}),
+    );
+    localStorage.setItem(TOKEN_KEY, res.token);
+  }
+
+  private clearSession(): void {
+    localStorage.removeItem(TOKEN_KEY);
+    this._user.set(null);
+  }
+}

--- a/web/frontend/src/app/pages/callback/callback.component.html
+++ b/web/frontend/src/app/pages/callback/callback.component.html
@@ -1,0 +1,8 @@
+<div class="callback-page">
+  @if (error) {
+    <p class="error">{{ error }}</p>
+    <a routerLink="/login">Retour à la connexion</a>
+  } @else {
+    <p>Connexion en cours…</p>
+  }
+</div>

--- a/web/frontend/src/app/pages/callback/callback.component.ts
+++ b/web/frontend/src/app/pages/callback/callback.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  selector: 'app-callback',
+  templateUrl: './callback.component.html',
+})
+export class CallbackComponent implements OnInit {
+  error: string | null = null;
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly auth: AuthService,
+  ) {}
+
+  async ngOnInit(): Promise<void> {
+    const code = this.route.snapshot.queryParamMap.get('code');
+    const state = this.route.snapshot.queryParamMap.get('state');
+
+    if (!code || !state) {
+      this.error = 'Paramètres OAuth manquants.';
+      return;
+    }
+
+    try {
+      await this.auth.handleCallback(code, state);
+      this.router.navigate(['/dashboard']);
+    } catch {
+      this.error = 'Échec de l\'authentification. Veuillez réessayer.';
+    }
+  }
+}

--- a/web/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/web/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -1,0 +1,12 @@
+<div class="dashboard-page">
+  <header>
+    <h1>MazWorld</h1>
+    @if (user()) {
+      <span>{{ user()!.username }}</span>
+      <button (click)="logout()">Déconnexion</button>
+    }
+  </header>
+  <main>
+    <p>Dashboard — à venir.</p>
+  </main>
+</div>

--- a/web/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/web/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+})
+export class DashboardComponent {
+  readonly user = this.auth.user;
+
+  constructor(private readonly auth: AuthService) {}
+
+  logout(): void {
+    this.auth.logout();
+  }
+}

--- a/web/frontend/src/app/pages/login/login.component.html
+++ b/web/frontend/src/app/pages/login/login.component.html
@@ -1,0 +1,9 @@
+<div class="login-page">
+  <div class="login-card">
+    <h1>MazWorld</h1>
+    <p>Connectez-vous avec Discord pour accéder à l'application.</p>
+    <button (click)="login()" class="btn-discord">
+      Se connecter avec Discord
+    </button>
+  </div>
+</div>

--- a/web/frontend/src/app/pages/login/login.component.scss
+++ b/web/frontend/src/app/pages/login/login.component.scss
@@ -1,0 +1,25 @@
+.login-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.login-card {
+  text-align: center;
+  padding: 2rem;
+}
+
+.btn-discord {
+  background: #5865f2;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+
+  &:hover {
+    background: #4752c4;
+  }
+}

--- a/web/frontend/src/app/pages/login/login.component.ts
+++ b/web/frontend/src/app/pages/login/login.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrl: './login.component.scss',
+})
+export class LoginComponent {
+  constructor(private readonly auth: AuthService) {}
+
+  login(): void {
+    this.auth.login();
+  }
+}

--- a/web/frontend/src/environments/environment.development.ts
+++ b/web/frontend/src/environments/environment.development.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:8000',
+};

--- a/web/frontend/src/environments/environment.ts
+++ b/web/frontend/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiUrl: 'https://mazworld.example.com',
+};


### PR DESCRIPTION
﻿## Feature #31 - Liaison front/back

Mise en place de la liaison entre le frontend Angular et le backend Symfony.

### SU #134 - Configuration Angular
- Environments production/development avec apiUrl
- provideHttpClient dans app.config.ts
- Proxy dev proxy.conf.json pour eviter les CORS en local
- angular.json : fileReplacements + proxyConfig

### SU #135 - AuthService, intercepteur JWT et Auth Guard
- User, AuthResponse, Guild models
- AuthService : flux OAuth Discord complet (login, callback, logout, refresh, init)
- JwtInterceptor : injecte Authorization Bearer sur chaque requete
- AuthGuard : protection des routes par canActivateFn
- Pages : /login, /auth/callback, /dashboard
- Routes Angular configurees

Closes #31
