### PR TITLE
SU #109 — Charte graphique : classes boutons globales

### DIFF
--- a/web/frontend/src/app/features/auth/auth-callback.component.html
+++ b/web/frontend/src/app/features/auth/auth-callback.component.html
@@ -7,7 +7,7 @@
   } @else if (error()) {
     <div class="callback-state callback-state--error">
       <p class="error-message">{{ error() }}</p>
-      <button class="btn-retry" (click)="retry()">Réessayer</button>
+      <button class="btn-primary" (click)="retry()">Réessayer</button>
     </div>
   } @else {
     <div class="callback-state callback-state--success">

--- a/web/frontend/src/app/features/auth/auth-callback.component.scss
+++ b/web/frontend/src/app/features/auth/auth-callback.component.scss
@@ -25,18 +25,3 @@
   color: var(--color-text-dim);
   font-size: 0.9rem;
 }
-
-.btn-retry {
-  margin-top: var(--spacing-sm);
-  padding: 0.6rem 1.5rem;
-  background: var(--color-accent);
-  color: #fff;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 1rem;
-  transition: background var(--transition-fast);
-
-  &:hover {
-    background: var(--color-accent-2);
-  }
-}

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -21,7 +21,7 @@
           <img [src]="auth.userAvatar()!" [alt]="auth.displayName()!" class="site-header__avatar" />
         }
         <a routerLink="/dashboard" class="site-header__username">{{ auth.displayName() }}</a>
-        <button class="btn-logout" (click)="logout()">Déconnexion</button>
+        <button class="btn-ghost" (click)="logout()">Déconnexion</button>
       } @else {
         <button class="btn-discord" (click)="login()">Connexion Discord</button>
       }

--- a/web/frontend/src/app/shared/components/header/header.component.scss
+++ b/web/frontend/src/app/shared/components/header/header.component.scss
@@ -62,32 +62,6 @@
   }
 }
 
-.btn-discord {
-  padding: 0.5rem 1.25rem;
-  background: #5865f2;
-  color: #fff;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 0.9rem;
-  transition: background var(--transition-fast);
-
-  &:hover { background: #4752c4; }
-}
-
-.btn-logout {
-  padding: 0.4rem 1rem;
-  background: transparent;
-  color: var(--color-text-dim);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: var(--radius-sm);
-  font-size: 0.85rem;
-  transition: all var(--transition-fast);
-
-  &:hover {
-    color: var(--color-text);
-    border-color: rgba(255, 107, 53, 0.4);
-  }
-}
 
 @media (max-width: 768px) {
   .site-header {

--- a/web/frontend/src/styles.scss
+++ b/web/frontend/src/styles.scss
@@ -187,6 +187,148 @@ button {
   }
 }
 
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.5rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all var(--transition-fast);
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  /* Sizes */
+  &--sm { padding: 0.4rem 1rem; font-size: 0.85rem; }
+  &--lg { padding: 0.875rem 2rem; font-size: 1.05rem; }
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-2));
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(255, 107, 53, 0.4);
+    color: #fff;
+  }
+
+  &:active:not(:disabled) { transform: translateY(0); }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.btn-secondary {
+  background: rgba(255, 107, 53, 0.1);
+  color: var(--color-accent);
+  border: 1px solid rgba(255, 107, 53, 0.3);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 107, 53, 0.2);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--color-text-dim);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: var(--radius-sm);
+  padding: 0.625rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled) {
+    color: var(--color-text);
+    border-color: rgba(255, 107, 53, 0.4);
+  }
+
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.btn-danger {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-sm);
+  padding: 0.625rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled) {
+    background: rgba(239, 68, 68, 0.2);
+    border-color: #ef4444;
+  }
+
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.btn-discord {
+  background: #5865f2;
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled) { background: #4752c4; }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
 /* ===== CARDS ===== */
 .card {
   background: linear-gradient(135deg, rgba(26, 26, 37, 0.6), rgba(20, 20, 30, 0.4));


### PR DESCRIPTION
﻿## SU #109 — Charte graphique du projet

### Changements
- Ajout dans `styles.scss` des classes boutons globales réutilisables :
  - `.btn-primary` — gradient accent, avec hover lift et glow
  - `.btn-secondary` — fond accent transparent, bordure accent
  - `.btn-ghost` — transparent avec bordure subtile (remplace `.btn-logout`)
  - `.btn-danger` — rouge avec fond transparent
  - `.btn-discord` — violet Discord `#5865f2`
  - `.btn` + modificateurs BEM `--sm` / `--lg` pour les tailles
- Suppression des styles boutons redondants dans `header.component.scss` (`btn-discord`, `btn-logout`)
- Suppression de `.btn-retry` dans `auth-callback.component.scss` → remplacé par `.btn-primary`
- Harmonisation : `btn-ghost` utilisé dans le header pour la déconnexion

### Pourquoi
Les classes boutons étaient dupliquées ou manquantes (`btn-primary` référencé dans le template mais non défini). Cette SU centralise tous les styles de boutons dans le fichier global afin qu'ils soient disponibles dans toutes les features sans import supplémentaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
