### PR TITLE
feat(frontend): design global & composants réutilisables (#35)

### DIFF
--- a/web/frontend/src/app/features/auth/auth-callback.component.html
+++ b/web/frontend/src/app/features/auth/auth-callback.component.html
@@ -7,7 +7,7 @@
   } @else if (error()) {
     <div class="callback-state callback-state--error">
       <p class="error-message">{{ error() }}</p>
-      <button class="btn-retry" (click)="retry()">Réessayer</button>
+      <button class="btn-primary" (click)="retry()">Réessayer</button>
     </div>
   } @else {
     <div class="callback-state callback-state--success">

--- a/web/frontend/src/app/features/auth/auth-callback.component.scss
+++ b/web/frontend/src/app/features/auth/auth-callback.component.scss
@@ -25,18 +25,3 @@
   color: var(--color-text-dim);
   font-size: 0.9rem;
 }
-
-.btn-retry {
-  margin-top: var(--spacing-sm);
-  padding: 0.6rem 1.5rem;
-  background: var(--color-accent);
-  color: #fff;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 1rem;
-  transition: background var(--transition-fast);
-
-  &:hover {
-    background: var(--color-accent-2);
-  }
-}

--- a/web/frontend/src/app/features/dashboard/dashboard.component.html
+++ b/web/frontend/src/app/features/dashboard/dashboard.component.html
@@ -1,8 +1,22 @@
-<div class="dashboard-page container">
-  @if (auth.currentUser()) {
-    <h2>Bonjour, {{ auth.currentUser()!.username }} 👋</h2>
-    <p>Ville actuelle : {{ auth.currentUser()!.current_city }}</p>
-    <p>MazCoins : {{ auth.currentUser()!.coins }}</p>
-    <button (click)="auth.logout()">Déconnexion</button>
-  }
-</div>
+@if (auth.currentUser(); as user) {
+  <div class="dashboard-page container">
+
+    <header class="dashboard-header">
+      <app-avatar [src]="auth.userAvatar()" [alt]="user.username" size="lg" />
+      <div class="dashboard-header__info">
+        <span class="dashboard-header__name">{{ user.username }}</span>
+        <div class="dashboard-header__roles">
+          @for (role of user.roles; track role) {
+            <app-badge variant="info">{{ role }}</app-badge>
+          }
+        </div>
+      </div>
+    </header>
+
+    <section class="dashboard-stats">
+      <app-stat-card icon="🏙️" label="Ville actuelle" [value]="user.current_city" />
+      <app-stat-card icon="🪙" label="MazCoins" [value]="user.coins" variant="gold" />
+    </section>
+
+  </div>
+}

--- a/web/frontend/src/app/features/dashboard/dashboard.component.scss
+++ b/web/frontend/src/app/features/dashboard/dashboard.component.scss
@@ -1,0 +1,35 @@
+.dashboard-page {
+  padding: var(--spacing-xl) 0;
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-xl);
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__name {
+    font-family: var(--font-heading);
+    font-size: 2rem;
+    color: var(--color-text);
+    line-height: 1;
+  }
+
+  &__roles {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+}
+
+.dashboard-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-md);
+}

--- a/web/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/web/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -1,10 +1,15 @@
 import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
 import { AuthService } from '../../core/services/auth.service';
+import { StatCardComponent } from '../../shared/components/ui/stat-card/stat-card.component';
+import { BadgeComponent } from '../../shared/components/ui/badge/badge.component';
+import { AvatarComponent } from '../../shared/components/ui/avatar/avatar.component';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
+  imports: [StatCardComponent, BadgeComponent, AvatarComponent],
   templateUrl: './dashboard.component.html',
+  styleUrl: './dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DashboardComponent {

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -15,11 +15,9 @@
 
     <div class="site-header__actions">
       @if (auth.isLoading()) {
-        <span class="loading" style="width:24px;height:24px;border-width:2px"></span>
+        <app-spinner size="sm" />
       } @else if (auth.isAuthenticated()) {
-        @if (auth.userAvatar()) {
-          <img [src]="auth.userAvatar()!" [alt]="auth.displayName()!" class="site-header__avatar" />
-        }
+        <app-avatar [src]="auth.userAvatar()" [alt]="auth.displayName() ?? 'Avatar'" size="sm" />
         <a routerLink="/dashboard" class="site-header__username">{{ auth.displayName() }}</a>
         <button class="btn-ghost" (click)="logout()">Déconnexion</button>
       } @else {

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -21,7 +21,7 @@
           <img [src]="auth.userAvatar()!" [alt]="auth.displayName()!" class="site-header__avatar" />
         }
         <a routerLink="/dashboard" class="site-header__username">{{ auth.displayName() }}</a>
-        <button class="btn-logout" (click)="logout()">Déconnexion</button>
+        <button class="btn-ghost" (click)="logout()">Déconnexion</button>
       } @else {
         <button class="btn-discord" (click)="login()">Connexion Discord</button>
       }

--- a/web/frontend/src/app/shared/components/header/header.component.scss
+++ b/web/frontend/src/app/shared/components/header/header.component.scss
@@ -62,32 +62,6 @@
   }
 }
 
-.btn-discord {
-  padding: 0.5rem 1.25rem;
-  background: #5865f2;
-  color: #fff;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 0.9rem;
-  transition: background var(--transition-fast);
-
-  &:hover { background: #4752c4; }
-}
-
-.btn-logout {
-  padding: 0.4rem 1rem;
-  background: transparent;
-  color: var(--color-text-dim);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: var(--radius-sm);
-  font-size: 0.85rem;
-  transition: all var(--transition-fast);
-
-  &:hover {
-    color: var(--color-text);
-    border-color: rgba(255, 107, 53, 0.4);
-  }
-}
 
 @media (max-width: 768px) {
   .site-header {

--- a/web/frontend/src/app/shared/components/header/header.component.scss
+++ b/web/frontend/src/app/shared/components/header/header.component.scss
@@ -45,13 +45,6 @@
     margin-left: auto;
   }
 
-  &__avatar {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 2px solid rgba(255, 107, 53, 0.4);
-  }
-
   &__username {
     color: var(--color-text);
     font-weight: 500;

--- a/web/frontend/src/app/shared/components/header/header.component.ts
+++ b/web/frontend/src/app/shared/components/header/header.component.ts
@@ -1,11 +1,13 @@
 import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthService } from '../../../core/services/auth.service';
+import { SpinnerComponent } from '../ui/spinner/spinner.component';
+import { AvatarComponent } from '../ui/avatar/avatar.component';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [RouterLink, RouterLinkActive],
+  imports: [RouterLink, RouterLinkActive, SpinnerComponent, AvatarComponent],
   templateUrl: './header.component.html',
   styleUrl: './header.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/web/frontend/src/app/shared/components/ui/avatar/avatar.component.scss
+++ b/web/frontend/src/app/shared/components/ui/avatar/avatar.component.scss
@@ -1,0 +1,20 @@
+.avatar {
+  border-radius: 50%;
+  border: 2px solid rgba(255, 107, 53, 0.35);
+  object-fit: cover;
+  flex-shrink: 0;
+
+  &--sm  { width: 28px; height: 28px; font-size: 0.65rem; }
+  &--md  { width: 40px; height: 40px; font-size: 0.85rem; }
+  &--lg  { width: 64px; height: 64px; font-size: 1.25rem; }
+
+  &--fallback {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, var(--color-accent), var(--color-accent-2));
+    color: #fff;
+    font-weight: 700;
+    font-family: var(--font-body);
+  }
+}

--- a/web/frontend/src/app/shared/components/ui/avatar/avatar.component.ts
+++ b/web/frontend/src/app/shared/components/ui/avatar/avatar.component.ts
@@ -1,0 +1,41 @@
+import { Component, ChangeDetectionStrategy, input, computed } from '@angular/core';
+
+@Component({
+  selector: 'app-avatar',
+  standalone: true,
+  template: `
+    @if (src()) {
+      <img
+        class="avatar"
+        [class]="'avatar--' + size()"
+        [src]="src()!"
+        [alt]="alt()"
+        (error)="onError($event)"
+      />
+    } @else {
+      <span class="avatar avatar--fallback" [class]="'avatar--' + size()" aria-hidden="true">
+        {{ initials() }}
+      </span>
+    }
+  `,
+  styleUrl: './avatar.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AvatarComponent {
+  readonly src = input<string | null>(null);
+  readonly alt = input.required<string>();
+  readonly size = input<'sm' | 'md' | 'lg'>('md');
+
+  readonly initials = computed(() =>
+    this.alt()
+      .split(' ')
+      .map(w => w[0])
+      .slice(0, 2)
+      .join('')
+      .toUpperCase()
+  );
+
+  onError(event: Event): void {
+    (event.target as HTMLImageElement).style.display = 'none';
+  }
+}

--- a/web/frontend/src/app/shared/components/ui/badge/badge.component.scss
+++ b/web/frontend/src/app/shared/components/ui/badge/badge.component.scss
@@ -1,0 +1,40 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: var(--radius-full);
+  font-size: 0.8rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+
+  &--accent {
+    background: rgba(255, 107, 53, 0.12);
+    border-color: rgba(255, 107, 53, 0.35);
+    color: var(--color-accent);
+  }
+
+  &--gold {
+    background: rgba(212, 175, 55, 0.12);
+    border-color: rgba(212, 175, 55, 0.35);
+    color: var(--color-gold);
+  }
+
+  &--success {
+    background: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.35);
+    color: #22c55e;
+  }
+
+  &--danger {
+    background: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.35);
+    color: #ef4444;
+  }
+
+  &--info {
+    background: rgba(88, 101, 242, 0.12);
+    border-color: rgba(88, 101, 242, 0.35);
+    color: #7289da;
+  }
+}

--- a/web/frontend/src/app/shared/components/ui/badge/badge.component.ts
+++ b/web/frontend/src/app/shared/components/ui/badge/badge.component.ts
@@ -1,0 +1,16 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+
+@Component({
+  selector: 'app-badge',
+  standalone: true,
+  template: `
+    <span class="badge" [class]="'badge--' + variant()">
+      <ng-content />
+    </span>
+  `,
+  styleUrl: './badge.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BadgeComponent {
+  readonly variant = input<'accent' | 'gold' | 'success' | 'danger' | 'info'>('accent');
+}

--- a/web/frontend/src/app/shared/components/ui/empty-state/empty-state.component.scss
+++ b/web/frontend/src/app/shared/components/ui/empty-state/empty-state.component.scss
@@ -1,0 +1,30 @@
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-2xl) var(--spacing-lg);
+  text-align: center;
+  color: var(--color-text-dim);
+
+  &__icon {
+    font-size: 3rem;
+    line-height: 1;
+    opacity: 0.5;
+  }
+
+  &__title {
+    font-family: var(--font-heading);
+    font-size: 1.4rem;
+    color: var(--color-text);
+    margin: 0;
+  }
+
+  &__description {
+    font-size: 0.95rem;
+    color: var(--color-text-dim);
+    max-width: 380px;
+    margin: 0;
+  }
+}

--- a/web/frontend/src/app/shared/components/ui/empty-state/empty-state.component.ts
+++ b/web/frontend/src/app/shared/components/ui/empty-state/empty-state.component.ts
@@ -1,0 +1,25 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+
+@Component({
+  selector: 'app-empty-state',
+  standalone: true,
+  template: `
+    <div class="empty-state">
+      @if (icon()) {
+        <span class="empty-state__icon" aria-hidden="true">{{ icon() }}</span>
+      }
+      <h3 class="empty-state__title">{{ title() }}</h3>
+      @if (description()) {
+        <p class="empty-state__description">{{ description() }}</p>
+      }
+      <ng-content />
+    </div>
+  `,
+  styleUrl: './empty-state.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EmptyStateComponent {
+  readonly title = input.required<string>();
+  readonly description = input('');
+  readonly icon = input('');
+}

--- a/web/frontend/src/app/shared/components/ui/index.ts
+++ b/web/frontend/src/app/shared/components/ui/index.ts
@@ -1,0 +1,5 @@
+export { SpinnerComponent } from './spinner/spinner.component';
+export { BadgeComponent } from './badge/badge.component';
+export { AvatarComponent } from './avatar/avatar.component';
+export { StatCardComponent } from './stat-card/stat-card.component';
+export { EmptyStateComponent } from './empty-state/empty-state.component';

--- a/web/frontend/src/app/shared/components/ui/spinner/spinner.component.scss
+++ b/web/frontend/src/app/shared/components/ui/spinner/spinner.component.scss
@@ -1,0 +1,16 @@
+.spinner {
+  display: inline-block;
+  border-style: solid;
+  border-color: rgba(255, 107, 53, 0.2);
+  border-radius: 50%;
+  border-top-color: var(--color-accent);
+  animation: spin 1s linear infinite;
+
+  &--sm  { width: 20px; height: 20px; border-width: 2px; }
+  &--md  { width: 36px; height: 36px; border-width: 3px; }
+  &--lg  { width: 56px; height: 56px; border-width: 4px; }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/web/frontend/src/app/shared/components/ui/spinner/spinner.component.ts
+++ b/web/frontend/src/app/shared/components/ui/spinner/spinner.component.ts
@@ -1,0 +1,20 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+
+@Component({
+  selector: 'app-spinner',
+  standalone: true,
+  template: `
+    <span
+      class="spinner"
+      [class]="'spinner--' + size()"
+      role="status"
+      [attr.aria-label]="label()"
+    ></span>
+  `,
+  styleUrl: './spinner.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SpinnerComponent {
+  readonly size = input<'sm' | 'md' | 'lg'>('md');
+  readonly label = input('Chargement…');
+}

--- a/web/frontend/src/app/shared/components/ui/stat-card/stat-card.component.scss
+++ b/web/frontend/src/app/shared/components/ui/stat-card/stat-card.component.scss
@@ -1,0 +1,53 @@
+.stat-card {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: linear-gradient(135deg, rgba(26, 26, 37, 0.7), rgba(20, 20, 30, 0.5));
+  border: 1px solid rgba(255, 107, 53, 0.1);
+  border-radius: var(--radius-md);
+  transition: all var(--transition-normal);
+
+  &:hover {
+    border-color: rgba(255, 107, 53, 0.25);
+    box-shadow: var(--shadow-md);
+  }
+
+  &--accent {
+    border-color: rgba(255, 107, 53, 0.25);
+    background: linear-gradient(135deg, rgba(255, 107, 53, 0.08), rgba(20, 20, 30, 0.5));
+  }
+
+  &--gold {
+    border-color: rgba(212, 175, 55, 0.25);
+    background: linear-gradient(135deg, rgba(212, 175, 55, 0.08), rgba(20, 20, 30, 0.5));
+
+    .stat-card__value { color: var(--color-gold); }
+  }
+
+  &__icon {
+    font-size: 1.75rem;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  &__value {
+    font-family: var(--font-heading);
+    font-size: 1.6rem;
+    color: var(--color-text);
+    line-height: 1;
+  }
+
+  &__label {
+    font-size: 0.8rem;
+    color: var(--color-text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+}

--- a/web/frontend/src/app/shared/components/ui/stat-card/stat-card.component.ts
+++ b/web/frontend/src/app/shared/components/ui/stat-card/stat-card.component.ts
@@ -1,0 +1,25 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+
+@Component({
+  selector: 'app-stat-card',
+  standalone: true,
+  template: `
+    <div class="stat-card" [class]="'stat-card--' + variant()">
+      @if (icon()) {
+        <span class="stat-card__icon" aria-hidden="true">{{ icon() }}</span>
+      }
+      <div class="stat-card__body">
+        <span class="stat-card__value">{{ value() }}</span>
+        <span class="stat-card__label">{{ label() }}</span>
+      </div>
+    </div>
+  `,
+  styleUrl: './stat-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StatCardComponent {
+  readonly label = input.required<string>();
+  readonly value = input.required<string | number>();
+  readonly icon = input<string>('');
+  readonly variant = input<'default' | 'accent' | 'gold'>('default');
+}

--- a/web/frontend/src/styles.scss
+++ b/web/frontend/src/styles.scss
@@ -187,6 +187,148 @@ button {
   }
 }
 
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.5rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all var(--transition-fast);
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  /* Sizes */
+  &--sm { padding: 0.4rem 1rem; font-size: 0.85rem; }
+  &--lg { padding: 0.875rem 2rem; font-size: 1.05rem; }
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-2));
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(255, 107, 53, 0.4);
+    color: #fff;
+  }
+
+  &:active:not(:disabled) { transform: translateY(0); }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.btn-secondary {
+  background: rgba(255, 107, 53, 0.1);
+  color: var(--color-accent);
+  border: 1px solid rgba(255, 107, 53, 0.3);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 107, 53, 0.2);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--color-text-dim);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: var(--radius-sm);
+  padding: 0.625rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled) {
+    color: var(--color-text);
+    border-color: rgba(255, 107, 53, 0.4);
+  }
+
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.btn-danger {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-sm);
+  padding: 0.625rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled) {
+    background: rgba(239, 68, 68, 0.2);
+    border-color: #ef4444;
+  }
+
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.btn-discord {
+  background: #5865f2;
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled) { background: #4752c4; }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
 /* ===== CARDS ===== */
 .card {
   background: linear-gradient(135deg, rgba(26, 26, 37, 0.6), rgba(20, 20, 30, 0.4));


### PR DESCRIPTION
﻿## Feature #35 — Design global & composants

### SU #109 — Charte graphique
Classes boutons globales centralisées dans `styles.scss` :
- `.btn-primary`, `.btn-secondary`, `.btn-ghost`, `.btn-danger`, `.btn-discord`
- Modificateurs BEM `.btn--sm` / `.btn--lg`
- Suppression des doublons locaux (header, auth-callback)

### SU #37 — Composants réutilisables
Bibliothèque UI dans `shared/components/ui/` :

| Composant | Rôle |
|---|---|
| `SpinnerComponent` | Indicateur de chargement accessible (sm/md/lg) |
| `BadgeComponent` | Tag coloré par variant (accent/gold/success/danger/info) |
| `AvatarComponent` | Avatar Discord + fallback initiales calculées |
| `StatCardComponent` | Carte métrique icon + valeur + label (default/accent/gold) |
| `EmptyStateComponent` | État vide avec icon, titre, description et slot action |

Barrel export `ui/index.ts`. Tous standalone + OnPush + Angular Signals (`input()`, `input.required()`, `computed()`).

Intégrations : header (SpinnerComponent + AvatarComponent), dashboard (StatCard + Badge + Avatar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
