### PR TITLE
fix(frontend): port API 8008, nav publique et home page

### DIFF
--- a/web/frontend/proxy.conf.json
+++ b/web/frontend/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8000",
+    "target": "http://localhost:8008",
     "secure": false,
     "changeOrigin": true
   }

--- a/web/frontend/src/app/features/home/home.component.html
+++ b/web/frontend/src/app/features/home/home.component.html
@@ -1,11 +1,58 @@
-<main class="home-page container">
-  <section class="hero">
-    <h1 class="text-gradient">MazWorld</h1>
-    <p>Voyageur aujourd'hui, magnat demain.</p>
-    @if (auth.isAuthenticated()) {
-      <a routerLink="/dashboard" class="btn-primary">Mon dashboard</a>
-    } @else {
-      <button class="btn-discord" (click)="login()">Se connecter avec Discord</button>
-    }
+<main class="home-page">
+
+  <!-- Hero -->
+  <section class="hero container">
+    <div class="hero__content">
+      <p class="hero__eyebrow">Discord RPG</p>
+      <h1 class="hero__title">
+        <span class="text-gradient">MazWorld</span>
+      </h1>
+      <p class="hero__subtitle">
+        Voyagez de ville en ville, accumulez des MazCoins et gravissez le classement
+        au fil de vos aventures Discord.
+      </p>
+      <div class="hero__actions">
+        @if (auth.isAuthenticated()) {
+          <a routerLink="/dashboard" class="btn-primary">Mon dashboard</a>
+          <a routerLink="/map" class="btn-ghost">Explorer la carte</a>
+        } @else {
+          <button class="btn-discord" (click)="login()">
+            Se connecter avec Discord
+          </button>
+          <a routerLink="/leaderboard" class="btn-ghost">Voir le classement</a>
+        }
+      </div>
+    </div>
+    <div class="hero__visual" aria-hidden="true">
+      <div class="hero__orb hero__orb--1"></div>
+      <div class="hero__orb hero__orb--2"></div>
+    </div>
   </section>
+
+  <!-- Features -->
+  <section class="features container">
+    <div class="features__grid">
+      <div class="feature-card">
+        <span class="feature-card__icon">🗺️</span>
+        <h3>Carte interactive</h3>
+        <p>Voyagez entre les villes, découvrez de nouveaux territoires et construisez votre empire.</p>
+      </div>
+      <div class="feature-card">
+        <span class="feature-card__icon">🪙</span>
+        <h3>MazCoins</h3>
+        <p>Gagnez des MazCoins en interagissant sur Discord. Dépensez-les dans la boutique.</p>
+      </div>
+      <div class="feature-card">
+        <span class="feature-card__icon">🏆</span>
+        <h3>Classement</h3>
+        <p>Affrontez la communauté et hissez-vous en haut du classement mondial.</p>
+      </div>
+      <div class="feature-card">
+        <span class="feature-card__icon">🤖</span>
+        <h3>Bot Discord</h3>
+        <p>Invitez le bot sur votre serveur et jouez directement depuis Discord.</p>
+      </div>
+    </div>
+  </section>
+
 </main>

--- a/web/frontend/src/app/features/home/home.component.scss
+++ b/web/frontend/src/app/features/home/home.component.scss
@@ -1,0 +1,139 @@
+.home-page {
+  overflow: hidden;
+}
+
+/* ===== HERO ===== */
+.hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-height: calc(100vh - 64px);
+  padding: var(--spacing-2xl) 0;
+
+  &__content {
+    position: relative;
+    z-index: 1;
+    max-width: 640px;
+    animation: fadeInUp 0.6s ease both;
+  }
+
+  &__eyebrow {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  &__title {
+    font-size: clamp(3.5rem, 8vw, 6rem);
+    line-height: 1;
+    margin-bottom: var(--spacing-md);
+  }
+
+  &__subtitle {
+    font-size: 1.15rem;
+    color: var(--color-text-dim);
+    max-width: 500px;
+    margin-bottom: var(--spacing-xl);
+    line-height: 1.7;
+  }
+
+  &__actions {
+    display: flex;
+    gap: var(--spacing-sm);
+    flex-wrap: wrap;
+  }
+
+  &__visual {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  &__orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.25;
+
+    &--1 {
+      width: 500px;
+      height: 500px;
+      background: radial-gradient(circle, var(--color-accent), transparent 70%);
+      right: -100px;
+      top: 50%;
+      transform: translateY(-50%);
+      animation: pulse 6s ease-in-out infinite;
+    }
+
+    &--2 {
+      width: 300px;
+      height: 300px;
+      background: radial-gradient(circle, var(--color-accent-2), transparent 70%);
+      right: 200px;
+      bottom: 10%;
+      animation: pulse 8s ease-in-out infinite 2s;
+    }
+  }
+}
+
+/* ===== FEATURES ===== */
+.features {
+  padding: var(--spacing-2xl) 0;
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--spacing-md);
+  }
+}
+
+.feature-card {
+  padding: var(--spacing-lg);
+  background: linear-gradient(135deg, rgba(26, 26, 37, 0.6), rgba(20, 20, 30, 0.4));
+  border: 1px solid rgba(255, 107, 53, 0.08);
+  border-radius: var(--radius-lg);
+  transition: all var(--transition-normal);
+  animation: fadeInUp 0.6s ease both;
+
+  &:nth-child(2) { animation-delay: 0.1s; }
+  &:nth-child(3) { animation-delay: 0.2s; }
+  &:nth-child(4) { animation-delay: 0.3s; }
+
+  &:hover {
+    border-color: rgba(255, 107, 53, 0.25);
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+  }
+
+  &__icon {
+    font-size: 2rem;
+    display: block;
+    margin-bottom: var(--spacing-sm);
+  }
+
+  h3 {
+    font-size: 1.2rem;
+    margin-bottom: 0.5rem;
+    color: var(--color-text);
+  }
+
+  p {
+    font-size: 0.9rem;
+    color: var(--color-text-dim);
+    line-height: 1.6;
+    margin: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .hero {
+    min-height: auto;
+    padding: var(--spacing-xl) 0;
+
+    &__title { font-size: clamp(2.5rem, 10vw, 4rem); }
+    &__orb { display: none; }
+  }
+}

--- a/web/frontend/src/app/features/home/home.component.ts
+++ b/web/frontend/src/app/features/home/home.component.ts
@@ -7,6 +7,7 @@ import { AuthService } from '../../core/services/auth.service';
   standalone: true,
   imports: [RouterLink],
   templateUrl: './home.component.html',
+  styleUrl: './home.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HomeComponent {

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -6,11 +6,11 @@
 
     <nav class="site-header__nav" aria-label="Navigation principale">
       @if (auth.isAuthenticated()) {
-        <a routerLink="/map"         routerLinkActive="active">Carte</a>
-        <a routerLink="/shop"        routerLinkActive="active">Boutique</a>
-        <a routerLink="/leaderboard" routerLinkActive="active">Classement</a>
-        <a routerLink="/commands"    routerLinkActive="active">Commandes</a>
+        <a routerLink="/map"      routerLinkActive="active">Carte</a>
+        <a routerLink="/shop"     routerLinkActive="active">Boutique</a>
       }
+      <a routerLink="/leaderboard" routerLinkActive="active">Classement</a>
+      <a routerLink="/commands"    routerLinkActive="active">Commandes</a>
     </nav>
 
     <div class="site-header__actions">

--- a/web/frontend/src/environments/environment.development.ts
+++ b/web/frontend/src/environments/environment.development.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8000',
+  apiUrl: 'http://localhost:8008',
 };


### PR DESCRIPTION
﻿## Fix — Port API, nav publique et home page

### Corrections
- **Port API** : `environment.development.ts` et `proxy.conf.json` corrigés de 8000 → **8008** (port réel du serveur Symfony)
- **Header nav** : `Classement` et `Commandes` sont des routes publiques (`app.routes.ts`) mais n'apparaissaient dans la nav que si l'utilisateur était connecté — bug corrigé
- **Home page** : remplace le placeholder minimaliste par une vraie landing page :
  - Hero pleine hauteur avec titre, sous-titre, orbs décoratifs animés et CTA adaptatif (dashboard/carte si connecté, Discord/classement sinon)
  - Section "Features" avec 4 cartes (Carte, MazCoins, Classement, Bot Discord)
  - Animations `fadeInUp` + `pulse` avec `prefers-reduced-motion` respecté via le global

