### PR TITLE
feat(#56): affichage du profil utilisateur

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mazworld",
+  "version": "1.0.0",
+  "scripts": {
+    "install:all": "cd web/frontend && npm i && cd ../../bot && npm i",
+    "dev": "concurrently --kill-others --kill-others-on-fail -c red,blue,green --names Back,Front,Bot \"npm run dev:back\" \"npm run dev:front\" \"npm run dev:bot\"",
+    "dev:front": "cd web/frontend && npm run start",
+    "dev:back": "cd web/backend && symfony server:start -p 8008",
+    "dev:bot": "cd bot && npm run dev"
+  },
+  "devDependencies": {
+    "concurrently": "^9.1.2"
+  }
+}

--- a/web/backend/src/DataFixtures/AppFixtures.php
+++ b/web/backend/src/DataFixtures/AppFixtures.php
@@ -2,6 +2,9 @@
 
 namespace App\DataFixtures;
 
+use App\Entity\City;
+use App\Entity\CityJob;
+use App\Entity\Route;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
@@ -9,11 +12,158 @@ class AppFixtures extends Fixture
 {
     public function load(ObjectManager $manager): void
     {
-        // Les fixtures seront implémentées au fur et à mesure de la création des entités :
-        // - Villes et routes
-        // - Items de la boutique
-        // - Données de test utilisateurs
-
+        $cities = $this->createCities($manager);
+        $this->createRoutes($manager, $cities);
         $manager->flush();
+    }
+
+    /**
+     * @return array<string, City>
+     */
+    private function createCities(ObjectManager $manager): array
+    {
+        $data = [
+            'willowbrook' => [
+                'name'        => 'Willowbrook',
+                'description' => 'Une paisible bourgade nichée entre les collines, point de départ idéal pour tout voyageur.',
+                'emoji'       => '🌿',
+                'theme'       => 'nature',
+                'position_x'  => 200,
+                'position_y'  => 350,
+                'jobs'        => [
+                    ['🌾', 'Fermier',    'Semer les champs',      'Arroser les cultures',  'Récolter les légumes'],
+                    ['🪵', 'Bûcheron',   'Abattre des arbres',    'Débiter les troncs',    'Livrer le bois'],
+                    ['🧺', 'Artisan',    'Tisser des paniers',    'Tanner le cuir',        'Vendre en marché'],
+                ],
+            ],
+            'ironhaven' => [
+                'name'        => 'Ironhaven',
+                'description' => 'Une cité industrielle dont les forges illuminent la nuit, réputée pour ses artisans du métal.',
+                'emoji'       => '⚒️',
+                'theme'       => 'industrial',
+                'position_x'  => 500,
+                'position_y'  => 200,
+                'jobs'        => [
+                    ['🔨', 'Forgeron',   'Fondre le minerai',     'Forger les lames',      'Polir les pièces'],
+                    ['⚙️', 'Mécanicien', 'Réparer les machines',  'Lubrifier les rouages', 'Tester les mécanismes'],
+                    ['🏗️', 'Ouvrier',    'Couler le béton',       'Monter les échafaudages','Finir les façades'],
+                ],
+            ],
+            'crystalport' => [
+                'name'        => 'Crystalport',
+                'description' => "Un port animé où se croisent marchands et marins. Les eaux azurées reflètent les voiles colorées.",
+                'emoji'       => '⚓',
+                'theme'       => 'maritime',
+                'position_x'  => 750,
+                'position_y'  => 400,
+                'jobs'        => [
+                    ['🎣', 'Pêcheur',    'Lancer les filets',     'Trier les poissons',    'Vendre au marché'],
+                    ['🚢', 'Marin',      'Hisser les voiles',     'Naviguer au large',     'Décharger la cargaison'],
+                    ['🏪', 'Commerçant', 'Négocier les prix',     'Emballer les produits', 'Enregistrer les ventes'],
+                ],
+            ],
+            'shadowpeak' => [
+                'name'        => 'Shadowpeak',
+                'description' => 'Un village perché dans les montagnes brumeuses, gardien de secrets anciens.',
+                'emoji'       => '🏔️',
+                'theme'       => 'mountain',
+                'position_x'  => 400,
+                'position_y'  => 100,
+                'jobs'        => [
+                    ['⛏️', 'Mineur',     'Creuser les galeries',  'Extraire les cristaux', 'Trier les minerais'],
+                    ['🧙', 'Alchimiste', 'Cueillir les herbes',   'Distiller les potions', 'Analyser les effets'],
+                    ['🏹', 'Chasseur',   'Poser des pièges',      'Traquer le gibier',     'Dépouiller les prises'],
+                ],
+            ],
+            'goldenfields' => [
+                'name'        => 'Goldenfields',
+                'description' => "De vastes plaines dorées à perte de vue, grenier du royaume et terre de prospérité.",
+                'emoji'       => '🌾',
+                'theme'       => 'plains',
+                'position_x'  => 650,
+                'position_y'  => 550,
+                'jobs'        => [
+                    ['🐄', 'Éleveur',    'Nourrir le bétail',     'Traire les vaches',     'Soigner les animaux'],
+                    ['🌽', 'Agriculteur','Labourer les champs',   'Planter les graines',   'Moissonner les épis'],
+                    ['🧑‍🍳', 'Cuisinier', 'Éplucher les légumes',  'Cuisiner les plats',    'Servir les convives'],
+                ],
+            ],
+            'neonhub' => [
+                'name'        => 'NeonHub',
+                'description' => 'La métropole high-tech, cœur technologique du monde MazWorld, toujours en effervescence.',
+                'emoji'       => '🌆',
+                'theme'       => 'cyber',
+                'position_x'  => 900,
+                'position_y'  => 250,
+                'jobs'        => [
+                    ['💻', 'Développeur','Écrire du code',         'Corriger des bugs',     'Déployer en production'],
+                    ['📡', 'Technicien', 'Câbler les serveurs',   'Tester la connexion',   'Surveiller le réseau'],
+                    ['🤖', 'Ingénieur',  'Concevoir les systèmes','Tester les prototypes', 'Rédiger la documentation'],
+                ],
+            ],
+        ];
+
+        $cities = [];
+        foreach ($data as $id => $cfg) {
+            $city = (new City())
+                ->setCityId($id)
+                ->setName($cfg['name'])
+                ->setDescription($cfg['description'])
+                ->setEmoji($cfg['emoji'])
+                ->setTheme($cfg['theme'])
+                ->setPositionX($cfg['position_x'])
+                ->setPositionY($cfg['position_y']);
+
+            foreach ($cfg['jobs'] as [$emoji, $name, $t1, $t2, $t3]) {
+                $job = (new CityJob())
+                    ->setCity($city)
+                    ->setJobEmoji($emoji)
+                    ->setJobName($name)
+                    ->setTask1($t1)
+                    ->setTask2($t2)
+                    ->setTask3($t3);
+                $manager->persist($job);
+            }
+
+            $manager->persist($city);
+            $cities[$id] = $city;
+        }
+
+        return $cities;
+    }
+
+    /**
+     * @param array<string, City> $c
+     */
+    private function createRoutes(ObjectManager $manager, array $c): void
+    {
+        $routes = [
+            // [from, to, cost, duration_minutes]
+            ['willowbrook',  'ironhaven',    50,  60],
+            ['ironhaven',    'willowbrook',  50,  60],
+            ['willowbrook',  'goldenfields', 40,  45],
+            ['goldenfields', 'willowbrook',  40,  45],
+            ['ironhaven',    'shadowpeak',   80, 120],
+            ['shadowpeak',   'ironhaven',    80, 120],
+            ['ironhaven',    'crystalport',  60,  90],
+            ['crystalport',  'ironhaven',    60,  90],
+            ['crystalport',  'neonhub',      70,  75],
+            ['neonhub',      'crystalport',  70,  75],
+            ['crystalport',  'goldenfields', 55,  65],
+            ['goldenfields', 'crystalport',  55,  65],
+            ['goldenfields', 'neonhub',      90, 100],
+            ['neonhub',      'goldenfields', 90, 100],
+            ['shadowpeak',   'neonhub',     120, 150],
+            ['neonhub',      'shadowpeak',  120, 150],
+        ];
+
+        foreach ($routes as [$from, $to, $cost, $duration]) {
+            $route = (new Route())
+                ->setCityFrom($c[$from])
+                ->setCityTo($c[$to])
+                ->setCost($cost)
+                ->setDuration($duration);
+            $manager->persist($route);
+        }
     }
 }

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/animations": "^21.2.17",
         "@angular/common": "^21.0.0",
         "@angular/compiler": "^21.0.0",
         "@angular/core": "^21.0.0",
@@ -320,6 +321,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/animations": {
+      "version": "21.2.17",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.17.tgz",
+      "integrity": "sha512-zOW8FFa9qfbVkZ5TulxDkl1C3+gEjWfAAD5Z2MycA6pjVJQlLYPiTAGq+flOQ3yZfTT0z6kd5rejQMXWI81Dvg==",
+      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "21.2.17"
       }
     },
     "node_modules/@angular/build": {

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -23,6 +23,7 @@
   "private": true,
   "packageManager": "npm@10.9.2",
   "dependencies": {
+    "@angular/animations": "^21.2.17",
     "@angular/common": "^21.0.0",
     "@angular/compiler": "^21.0.0",
     "@angular/core": "^21.0.0",

--- a/web/frontend/proxy.conf.json
+++ b/web/frontend/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8008",
+    "target": "https://localhost:8008",
     "secure": false,
     "changeOrigin": true
   }

--- a/web/frontend/src/app/core/data/backgrounds.json
+++ b/web/frontend/src/app/core/data/backgrounds.json
@@ -1,0 +1,10 @@
+{
+  "backgrounds": [
+    { "id": "bg_default", "name": "Défaut", "color": "#2f3136", "price": 0 },
+    { "id": "bg_blue", "name": "Bleu Discord", "color": "#5865f2", "price": 50 },
+    { "id": "bg_purple", "name": "Violet", "color": "#9b59b6", "price": 75 },
+    { "id": "bg_green", "name": "Vert", "color": "#2ecc71", "price": 75 },
+    { "id": "bg_red", "name": "Rouge", "color": "#e74c3c", "price": 75 },
+    { "id": "bg_orange", "name": "Orange MazWorld", "color": "#ff6b35", "price": 100 }
+  ]
+}

--- a/web/frontend/src/app/core/data/badges.json
+++ b/web/frontend/src/app/core/data/badges.json
@@ -1,0 +1,10 @@
+{
+  "badges": [
+    { "id": "badge_founder", "name": "Fondateur", "emoji": "👑", "icon": "crown", "price": 500 },
+    { "id": "badge_verified", "name": "Vérifié", "emoji": "✅", "icon": "check-circle", "price": 100 },
+    { "id": "badge_star", "name": "Étoile", "emoji": "⭐", "icon": "star", "price": 150 },
+    { "id": "badge_heart", "name": "Cœur", "emoji": "❤️", "icon": "heart", "price": 100 },
+    { "id": "badge_fire", "name": "Feu", "emoji": "🔥", "icon": "flame", "price": 200 },
+    { "id": "badge_diamond", "name": "Diamant", "emoji": "💎", "icon": "gem", "price": 300 }
+  ]
+}

--- a/web/frontend/src/app/core/data/data.types.ts
+++ b/web/frontend/src/app/core/data/data.types.ts
@@ -1,0 +1,22 @@
+export interface Background {
+  id: string;
+  name: string;
+  color: string;
+  price: number;
+}
+
+export interface Badge {
+  id: string;
+  name: string;
+  emoji: string;
+  icon: string;
+  price: number;
+}
+
+export interface BackgroundsData {
+  backgrounds: Background[];
+}
+
+export interface BadgesData {
+  badges: Badge[];
+}

--- a/web/frontend/src/app/core/data/index.ts
+++ b/web/frontend/src/app/core/data/index.ts
@@ -1,0 +1,24 @@
+export * from './data.types';
+
+import backgroundsJson from './backgrounds.json';
+import badgesJson from './badges.json';
+import type { Background, Badge } from './data.types';
+
+export const BACKGROUNDS: Background[] = backgroundsJson.backgrounds;
+export const BADGES: Badge[] = badgesJson.badges;
+
+export function getBackgroundById(id: string): Background | undefined {
+  return BACKGROUNDS.find(bg => bg.id === id);
+}
+
+export function getBackgroundColor(id: string): string {
+  return getBackgroundById(id)?.color ?? '#2f3136';
+}
+
+export function getBadgeById(id: string): Badge | undefined {
+  return BADGES.find(b => b.id === id);
+}
+
+export function getBadgeEmoji(id: string): string {
+  return getBadgeById(id)?.emoji ?? '❓';
+}

--- a/web/frontend/src/app/core/guards/index.ts
+++ b/web/frontend/src/app/core/guards/index.ts
@@ -1,0 +1,1 @@
+export * from './auth.guard';

--- a/web/frontend/src/app/core/index.ts
+++ b/web/frontend/src/app/core/index.ts
@@ -1,0 +1,6 @@
+export * from './models';
+export * from './services';
+export * from './utils';
+export * from './data';
+export * from './guards';
+export * from './interceptors';

--- a/web/frontend/src/app/core/interceptors/index.ts
+++ b/web/frontend/src/app/core/interceptors/index.ts
@@ -1,0 +1,1 @@
+export * from './jwt.interceptor';

--- a/web/frontend/src/app/core/interceptors/jwt.interceptor.ts
+++ b/web/frontend/src/app/core/interceptors/jwt.interceptor.ts
@@ -4,7 +4,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { catchError, throwError } from 'rxjs';
 import { AuthStorageService } from '../services/auth-storage.service';
 
-const PUBLIC_URLS = ['/api/auth/discord/login', '/api/auth/discord/callback', '/api/auth/verify'];
+const PUBLIC_URLS = ['/api/auth/discord/login', '/api/auth/discord/callback'];
 
 export const jwtInterceptor: HttpInterceptorFn = (req, next) => {
   if (!isPlatformBrowser(inject(PLATFORM_ID))) return next(req);

--- a/web/frontend/src/app/core/models/index.ts
+++ b/web/frontend/src/app/core/models/index.ts
@@ -1,0 +1,2 @@
+export * from './user.model';
+export * from './profile.model';

--- a/web/frontend/src/app/core/models/profile.model.ts
+++ b/web/frontend/src/app/core/models/profile.model.ts
@@ -1,0 +1,35 @@
+export type BadgeId =
+  | 'badge_founder'
+  | 'badge_verified'
+  | 'badge_star'
+  | 'badge_heart'
+  | 'badge_fire'
+  | 'badge_diamond';
+
+export type BackgroundId =
+  | 'bg_default'
+  | 'bg_blue'
+  | 'bg_purple'
+  | 'bg_green'
+  | 'bg_red'
+  | 'bg_orange';
+
+export interface UserProfile {
+  user_id: string;
+  username: string;
+  discord_avatar: string | null;
+  coins: number;
+  equipped_background: BackgroundId;
+  equipped_badges: BadgeId[];
+  current_city: string | null;
+  current_city_name: string;
+  traveling_to: string | null;
+  arrival_time: number | null;
+  created_at: string;
+  visited_cities_count: number;
+  inventory_count: number;
+}
+
+export interface ProfileResponse {
+  profile: UserProfile;
+}

--- a/web/frontend/src/app/core/services/index.ts
+++ b/web/frontend/src/app/core/services/index.ts
@@ -1,0 +1,3 @@
+export * from './auth.service';
+export * from './auth-storage.service';
+export * from './profile.service';

--- a/web/frontend/src/app/core/services/profile.service.ts
+++ b/web/frontend/src/app/core/services/profile.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import type { UserProfile, ProfileResponse } from '../models/profile.model';
+
+@Injectable({ providedIn: 'root' })
+export class ProfileService {
+  private readonly http = inject(HttpClient);
+
+  getMyProfile(): Observable<UserProfile> {
+    return this.http
+      .get<ProfileResponse>(`${environment.apiUrl}/api/profile/me`)
+      .pipe(map(res => res.profile));
+  }
+}

--- a/web/frontend/src/app/core/utils/index.ts
+++ b/web/frontend/src/app/core/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './profile.utils';

--- a/web/frontend/src/app/core/utils/profile.utils.ts
+++ b/web/frontend/src/app/core/utils/profile.utils.ts
@@ -1,0 +1,23 @@
+import { getBackgroundColor, getBackgroundById } from '../data';
+
+export const MAX_BADGE_SLOTS = 6;
+
+export function getBadgeSlots(equippedBadges: string[] = []): (string | null)[] {
+  return Array.from({ length: MAX_BADGE_SLOTS }, (_, i) => equippedBadges[i] ?? null);
+}
+
+export function getBackgroundName(backgroundId: string): string {
+  return getBackgroundById(backgroundId)?.name ?? 'Défaut';
+}
+
+export function getBackgroundStyle(backgroundId: string): Record<string, string> {
+  return { 'background-color': getBackgroundColor(backgroundId) };
+}
+
+export function formatDateFr(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('fr-FR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}

--- a/web/frontend/src/app/features/profile/profile.component.html
+++ b/web/frontend/src/app/features/profile/profile.component.html
@@ -1,3 +1,130 @@
-<div class="container">
-  <h2>Profil — à venir</h2>
-</div>
+<main class="profile-page">
+
+  @if (isLoading()) {
+    <div class="profile-page__loading">
+      <app-spinner size="lg" label="Chargement du profil…" />
+    </div>
+  } @else if (hasError()) {
+    <div class="profile-page__error">
+      <span class="error-icon" aria-hidden="true">⚠️</span>
+      <p>Impossible de charger le profil.</p>
+      <button class="btn btn-primary btn--sm" (click)="load()">Réessayer</button>
+    </div>
+  } @else if (profile(); as p) {
+
+    <!-- Profile card -->
+    <section class="profile-card-section container">
+      <div class="profile-card" [style.background-color]="backgroundColor()">
+        <div class="profile-card__overlay"></div>
+        <div class="profile-card__border"></div>
+
+        <!-- Avatar -->
+        <div class="profile-card__avatar-wrap">
+          <app-avatar
+            [src]="auth.userAvatar()"
+            [alt]="p.username"
+            size="lg"
+          />
+        </div>
+
+        <!-- Info -->
+        <div class="profile-card__info">
+          <h1 class="profile-card__username">{{ p.username }}</h1>
+          <div class="profile-card__sep" aria-hidden="true"></div>
+
+          <!-- Badges -->
+          <div class="profile-card__badges">
+            <span class="profile-card__badges-label">Badges</span>
+            <div class="profile-card__badges-grid">
+              @for (badge of badgeSlots(); track $index) {
+                <div class="badge-slot" [class.badge-slot--empty]="!badge" [title]="badge ?? 'Vide'">
+                  @if (badge) {
+                    <span class="badge-slot__emoji" aria-label="Badge {{ badge }}">{{ getBadgeEmoji(badge) }}</span>
+                  }
+                </div>
+              }
+            </div>
+          </div>
+
+          <!-- Stats inline -->
+          <div class="profile-card__stats">
+            <span>
+              <span class="stat-label">Background :</span>
+              <span class="stat-value">{{ backgroundName() }}</span>
+            </span>
+            <span>
+              <span class="stat-label">Badges :</span>
+              <span class="stat-value">{{ p.equipped_badges.length }}/6</span>
+            </span>
+          </div>
+        </div>
+
+        <!-- Coins -->
+        <div class="profile-card__coins" [attr.aria-label]="p.coins + ' MazCoins'">
+          <span aria-hidden="true">💰</span>
+          <span class="profile-card__coins-value">{{ p.coins }}</span>
+          <span class="profile-card__coins-unit">MC</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Detail cards -->
+    <section class="profile-details container">
+      <div class="details-grid">
+
+        <div class="detail-card">
+          <span class="detail-card__icon" aria-hidden="true">🏙️</span>
+          <div>
+            <p class="detail-card__label">Ville actuelle</p>
+            <p class="detail-card__value">{{ p.current_city_name }}</p>
+          </div>
+        </div>
+
+        <div class="detail-card">
+          <span class="detail-card__icon" aria-hidden="true">📅</span>
+          <div>
+            <p class="detail-card__label">Membre depuis</p>
+            <p class="detail-card__value">{{ memberSince() }}</p>
+          </div>
+        </div>
+
+        <div class="detail-card">
+          <span class="detail-card__icon" aria-hidden="true">🗺️</span>
+          <div>
+            <p class="detail-card__label">Villes visitées</p>
+            <p class="detail-card__value">{{ p.visited_cities_count }}</p>
+          </div>
+        </div>
+
+        <div class="detail-card">
+          <span class="detail-card__icon" aria-hidden="true">🎒</span>
+          <div>
+            <p class="detail-card__label">Inventaire</p>
+            <p class="detail-card__value">{{ p.inventory_count }} objets</p>
+          </div>
+        </div>
+
+        @if (p.traveling_to) {
+          <div class="detail-card detail-card--accent">
+            <span class="detail-card__icon" aria-hidden="true">✈️</span>
+            <div>
+              <p class="detail-card__label">En voyage vers</p>
+              <p class="detail-card__value">{{ p.traveling_to }}</p>
+            </div>
+          </div>
+        }
+
+      </div>
+    </section>
+
+    <!-- Quick actions -->
+    <nav class="profile-actions container" aria-label="Actions rapides">
+      <a routerLink="/map"         class="action-btn"><span aria-hidden="true">🗺️</span> Carte</a>
+      <a routerLink="/shop"        class="action-btn"><span aria-hidden="true">🛒</span> Boutique</a>
+      <a routerLink="/leaderboard" class="action-btn"><span aria-hidden="true">🏆</span> Classement</a>
+      <a routerLink="/dashboard"   class="action-btn"><span aria-hidden="true">🏠</span> Dashboard</a>
+    </nav>
+
+  }
+
+</main>

--- a/web/frontend/src/app/features/profile/profile.component.scss
+++ b/web/frontend/src/app/features/profile/profile.component.scss
@@ -1,0 +1,284 @@
+.profile-page {
+  min-height: calc(100vh - 68px);
+  padding: var(--spacing-xl) 0;
+
+  &__loading,
+  &__error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 50vh;
+    gap: var(--spacing-md);
+    color: var(--color-text-dim);
+  }
+
+  &__error {
+    .error-icon { font-size: 2.5rem; }
+
+    p {
+      color: var(--color-text-dim);
+      margin: 0;
+    }
+  }
+}
+
+/* ===== PROFILE CARD ===== */
+.profile-card-section {
+  margin-bottom: var(--spacing-xl);
+}
+
+.profile-card {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 2.5 / 1;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  padding: 2rem 2.5rem;
+  gap: 2rem;
+
+  @media (max-width: 768px) {
+    aspect-ratio: auto;
+    flex-direction: column;
+    align-items: center;
+    padding: 1.5rem;
+    text-align: center;
+  }
+
+  &__overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0.55) 100%);
+    z-index: 1;
+  }
+
+  &__border {
+    position: absolute;
+    inset: 10px;
+    border: 2px solid rgba(255, 255, 255, 0.7);
+    border-radius: calc(var(--radius-lg) - 4px);
+    z-index: 2;
+    pointer-events: none;
+  }
+
+  &__avatar-wrap {
+    position: relative;
+    z-index: 3;
+    flex-shrink: 0;
+
+    app-avatar {
+      --avatar-size: 140px;
+
+      @media (max-width: 768px) {
+        --avatar-size: 110px;
+      }
+    }
+  }
+
+  &__info {
+    position: relative;
+    z-index: 3;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  &__username {
+    font-family: var(--font-heading);
+    font-size: 2.4rem;
+    font-weight: 700;
+    color: #fff;
+    margin: 0;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+
+    @media (max-width: 768px) {
+      font-size: 1.8rem;
+    }
+  }
+
+  &__sep {
+    width: min(100%, 360px);
+    height: 2px;
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 1px;
+
+    @media (max-width: 768px) {
+      margin: 0 auto;
+    }
+  }
+
+  &__badges {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  &__badges-label {
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.65);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  &__badges-grid {
+    display: flex;
+    gap: 0.5rem;
+
+    @media (max-width: 768px) {
+      justify-content: center;
+    }
+  }
+
+  &__stats {
+    display: flex;
+    gap: 1.5rem;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.6);
+    margin-top: auto;
+
+    @media (max-width: 768px) {
+      flex-direction: column;
+      gap: 0.25rem;
+      align-items: center;
+    }
+
+    .stat-label { margin-right: 0.3rem; }
+    .stat-value { color: #fff; font-weight: 500; }
+  }
+
+  &__coins {
+    position: absolute;
+    bottom: 24px;
+    right: 24px;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(0, 0, 0, 0.55);
+    border: 2px solid rgba(255, 215, 0, 0.75);
+    border-radius: var(--radius-md);
+    padding: 0.6rem 1rem;
+
+    @media (max-width: 768px) {
+      position: static;
+      margin-top: 0.5rem;
+    }
+  }
+
+  &__coins-value {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: #ffd700;
+    font-family: var(--font-heading);
+  }
+
+  &__coins-unit {
+    font-size: 0.8rem;
+    color: rgba(255, 215, 0, 0.75);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+  }
+}
+
+/* ===== BADGE SLOTS ===== */
+.badge-slot {
+  width: 48px;
+  height: 48px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color var(--transition-fast);
+
+  &--empty { opacity: 0.45; }
+
+  &:not(.badge-slot--empty):hover {
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+
+  &__emoji { font-size: 1.6rem; }
+}
+
+/* ===== DETAIL CARDS ===== */
+.profile-details {
+  margin-bottom: var(--spacing-xl);
+}
+
+.details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: var(--spacing-md);
+}
+
+.detail-card {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  background: var(--color-surface);
+  border: 1px solid rgba(255, 107, 53, 0.1);
+  border-radius: var(--radius-md);
+  padding: 1.1rem 1.25rem;
+  transition: transform var(--transition-fast), border-color var(--transition-fast);
+
+  &:hover {
+    transform: translateY(-2px);
+    border-color: rgba(255, 107, 53, 0.25);
+  }
+
+  &--accent {
+    border-color: rgba(255, 107, 53, 0.3);
+    background: rgba(255, 107, 53, 0.05);
+  }
+
+  &__icon { font-size: 1.75rem; }
+
+  &__label {
+    margin: 0;
+    font-size: 0.78rem;
+    color: var(--color-text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  &__value {
+    margin: 0.2rem 0 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+}
+
+/* ===== QUICK ACTIONS ===== */
+.profile-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.action-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1.25rem;
+  background: var(--color-surface);
+  border: 1px solid rgba(255, 107, 53, 0.15);
+  border-radius: var(--radius-md);
+  color: var(--color-text-dim);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    background: rgba(255, 107, 53, 0.08);
+    border-color: rgba(255, 107, 53, 0.3);
+    color: var(--color-text);
+    transform: translateY(-2px);
+  }
+}

--- a/web/frontend/src/app/features/profile/profile.component.ts
+++ b/web/frontend/src/app/features/profile/profile.component.ts
@@ -1,9 +1,60 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, inject, ChangeDetectionStrategy, computed, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { AuthService } from '../../core/services/auth.service';
+import { ProfileService } from '../../core/services/profile.service';
+import type { UserProfile } from '../../core/models/profile.model';
+import { SpinnerComponent } from '../../shared/components/ui/spinner/spinner.component';
+import { AvatarComponent } from '../../shared/components/ui/avatar/avatar.component';
+import { getBadgeSlots, getBackgroundName, formatDateFr } from '../../core/utils/profile.utils';
+import { getBackgroundColor, getBadgeEmoji } from '../../core/data';
 
 @Component({
   selector: 'app-profile',
   standalone: true,
+  imports: [RouterLink, SpinnerComponent, AvatarComponent],
   templateUrl: './profile.component.html',
+  styleUrl: './profile.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ProfileComponent {}
+export class ProfileComponent implements OnInit {
+  protected readonly auth = inject(AuthService);
+  private readonly profileService = inject(ProfileService);
+
+  readonly profile = signal<UserProfile | null>(null);
+  readonly isLoading = signal(true);
+  readonly hasError = signal(false);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading.set(true);
+    this.hasError.set(false);
+    this.profileService.getMyProfile().subscribe({
+      next: p => { this.profile.set(p); this.isLoading.set(false); },
+      error: () => { this.hasError.set(true); this.isLoading.set(false); },
+    });
+  }
+
+  readonly backgroundColor = computed(() => {
+    const p = this.profile();
+    return p ? getBackgroundColor(p.equipped_background) : '#2f3136';
+  });
+
+  readonly backgroundName = computed(() => {
+    const p = this.profile();
+    return p ? getBackgroundName(p.equipped_background) : 'Défaut';
+  });
+
+  readonly memberSince = computed(() => {
+    const p = this.profile();
+    return p ? formatDateFr(p.created_at) : '';
+  });
+
+  readonly badgeSlots = computed(() =>
+    getBadgeSlots(this.profile()?.equipped_badges),
+  );
+
+  readonly getBadgeEmoji = getBadgeEmoji;
+}


### PR DESCRIPTION
## Summary

- Page profil Angular avec carte personnalisée (background, badges), coins, ville, date d'inscription et actions rapides
- Core module : `data/` (badges, backgrounds), `models/profile.model`, `utils/profile.utils`, `services/profile.service`, barrels
- Fixtures backend : 6 villes + jobs + routes pour le flow d'inscription Discord
- Correction flux auth JWT : proxy HTTPS, intercepteur `verifyToken`, script dev

## Changements

### Frontend
- `features/profile/` — composant complet (signals + OnPush, Angular 17+ control flow, SCSS BEM)
- `core/data/` — badges.json, backgrounds.json, types et helpers
- `core/models/profile.model.ts` — `UserProfile`, `ProfileResponse`, `BadgeId`, `BackgroundId`
- `core/utils/profile.utils.ts` — slots badges, nom background, formatage date FR
- `core/services/profile.service.ts` — `getMyProfile()`
- `proxy.conf.json` — cible `https://localhost:8008` (Symfony CLI HTTPS par défaut)
- `jwt.interceptor.ts` — retrait de `/api/auth/verify` des `PUBLIC_URLS`

### Backend
- `AppFixtures.php` — 6 villes (Willowbrook, Ironhaven, Crystalport, Shadowpeak, Goldenfields, NeonHub) + 3 jobs/ville + 16 routes

### Root
- `package.json` — `concurrently` Back+Front+Bot + suppression `--no-tls`

## Test plan

- [ ] Connexion Discord → redirect `/dashboard`
- [ ] Navigation `/profile` → carte profil avec pseudo, avatar, badges, coins, ville, date
- [ ] Rechargement page → utilisateur reste connecté