### PR TITLE
fix(bot+dev): correct TypeScript flags type and npm dev command

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -54,11 +54,11 @@ const initializeBot = async () => {
         await command.execute(interaction);
       } catch (error: any) {
         console.error(`Erreur lors de /${interaction.commandName} :`, error);
-        const reply = { content: "❌ Une erreur est survenue lors de l'exécution de cette commande.", flags: MessageFlags.Ephemeral };
+        const errorMsg = "❌ Une erreur est survenue lors de l'exécution de cette commande.";
         if (interaction.replied || interaction.deferred) {
-          await interaction.editReply(reply);
+          await interaction.editReply({ content: errorMsg });
         } else {
-          await interaction.reply(reply);
+          await interaction.reply({ content: errorMsg, flags: MessageFlags.Ephemeral });
         }
       }
     } else if (interaction.isButton() || interaction.isStringSelectMenu()) {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "scripts": {
     "install:all": "cd web/frontend && npm i && cd ../../bot && npm i",
-    "dev": "concurrently --kill-others --kill-others-on-fail -c red,blue,green --names Back,Front,Bot \"npm run dev:back\" \"npm run dev:front\" \"npm run dev:bot\"",
+    "dev": "concurrently --kill-others-on-fail -c red,blue,green --names Back,Front,Bot \"npm run dev:back\" \"npm run dev:front\" \"npm run dev:bot\"",
     "dev:front": "cd web/frontend && npm run start",
-    "dev:back": "cd web/backend && symfony server:start -p 8008",
+    "dev:back": "cd web/backend && symfony server:start --port=8008 --no-tls",
     "dev:bot": "cd bot && npm run dev"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Fix editReply/reply error handling in bot: Ephemeral flag cannot be passed to editReply (TypeScript type mismatch)
- Fix symfony server:start flag: -p 8008 to --port=8008 --no-tls
- Switch concurrently from --kill-others to --kill-others-on-fail so a clean backend exit does not kill frontend/bot

## Test plan

- [ ] npm run dev starts all 3 services without error
- [ ] Bot compiles and connects to Discord
- [ ] Frontend serves on http://localhost:4200
- [ ] Backend serves on http://127.0.0.1:8008