### PR TITLE
feat(auth): sessions persistantes via localStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Root dependencies (concurrently)
+node_modules/
+package-lock.json
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# OS files
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "install:all": "cd web/frontend && npm i && cd ../../bot && npm i",
     "dev": "concurrently --kill-others-on-fail -c red,blue,green --names Back,Front,Bot \"npm run dev:back\" \"npm run dev:front\" \"npm run dev:bot\"",
     "dev:front": "cd web/frontend && npm run start",
-    "dev:back": "cd web/backend && symfony server:start --port=8008 --no-tls",
+    "dev:back": "cd web/backend && symfony server:start --port=8008",
     "dev:bot": "cd bot && npm run dev"
   },
   "devDependencies": {

--- a/web/frontend/src/app/core/services/auth-storage.service.ts
+++ b/web/frontend/src/app/core/services/auth-storage.service.ts
@@ -12,44 +12,60 @@ const REDIRECT_URL_KEY = 'mw_redirect_url';
 export class AuthStorageService {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-  private get<T = string>(key: string): T | null {
+  private local<T = string>(key: string): T | null {
+    if (!this.isBrowser) return null;
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    try { return JSON.parse(raw) as T; } catch { return raw as unknown as T; }
+  }
+
+  private setLocal(key: string, value: unknown): void {
+    if (!this.isBrowser) return;
+    localStorage.setItem(key, typeof value === 'string' ? value : JSON.stringify(value));
+  }
+
+  private removeLocal(key: string): void {
+    if (this.isBrowser) localStorage.removeItem(key);
+  }
+
+  private session<T = string>(key: string): T | null {
     if (!this.isBrowser) return null;
     const raw = sessionStorage.getItem(key);
     if (!raw) return null;
     try { return JSON.parse(raw) as T; } catch { return raw as unknown as T; }
   }
 
-  private set(key: string, value: unknown): void {
+  private setSession(key: string, value: unknown): void {
     if (!this.isBrowser) return;
     sessionStorage.setItem(key, typeof value === 'string' ? value : JSON.stringify(value));
   }
 
-  private remove(key: string): void {
+  private removeSession(key: string): void {
     if (this.isBrowser) sessionStorage.removeItem(key);
   }
 
-  getToken(): string | null { return this.get(TOKEN_KEY); }
-  saveToken(token: string): void { this.set(TOKEN_KEY, token); }
-  clearToken(): void { this.remove(TOKEN_KEY); }
+  getToken(): string | null { return this.local(TOKEN_KEY); }
+  saveToken(token: string): void { this.setLocal(TOKEN_KEY, token); }
+  clearToken(): void { this.removeLocal(TOKEN_KEY); }
 
-  getUser(): User | null { return this.get<User>(USER_KEY); }
-  saveUser(user: User): void { this.set(USER_KEY, user); }
-  clearUser(): void { this.remove(USER_KEY); }
+  getUser(): User | null { return this.local<User>(USER_KEY); }
+  saveUser(user: User): void { this.setLocal(USER_KEY, user); }
+  clearUser(): void { this.removeLocal(USER_KEY); }
 
-  getState(): string | null { return this.get(STATE_KEY); }
-  saveState(state: string): void { this.set(STATE_KEY, state); }
-  clearState(): void { this.remove(STATE_KEY); }
+  getState(): string | null { return this.session(STATE_KEY); }
+  saveState(state: string): void { this.setSession(STATE_KEY, state); }
+  clearState(): void { this.removeSession(STATE_KEY); }
 
-  getProcessedCode(): string | null { return this.get(PROCESSED_CODE_KEY); }
-  saveProcessedCode(code: string): void { this.set(PROCESSED_CODE_KEY, code); }
-  clearProcessedCode(): void { this.remove(PROCESSED_CODE_KEY); }
+  getProcessedCode(): string | null { return this.session(PROCESSED_CODE_KEY); }
+  saveProcessedCode(code: string): void { this.setSession(PROCESSED_CODE_KEY, code); }
+  clearProcessedCode(): void { this.removeSession(PROCESSED_CODE_KEY); }
 
-  getRedirectUrl(): string | null { return this.get(REDIRECT_URL_KEY); }
-  saveRedirectUrl(url: string): void { this.set(REDIRECT_URL_KEY, url); }
-  clearRedirectUrl(): void { this.remove(REDIRECT_URL_KEY); }
+  getRedirectUrl(): string | null { return this.session(REDIRECT_URL_KEY); }
+  saveRedirectUrl(url: string): void { this.setSession(REDIRECT_URL_KEY, url); }
+  clearRedirectUrl(): void { this.removeSession(REDIRECT_URL_KEY); }
 
   clearAll(): void {
-    [TOKEN_KEY, USER_KEY, STATE_KEY, PROCESSED_CODE_KEY, REDIRECT_URL_KEY]
-      .forEach(k => this.remove(k));
+    [TOKEN_KEY, USER_KEY].forEach(k => this.removeLocal(k));
+    [STATE_KEY, PROCESSED_CODE_KEY, REDIRECT_URL_KEY].forEach(k => this.removeSession(k));
   }
 }


### PR DESCRIPTION
## Résumé

- `mw_token` et `mw_user` passent de `sessionStorage` à `localStorage` — session persistante entre fermetures de navigateur (JWT TTL 7 jours)
- OAuth state et processed code restent en `sessionStorage` (éphémère)
- Intercepteur JWT simplifié : suppression du clearAll agressif sur chaque 401
- Proxy Angular corrigé : target `https://localhost:8008`
- Script `dev:back` : retrait de `--no-tls`
- `.gitignore` racine ajouté

## Test plan

- [ ] Connexion Discord -> token visible dans localStorage
- [ ] Fermeture et réouverture onglet -> session restaurée
- [ ] Déconnexion -> localStorage vidé
- [ ] Un 401 API ne déconnecte pas

Closes #45