### PR TITLE
feat(map): affichage carte interactive & interactions villes — Feature #57 & #58

### DIFF
--- a/web/frontend/src/app/core/models/index.ts
+++ b/web/frontend/src/app/core/models/index.ts
@@ -1,2 +1,3 @@
 export * from './user.model';
 export * from './profile.model';
+export * from './travel.model';

--- a/web/frontend/src/app/core/models/travel.model.ts
+++ b/web/frontend/src/app/core/models/travel.model.ts
@@ -1,0 +1,77 @@
+export interface City {
+  city_id: string;
+  name: string;
+  description?: string;
+  emoji?: string;
+  theme?: string;
+  position_x: number;
+  position_y: number;
+}
+
+export interface RouteData {
+  route_id: number;
+  city_from: string;
+  city_to: string;
+  from_name: string;
+  from_emoji: string;
+  to_name: string;
+  to_emoji: string;
+  cost: number;
+  duration: number;
+}
+
+export interface TravelRoute {
+  route_id: number;
+  city_to: string;
+  destination_name: string;
+  destination_emoji: string;
+  cost: number;
+  duration: number;
+  visited: boolean;
+  effective_cost: number;
+}
+
+export interface CityJob {
+  job_id: number;
+  job_name: string;
+  job_emoji: string;
+  task_1: string;
+  task_2: string;
+  task_3: string;
+}
+
+export interface TravelMapData {
+  current_city: {
+    city_id: string;
+    name: string;
+    description: string;
+    emoji: string;
+    theme: string;
+  };
+  coins: number;
+  routes: TravelRoute[];
+  jobs: CityJob[];
+}
+
+export interface TravelStatus {
+  traveling: boolean;
+  destination?: string;
+  destination_name?: string;
+  destination_emoji?: string;
+  arrival_time?: number;
+}
+
+export interface TravelStartResult {
+  success: boolean;
+  message: string;
+  arrival_time?: number;
+  travel_cost?: number;
+  coins?: number;
+}
+
+export interface VisualRoute {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}

--- a/web/frontend/src/app/core/services/index.ts
+++ b/web/frontend/src/app/core/services/index.ts
@@ -1,3 +1,4 @@
 export * from './auth.service';
 export * from './auth-storage.service';
 export * from './profile.service';
+export * from './travel.service';

--- a/web/frontend/src/app/core/services/travel.service.ts
+++ b/web/frontend/src/app/core/services/travel.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import type { City, RouteData, TravelMapData, TravelStatus, TravelStartResult } from '../models/travel.model';
+
+@Injectable({ providedIn: 'root' })
+export class TravelService {
+  private readonly http = inject(HttpClient);
+  private readonly base = environment.apiUrl;
+
+  getAllCities(): Observable<City[]> {
+    return this.http.get<City[]>(`${this.base}/api/cities`);
+  }
+
+  getAllRoutes(): Observable<RouteData[]> {
+    return this.http.get<RouteData[]>(`${this.base}/api/routes`);
+  }
+
+  getMap(): Observable<TravelMapData> {
+    return this.http.get<TravelMapData>(`${this.base}/api/travel/map`);
+  }
+
+  getStatus(): Observable<TravelStatus> {
+    return this.http.get<TravelStatus>(`${this.base}/api/travel/status`);
+  }
+
+  startTravel(destinationId: string): Observable<TravelStartResult> {
+    return this.http.post<TravelStartResult>(`${this.base}/api/travel/start`, { destination_id: destinationId });
+  }
+}

--- a/web/frontend/src/app/features/map/map.component.html
+++ b/web/frontend/src/app/features/map/map.component.html
@@ -1,3 +1,204 @@
-<div class="container">
-  <h2>Carte — à venir</h2>
+<div class="map-page">
+
+  <!-- Loading -->
+  @if (isLoading()) {
+    <div class="map-state">
+      <div class="loading"></div>
+      <p>Chargement de la carte…</p>
+    </div>
+  }
+
+  <!-- Error -->
+  @else if (hasError()) {
+    <div class="map-state map-state--error">
+      <span>⚠️</span>
+      <p>Impossible de charger la carte.</p>
+      <button class="btn btn-primary" (click)="load()">Réessayer</button>
+    </div>
+  }
+
+  @else {
+    <!-- Header -->
+    <section class="map-header">
+      <div class="container">
+        <span class="section-label">MAP</span>
+        <h1>Carte du monde</h1>
+        <p class="subtitle">6 villes interconnectées vous attendent</p>
+      </div>
+    </section>
+
+    <!-- Bannière voyage en cours -->
+    @if (isTraveling()) {
+      <div class="travel-banner container">
+        <div class="travel-banner__inner">
+          <span class="travel-banner__icon">🚂</span>
+          <div class="travel-banner__text">
+            <span>En route vers {{ travelingToEmoji() }} <strong>{{ travelingToName() }}</strong></span>
+            <span class="travel-banner__countdown">Arrivée dans {{ formatCountdown(remainingSeconds()) }}</span>
+          </div>
+          <div class="travel-banner__coins">
+            <span>💰</span>
+            <span>{{ coins() }} MC</span>
+          </div>
+        </div>
+      </div>
+    } @else {
+      <div class="coins-bar container">
+        <span>💰 {{ coins() }} MazCoins</span>
+      </div>
+    }
+
+    <!-- Carte interactive -->
+    <section class="map-container container">
+      <div class="map-viewport">
+
+        <!-- Fond thématique dynamique -->
+        <div class="map-background">
+          @for (city of cities(); track city.city_id) {
+            <div class="bg-zone"
+              [style.left.%]="getCityPosition(city).x"
+              [style.top.%]="getCityPosition(city).y"
+              [style.background]="'radial-gradient(circle, ' + getThemeColor(city.theme) + ', transparent)'">
+            </div>
+          }
+        </div>
+
+        <!-- SVG routes -->
+        <svg class="map-svg" viewBox="0 0 1000 600" preserveAspectRatio="none">
+          <defs>
+            <linearGradient id="routeGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" style="stop-color:rgba(255,107,53,0.7)" />
+              <stop offset="100%" style="stop-color:rgba(247,147,30,0.7)" />
+            </linearGradient>
+          </defs>
+          @for (r of visualRoutes(); track $index) {
+            <line
+              [attr.x1]="r.x1" [attr.y1]="r.y1"
+              [attr.x2]="r.x2" [attr.y2]="r.y2"
+              stroke="url(#routeGrad)"
+              stroke-width="3"
+              stroke-linecap="round"
+              stroke-dasharray="16,8"
+              class="route-line" />
+          }
+        </svg>
+
+        <!-- Villes -->
+        <div class="cities">
+          @for (city of cities(); track city.city_id) {
+            <div
+              class="city"
+              [class.city--current]="isCurrentCity(city.city_id)"
+              [class.city--destination]="isDestination(city.city_id)"
+              [class.city--reachable]="getRouteToCity(city.city_id) !== null && !isCurrentCity(city.city_id)"
+              [class.city--selected]="selectedCity()?.city_id === city.city_id"
+              [class.city--near-bottom]="getCityPosition(city).y > 75"
+              [style.left.%]="getCityPosition(city).x"
+              [style.top.%]="getCityPosition(city).y"
+              (click)="selectCity(city)">
+
+              <div class="city-pulse"></div>
+
+              <div class="city-icon">
+                <span class="city-emoji">{{ city.emoji }}</span>
+              </div>
+
+              @if (isCurrentCity(city.city_id)) {
+                <span class="city-badge city-badge--here">Ici</span>
+              } @else if (isDestination(city.city_id)) {
+                <span class="city-badge city-badge--dest">→</span>
+              }
+
+              <div class="city-info">
+                <span class="city-name">{{ city.name }}</span>
+                <span class="city-theme">{{ city.theme }}</span>
+              </div>
+            </div>
+          }
+        </div>
+
+      </div>
+    </section>
+
+    <!-- Panneau de détails -->
+    <aside class="details-panel" [class.open]="selectedCity()">
+      @if (selectedCity(); as city) {
+        <div class="panel-content">
+          <button class="close-btn" (click)="closePanel()">✕</button>
+
+          <div class="panel-header">
+            <span class="panel-emoji">{{ city.emoji }}</span>
+            <div>
+              <h2>{{ city.name }}</h2>
+              <span class="panel-theme">{{ city.theme }}</span>
+              @if (isCurrentCity(city.city_id)) {
+                <span class="panel-badge panel-badge--here">📍 Vous êtes ici</span>
+              }
+            </div>
+          </div>
+
+          <p class="panel-description">{{ city.description }}</p>
+
+          <!-- Jobs (seulement si ville actuelle) -->
+          @if (isCurrentCity(city.city_id) && getCurrentCityJobs().length > 0) {
+            <div class="panel-section">
+              <h3>💼 Jobs disponibles</h3>
+              <div class="jobs-list">
+                @for (job of getCurrentCityJobs(); track job.job_id) {
+                  <div class="job-item">
+                    <span class="job-emoji">{{ job.job_emoji }}</span>
+                    <span class="job-name">{{ job.job_name }}</span>
+                  </div>
+                }
+              </div>
+            </div>
+          }
+
+          <!-- Routes depuis cette ville -->
+          @if (!isCurrentCity(city.city_id)) {
+            @if (getRouteToCity(city.city_id); as route) {
+              <div class="panel-section">
+                <h3>🛣️ Trajet depuis votre position</h3>
+                <div class="route-detail">
+                  <div class="route-detail__row">
+                    <span class="route-detail__label">Durée</span>
+                    <span class="route-detail__value">{{ formatDuration(route.duration) }}</span>
+                  </div>
+                  <div class="route-detail__row">
+                    <span class="route-detail__label">Coût</span>
+                    @if (route.visited) {
+                      <span class="route-detail__value route-detail__value--free">Gratuit <span class="tag-visited">déjà visitée</span></span>
+                    } @else {
+                      <span class="route-detail__value">{{ route.cost }} MC</span>
+                    }
+                  </div>
+                </div>
+
+                <button
+                  class="btn-travel"
+                  [disabled]="isTraveling() || !canAffordTravel(city.city_id)"
+                  (click)="startTravel(city.city_id)">
+                  @if (isTraveling()) {
+                    🚂 En voyage…
+                  } @else if (!canAffordTravel(city.city_id)) {
+                    ❌ Fonds insuffisants
+                  } @else if (route.visited) {
+                    🎒 Partir vers {{ city.name }} (Gratuit)
+                  } @else {
+                    🚂 Partir vers {{ city.name }} ({{ route.cost }} MC)
+                  }
+                </button>
+              </div>
+            } @else {
+              <div class="panel-section">
+                <p class="panel-unreachable">⛔ Pas de route directe depuis votre ville actuelle.</p>
+              </div>
+            }
+          }
+
+        </div>
+      }
+    </aside>
+  }
+
 </div>

--- a/web/frontend/src/app/features/map/map.component.scss
+++ b/web/frontend/src/app/features/map/map.component.scss
@@ -1,0 +1,564 @@
+.map-page {
+  min-height: calc(100vh - 68px);
+  color: var(--color-text);
+}
+
+/* ===== ÉTATS ===== */
+.map-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: var(--spacing-md);
+  color: var(--color-text-dim);
+
+  &--error span { font-size: 2.5rem; }
+  p { margin: 0; }
+}
+
+/* ===== HEADER ===== */
+.map-header {
+  padding: var(--spacing-xl) var(--spacing-lg);
+  text-align: center;
+
+  .section-label {
+    display: block;
+    font-family: var(--font-heading);
+    font-size: 4rem;
+    color: rgba(255, 107, 53, 0.15);
+    line-height: 1;
+    margin-bottom: 0.5rem;
+  }
+
+  h1 {
+    font-size: clamp(2rem, 5vw, 3.5rem);
+    margin: 0 0 0.75rem;
+  }
+
+  .subtitle {
+    font-size: 1.05rem;
+    color: var(--color-text-dim);
+    margin: 0;
+  }
+}
+
+/* ===== COINS & BANNIÈRE VOYAGE ===== */
+.coins-bar {
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: var(--spacing-sm);
+  font-size: 0.95rem;
+  color: var(--color-text-dim);
+  font-weight: 500;
+}
+
+.travel-banner {
+  margin-bottom: var(--spacing-sm);
+
+  &__inner {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    background: rgba(255, 107, 53, 0.08);
+    border: 1px solid rgba(255, 107, 53, 0.3);
+    border-radius: var(--radius-md);
+    padding: 1rem 1.5rem;
+  }
+
+  &__icon { font-size: 1.75rem; }
+
+  &__text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.95rem;
+
+    strong { color: var(--color-text); }
+  }
+
+  &__countdown {
+    font-family: var(--font-heading);
+    font-size: 1.4rem;
+    color: var(--color-accent);
+    letter-spacing: 0.05em;
+  }
+
+  &__coins {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.9rem;
+    color: var(--color-text-dim);
+    white-space: nowrap;
+  }
+}
+
+/* ===== CARTE ===== */
+.map-container {
+  padding-bottom: var(--spacing-xl);
+}
+
+.map-viewport {
+  position: relative;
+  width: 100%;
+  height: 70vh;
+  min-height: 520px;
+  background: linear-gradient(135deg, #0a0a15 0%, #15151f 50%, #0a0a15 100%);
+  border: 1px solid rgba(255, 107, 53, 0.2);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+/* Fond thématique */
+.map-background {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.bg-zone {
+  position: absolute;
+  width: 280px;
+  height: 280px;
+  border-radius: 50%;
+  filter: blur(70px);
+  opacity: 0.25;
+  transform: translate(-50%, -50%);
+  animation: zoneFloat 8s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@for $i from 1 through 6 {
+  .bg-zone:nth-child(#{$i}) { animation-delay: #{($i - 1) * 1.3}s; }
+}
+
+@keyframes zoneFloat {
+  0%, 100% { transform: translate(-50%, -50%) scale(1); }
+  50%       { transform: translate(-50%, -50%) scale(1.15); }
+}
+
+/* SVG routes */
+.map-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.route-line {
+  animation: routeDash 4s linear infinite;
+  opacity: 0.8;
+}
+
+@keyframes routeDash {
+  to { stroke-dashoffset: -24; }
+}
+
+/* ===== VILLES ===== */
+.cities {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+}
+
+.city {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  transition: all var(--transition-normal);
+
+  &:hover {
+    z-index: 10;
+
+    .city-pulse { opacity: 1; transform: translate(-50%, -50%) scale(1.5); }
+    .city-icon  { transform: scale(1.15); }
+    .city-info  { opacity: 1; transform: translate(-50%, 0); }
+  }
+
+  &--selected {
+    z-index: 11;
+
+    .city-icon {
+      border-color: var(--color-accent);
+      background: linear-gradient(135deg, rgba(255, 107, 53, 0.25), rgba(247, 147, 30, 0.15));
+      box-shadow: 0 0 28px rgba(255, 107, 53, 0.55);
+    }
+    .city-pulse { opacity: 1; animation: pulseGlow 2s ease-in-out infinite; }
+  }
+
+  &--current {
+    .city-icon {
+      border-color: #4caf50;
+      box-shadow: 0 0 22px rgba(76, 175, 80, 0.5);
+    }
+    .city-pulse { border-color: rgba(76, 175, 80, 0.5); }
+  }
+
+  &--destination {
+    .city-icon {
+      border-color: var(--color-accent-2);
+      box-shadow: 0 0 22px rgba(247, 147, 30, 0.5);
+      animation: destinationPulse 1.5s ease-in-out infinite;
+    }
+  }
+
+  &--reachable {
+    .city-icon { border-color: rgba(255, 107, 53, 0.5); }
+  }
+}
+
+.city-pulse {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 80px;
+  height: 80px;
+  transform: translate(-50%, -50%);
+  border: 2px solid rgba(255, 107, 53, 0.4);
+  border-radius: 50%;
+  opacity: 0;
+  transition: all var(--transition-normal);
+  pointer-events: none;
+}
+
+@keyframes pulseGlow {
+  0%, 100% { transform: translate(-50%, -50%) scale(1);   opacity: 0.6; }
+  50%       { transform: translate(-50%, -50%) scale(1.3); opacity: 0.25; }
+}
+
+@keyframes destinationPulse {
+  0%, 100% { box-shadow: 0 0 22px rgba(247, 147, 30, 0.5); }
+  50%       { box-shadow: 0 0 40px rgba(247, 147, 30, 0.8); }
+}
+
+.city-icon {
+  position: relative;
+  width: 60px;
+  height: 60px;
+  background: rgba(20, 20, 30, 0.9);
+  border: 2px solid rgba(255, 107, 53, 0.25);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-normal);
+  backdrop-filter: blur(8px);
+}
+
+.city-emoji {
+  font-size: 1.75rem;
+  filter: drop-shadow(0 0 6px rgba(255, 107, 53, 0.4));
+}
+
+.city-badge {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+
+  &--here {
+    background: rgba(76, 175, 80, 0.9);
+    color: #fff;
+  }
+
+  &--dest {
+    background: rgba(255, 152, 0, 0.9);
+    color: #fff;
+  }
+}
+
+.city-info {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translate(-50%, 8px);
+  text-align: center;
+  white-space: nowrap;
+  opacity: 0;
+  transition: all var(--transition-normal);
+  pointer-events: none;
+}
+
+.city--near-bottom {
+  .city-info {
+    top: auto;
+    bottom: calc(100% + 6px);
+    transform: translate(-50%, -8px);
+  }
+
+  &:hover .city-info {
+    transform: translate(-50%, 0);
+  }
+}
+
+.city-name {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  color: var(--color-text);
+}
+
+.city-theme {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--color-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-top: 2px;
+}
+
+/* ===== PANNEAU DÉTAILS ===== */
+.details-panel {
+  position: fixed;
+  top: 68px;
+  right: 0;
+  width: 400px;
+  height: calc(100vh - 68px);
+  background: linear-gradient(135deg, rgba(20, 20, 30, 0.97), rgba(15, 15, 22, 0.97));
+  border-left: 1px solid rgba(255, 107, 53, 0.2);
+  backdrop-filter: blur(20px);
+  transform: translateX(100%);
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 1000;
+  overflow-y: auto;
+
+  &.open { transform: translateX(0); }
+}
+
+.panel-content { padding: 2rem; }
+
+.close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 38px;
+  height: 38px;
+  background: rgba(255, 107, 53, 0.15);
+  border: 1px solid rgba(255, 107, 53, 0.3);
+  border-radius: 50%;
+  color: var(--color-accent);
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    background: rgba(255, 107, 53, 0.25);
+    transform: rotate(90deg);
+  }
+}
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid rgba(255, 107, 53, 0.15);
+
+  .panel-emoji {
+    font-size: 3.5rem;
+    filter: drop-shadow(0 0 16px rgba(255, 107, 53, 0.4));
+    flex-shrink: 0;
+  }
+
+  h2 {
+    font-size: 1.8rem;
+    margin: 0 0 0.2rem;
+  }
+
+  .panel-theme {
+    font-size: 0.8rem;
+    color: var(--color-accent);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    display: block;
+  }
+}
+
+.panel-badge {
+  display: inline-block;
+  margin-top: 0.4rem;
+  font-size: 0.75rem;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-weight: 600;
+
+  &--here {
+    background: rgba(76, 175, 80, 0.2);
+    border: 1px solid rgba(76, 175, 80, 0.5);
+    color: #81c784;
+  }
+}
+
+.panel-description {
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: var(--color-text-dim);
+  margin: 0 0 1.75rem;
+}
+
+.panel-section {
+  margin-bottom: 1.75rem;
+
+  h3 {
+    font-size: 1.25rem;
+    margin: 0 0 0.875rem;
+    color: var(--color-text);
+  }
+}
+
+.panel-unreachable {
+  font-size: 0.9rem;
+  color: var(--color-text-dim);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  padding: 1rem;
+  margin: 0;
+}
+
+/* Jobs */
+.jobs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.job-item {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 107, 53, 0.05);
+  border: 1px solid rgba(255, 107, 53, 0.1);
+  border-radius: var(--radius-sm);
+  transition: all var(--transition-fast);
+
+  .job-emoji { font-size: 1.4rem; }
+  .job-name  { font-size: 0.9rem; color: var(--color-text); }
+
+  &:hover {
+    background: rgba(255, 107, 53, 0.1);
+    border-color: rgba(255, 107, 53, 0.25);
+    transform: translateX(4px);
+  }
+}
+
+/* Route detail */
+.route-detail {
+  background: rgba(255, 107, 53, 0.05);
+  border: 1px solid rgba(255, 107, 53, 0.15);
+  border-radius: var(--radius-sm);
+  padding: 1rem;
+  margin-bottom: 1rem;
+
+  &__row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.4rem 0;
+
+    & + & {
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+    }
+  }
+
+  &__label {
+    font-size: 0.8rem;
+    color: var(--color-text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+  }
+
+  &__value {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+
+    &--free { color: #81c784; }
+  }
+}
+
+.tag-visited {
+  font-size: 0.7rem;
+  font-weight: 500;
+  background: rgba(76, 175, 80, 0.2);
+  border: 1px solid rgba(76, 175, 80, 0.4);
+  color: #81c784;
+  padding: 1px 7px;
+  border-radius: var(--radius-full);
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+/* Bouton voyage */
+.btn-travel {
+  width: 100%;
+  padding: 0.875rem 1.5rem;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-2));
+  border: none;
+  border-radius: var(--radius-sm);
+  color: #fff;
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+
+  &:not(:disabled):hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(255, 107, 53, 0.4);
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-text-dim);
+  }
+}
+
+/* ===== RESPONSIVE ===== */
+@media (max-width: 1024px) {
+  .details-panel { width: 360px; }
+}
+
+@media (max-width: 768px) {
+  .map-header {
+    padding: var(--spacing-lg) var(--spacing-sm);
+
+    .section-label { font-size: 3rem; }
+  }
+
+  .map-viewport {
+    height: 55vh;
+    min-height: 380px;
+  }
+
+  .details-panel {
+    width: 100%;
+    top: 68px;
+    height: calc(100vh - 68px);
+  }
+
+  .travel-banner__inner {
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+  }
+}

--- a/web/frontend/src/app/features/map/map.component.ts
+++ b/web/frontend/src/app/features/map/map.component.ts
@@ -1,9 +1,176 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, OnDestroy, signal, computed, inject, ChangeDetectionStrategy } from '@angular/core';
+import { forkJoin, interval, Subscription } from 'rxjs';
+import { TravelService } from '../../core/services/travel.service';
+import type { City, RouteData, TravelRoute, TravelMapData, TravelStatus, VisualRoute } from '../../core/models/travel.model';
 
 @Component({
   selector: 'app-map',
   standalone: true,
+  imports: [],
   templateUrl: './map.component.html',
+  styleUrl: './map.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MapComponent {}
+export class MapComponent implements OnInit, OnDestroy {
+  private readonly travelService = inject(TravelService);
+
+  readonly isLoading = signal(true);
+  readonly hasError = signal(false);
+  readonly isTraveling = signal(false);
+  readonly selectedCity = signal<City | null>(null);
+  readonly remainingSeconds = signal(0);
+  readonly travelingToName = signal('');
+  readonly travelingToEmoji = signal('');
+  readonly coins = signal(0);
+
+  readonly cities = signal<City[]>([]);
+  readonly allRoutes = signal<RouteData[]>([]);
+  private travelMapData: TravelMapData | null = null;
+  private travelStatus: TravelStatus | null = null;
+
+  readonly visualRoutes = computed<VisualRoute[]>(() => {
+    return this.allRoutes()
+      .map(r => {
+        const from = this.cities().find(c => c.city_id === r.city_from);
+        const to = this.cities().find(c => c.city_id === r.city_to);
+        if (!from || !to) return null;
+        let x1 = from.position_x, y1 = from.position_y;
+        let x2 = to.position_x, y2 = to.position_y;
+        if (x1 === x2) x2 += 0.001;
+        if (y1 === y2) y2 += 0.001;
+        return { x1, y1, x2, y2 };
+      })
+      .filter((r): r is VisualRoute => r !== null);
+  });
+
+  private countdownSub?: Subscription;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  ngOnDestroy(): void {
+    this.countdownSub?.unsubscribe();
+  }
+
+  load(): void {
+    this.isLoading.set(true);
+    this.hasError.set(false);
+
+    forkJoin({
+      cities: this.travelService.getAllCities(),
+      routes: this.travelService.getAllRoutes(),
+      map: this.travelService.getMap(),
+      status: this.travelService.getStatus(),
+    }).subscribe({
+      next: ({ cities, routes, map, status }) => {
+        this.cities.set(cities);
+        this.allRoutes.set(routes);
+        this.travelMapData = map;
+        this.travelStatus = status;
+        this.coins.set(map.coins);
+        this.isTraveling.set(status.traveling);
+        this.travelingToName.set(status.destination_name ?? '');
+        this.travelingToEmoji.set(status.destination_emoji ?? '');
+        this.isLoading.set(false);
+
+        if (status.traveling && status.arrival_time) {
+          this.startCountdown(status.arrival_time);
+        } else {
+          this.countdownSub?.unsubscribe();
+        }
+      },
+      error: () => {
+        this.hasError.set(true);
+        this.isLoading.set(false);
+      },
+    });
+  }
+
+  private startCountdown(arrivalTime: number): void {
+    this.countdownSub?.unsubscribe();
+    const update = () => {
+      const remaining = Math.max(0, arrivalTime - Math.floor(Date.now() / 1000));
+      this.remainingSeconds.set(remaining);
+      if (remaining === 0) {
+        this.countdownSub?.unsubscribe();
+        this.load();
+      }
+    };
+    update();
+    this.countdownSub = interval(1000).subscribe(update);
+  }
+
+  getCityPosition(city: City): { x: number; y: number } {
+    return {
+      x: (city.position_x / 1000) * 100,
+      y: (city.position_y / 600) * 100,
+    };
+  }
+
+  isCurrentCity(cityId: string): boolean {
+    return this.travelMapData?.current_city.city_id === cityId;
+  }
+
+  isDestination(cityId: string): boolean {
+    return this.travelStatus?.destination === cityId;
+  }
+
+  getRouteToCity(cityId: string): TravelRoute | null {
+    return this.travelMapData?.routes.find(r => r.city_to === cityId) ?? null;
+  }
+
+  getCurrentCityJobs() {
+    return this.travelMapData?.jobs ?? [];
+  }
+
+  getThemeColor(theme?: string): string {
+    const colors: Record<string, string> = {
+      nature: 'rgba(139, 195, 74, 0.4)',
+      industrial: 'rgba(255, 152, 0, 0.4)',
+      maritime: 'rgba(3, 169, 244, 0.4)',
+      mountain: 'rgba(158, 158, 158, 0.4)',
+      plains: 'rgba(255, 235, 59, 0.4)',
+      cyber: 'rgba(156, 39, 176, 0.4)',
+    };
+    return colors[theme ?? ''] ?? 'rgba(255, 107, 53, 0.4)';
+  }
+
+  selectCity(city: City): void {
+    this.selectedCity.set(city);
+  }
+
+  closePanel(): void {
+    this.selectedCity.set(null);
+  }
+
+  startTravel(cityId: string): void {
+    this.travelService.startTravel(cityId).subscribe({
+      next: (res) => {
+        if (res.success) {
+          this.closePanel();
+          this.load();
+        }
+      },
+    });
+  }
+
+  canAffordTravel(cityId: string): boolean {
+    const route = this.getRouteToCity(cityId);
+    if (!route) return false;
+    return route.effective_cost === 0 || this.coins() >= route.effective_cost;
+  }
+
+  formatDuration(minutes: number): string {
+    if (minutes < 60) return `${minutes} min`;
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    return m > 0 ? `${h}h${String(m).padStart(2, '0')}` : `${h}h`;
+  }
+
+  formatCountdown(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${String(s).padStart(2, '0')}`;
+  }
+}


### PR DESCRIPTION
## Résumé
- Carte SVG interactive avec 6 villes positionnées dynamiquement (`position_x/y`)
- Routes animées entre villes via `GET /api/routes`
- Fonds thématiques par ville (nature, industrial, maritime, mountain, plains, cyber)
- Panneau latéral : détails ville, jobs disponibles, bouton voyage avec coût/durée
- Bannière de voyage avec countdown temps réel (refresh auto à l'arrivée)
- Villes déjà visitées affichées "Gratuit" dans le panneau
- Vérification du solde avant activation du bouton voyage
- Label inversé pour les villes proches du bas de carte

## Plan de test
- [ ] Naviguer vers `/map` en étant connecté
- [ ] 6 villes visibles aux bonnes positions, routes SVG animées
- [ ] Clic ville accessible → panel avec coût/durée + bouton voyage
- [ ] Lancer un voyage → bannière countdown + ville de destination pulsée
- [ ] Solde insuffisant → bouton désactivé "Fonds insuffisants"
- [ ] Arrivée à destination → refresh automatique, ville actuelle mise à jour (halo vert)
- [ ] Goldenfields → label au-dessus de l'icône (pas de clip)

Closes #57 & #58
Closes #73
Closes #74
Closes #75