### PR TITLE
fix(dev): retrait --no-tls Symfony et ajout .gitignore racine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "install:all": "cd web/frontend && npm i && cd ../../bot && npm i",
     "dev": "concurrently --kill-others-on-fail -c red,blue,green --names Back,Front,Bot \"npm run dev:back\" \"npm run dev:front\" \"npm run dev:bot\"",
     "dev:front": "cd web/frontend && npm run start",
-    "dev:back": "cd web/backend && symfony server:start --port=8008 --no-tls",
+    "dev:back": "cd web/backend && symfony server:start --port=8008",
     "dev:bot": "cd bot && npm run dev"
   },
   "devDependencies": {


### PR DESCRIPTION
## Résumé
- Suppression de `--no-tls` dans `dev:back` : Symfony CLI sert en HTTPS par défaut sur Windows, le flag provoquait `ERR_SSL_WRONG_VERSION_NUMBER` côté bot et proxy Angular
- Ajout de `.gitignore` à la racine du monorepo pour exclure `node_modules/` et `package-lock.json` (absents depuis l'ajout de `concurrently`)

## Plan de test
- [ ] `npm run dev` démarre sans erreur SSL
- [ ] `node_modules/` à la racine n'apparaît plus dans `git status`