### PR TITLE
feat(shop): liste items boutique (Feature #60)

### DIFF
--- a/web/backend/src/DataFixtures/ShopFixtures.php
+++ b/web/backend/src/DataFixtures/ShopFixtures.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\DataFixtures;
+
+use App\Entity\ShopItem;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
+use Doctrine\Persistence\ObjectManager;
+
+class ShopFixtures extends Fixture implements FixtureGroupInterface
+{
+    public static function getGroups(): array
+    {
+        return ['shop'];
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $items = [
+            // Backgrounds
+            [
+                'item_id'   => 'bg_blue',
+                'item_type' => 'background',
+                'name'      => 'Ciel Nocturne',
+                'description' => 'Un ciel étoilé aux teintes bleues profondes.',
+                'price'     => 100,
+                'emoji'     => '🌌',
+            ],
+            [
+                'item_id'   => 'bg_purple',
+                'item_type' => 'background',
+                'name'      => 'Nuit Stellaire',
+                'description' => 'Les reflets violets d\'une nuit sans fin.',
+                'price'     => 150,
+                'emoji'     => '🔮',
+            ],
+            [
+                'item_id'   => 'bg_green',
+                'item_type' => 'background',
+                'name'      => 'Forêt Mystique',
+                'description' => 'Les profondeurs d\'une forêt enchantée.',
+                'price'     => 120,
+                'emoji'     => '🌿',
+            ],
+            [
+                'item_id'   => 'bg_red',
+                'item_type' => 'background',
+                'name'      => 'Volcan Ardent',
+                'description' => 'La lave incandescente d\'un volcan en éruption.',
+                'price'     => 180,
+                'emoji'     => '🌋',
+            ],
+            [
+                'item_id'   => 'bg_orange',
+                'item_type' => 'background',
+                'name'      => 'Désert Doré',
+                'description' => 'Les dunes infinies d\'un désert au coucher du soleil.',
+                'price'     => 130,
+                'emoji'     => '🏜️',
+            ],
+
+            // Badges
+            [
+                'item_id'   => 'badge_verified',
+                'item_type' => 'badge',
+                'name'      => 'Voyageur Vérifié',
+                'description' => 'Récompense les explorateurs reconnus.',
+                'price'     => 200,
+                'emoji'     => '✅',
+            ],
+            [
+                'item_id'   => 'badge_star',
+                'item_type' => 'badge',
+                'name'      => 'Étoile Montante',
+                'description' => 'Pour ceux qui brillent dans MazWorld.',
+                'price'     => 250,
+                'emoji'     => '⭐',
+            ],
+            [
+                'item_id'   => 'badge_heart',
+                'item_type' => 'badge',
+                'name'      => 'Âme Généreuse',
+                'description' => 'Décerné aux joueurs au grand cœur.',
+                'price'     => 220,
+                'emoji'     => '❤️',
+            ],
+            [
+                'item_id'   => 'badge_fire',
+                'item_type' => 'badge',
+                'name'      => 'Explorateur Ardent',
+                'description' => 'Pour les aventuriers qui ne s\'arrêtent jamais.',
+                'price'     => 300,
+                'emoji'     => '🔥',
+            ],
+            [
+                'item_id'   => 'badge_diamond',
+                'item_type' => 'badge',
+                'name'      => 'Diamant MazWorld',
+                'description' => 'Le badge ultime, réservé aux légendes.',
+                'price'     => 500,
+                'emoji'     => '💎',
+            ],
+        ];
+
+        foreach ($items as $data) {
+            $item = (new ShopItem())
+                ->setItemId($data['item_id'])
+                ->setItemType($data['item_type'])
+                ->setName($data['name'])
+                ->setDescription($data['description'])
+                ->setPrice($data['price'])
+                ->setEmoji($data['emoji'])
+                ->setAvailable(true);
+
+            $manager->persist($item);
+        }
+
+        $manager->flush();
+    }
+}

--- a/web/frontend/src/app/core/models/index.ts
+++ b/web/frontend/src/app/core/models/index.ts
@@ -1,3 +1,4 @@
 export * from './user.model';
 export * from './profile.model';
 export * from './travel.model';
+export * from './shop.model';

--- a/web/frontend/src/app/core/models/shop.model.ts
+++ b/web/frontend/src/app/core/models/shop.model.ts
@@ -1,0 +1,31 @@
+export type ItemType = 'background' | 'badge';
+export type ShopFilter = 'all' | 'background' | 'badge' | 'owned';
+
+export interface ShopItem {
+  item_id: string;
+  item_type: ItemType;
+  name: string;
+  description: string | null;
+  price: number;
+  emoji: string | null;
+  available: boolean;
+  owned?: boolean;
+  equipped?: boolean;
+}
+
+export interface ShopResponse {
+  items: ShopItem[];
+  user_coins: number;
+}
+
+export interface PurchaseResponse {
+  success: boolean;
+  message: string;
+  new_balance: number;
+  item: ShopItem;
+}
+
+export interface EquipResponse {
+  success: boolean;
+  message: string;
+}

--- a/web/frontend/src/app/core/services/index.ts
+++ b/web/frontend/src/app/core/services/index.ts
@@ -2,3 +2,4 @@ export * from './auth.service';
 export * from './auth-storage.service';
 export * from './profile.service';
 export * from './travel.service';
+export * from './shop.service';

--- a/web/frontend/src/app/core/services/shop.service.ts
+++ b/web/frontend/src/app/core/services/shop.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import type { ShopResponse, PurchaseResponse, EquipResponse } from '../models/shop.model';
+
+@Injectable({ providedIn: 'root' })
+export class ShopService {
+  private readonly http = inject(HttpClient);
+  private readonly base = environment.apiUrl;
+
+  getShopItems(): Observable<ShopResponse> {
+    return this.http.get<ShopResponse>(`${this.base}/api/shop`);
+  }
+
+  purchaseItem(itemId: string): Observable<PurchaseResponse> {
+    return this.http.post<PurchaseResponse>(`${this.base}/api/shop/purchase`, { item_id: itemId });
+  }
+
+  equipBackground(itemId: string): Observable<EquipResponse> {
+    return this.http.post<EquipResponse>(`${this.base}/api/profile/equip/background`, { item_id: itemId });
+  }
+
+  equipBadge(badgeId: string, slot: number): Observable<EquipResponse> {
+    return this.http.post<EquipResponse>(`${this.base}/api/profile/equip/badge`, { badge_id: badgeId, slot });
+  }
+}

--- a/web/frontend/src/app/features/shop/shop.component.html
+++ b/web/frontend/src/app/features/shop/shop.component.html
@@ -1,3 +1,171 @@
-<div class="container">
-  <h2>Boutique — à venir</h2>
+<div class="shop-page">
+
+  <!-- Header -->
+  <div class="shop-header container">
+    <div class="shop-header__content">
+      <span class="section-label">SHOP</span>
+      <h1>Boutique</h1>
+      <p class="subtitle">Personnalisez votre profil avec des backgrounds et badges uniques</p>
+    </div>
+    <div class="shop-header__balance">
+      <span>💰</span>
+      <span class="balance-value">{{ userCoins() }}</span>
+      <span class="balance-unit">MC</span>
+    </div>
+  </div>
+
+  <!-- Notification -->
+  @if (notification(); as notif) {
+    <div class="notification container" [class.notification--success]="notif.type === 'success'" [class.notification--error]="notif.type === 'error'">
+      <span>{{ notif.type === 'success' ? '✅' : '❌' }}</span>
+      <span>{{ notif.message }}</span>
+    </div>
+  }
+
+  <!-- Loading -->
+  @if (isLoading()) {
+    <div class="shop-state">
+      <div class="loading"></div>
+      <p>Chargement de la boutique…</p>
+    </div>
+  }
+
+  <!-- Error -->
+  @else if (hasError()) {
+    <div class="shop-state shop-state--error">
+      <span>⚠️</span>
+      <p>Impossible de charger la boutique.</p>
+      <button class="btn btn-primary btn--sm" (click)="load()">Réessayer</button>
+    </div>
+  }
+
+  @else {
+    <!-- Stats -->
+    <div class="shop-stats container">
+      <div class="stat-chip">
+        <span>🛍️</span>
+        <strong>{{ totalCount() }}</strong>
+        <span>Articles</span>
+      </div>
+      <div class="stat-chip">
+        <span>🖼️</span>
+        <strong>{{ bgCount() }}</strong>
+        <span>Backgrounds</span>
+      </div>
+      <div class="stat-chip">
+        <span>🏅</span>
+        <strong>{{ badgeCount() }}</strong>
+        <span>Badges</span>
+      </div>
+      <div class="stat-chip stat-chip--owned">
+        <span>📦</span>
+        <strong>{{ ownedCount() }}</strong>
+        <span>Possédés</span>
+      </div>
+    </div>
+
+    <!-- Filtres -->
+    <div class="shop-filters container">
+      @for (f of filters; track f) {
+        <button class="filter-btn" [class.filter-btn--active]="filter() === f" (click)="setFilter(f)">
+          <span>{{ filterIcon(f) }}</span>
+          <span>{{ filterLabel(f) }}</span>
+        </button>
+      }
+    </div>
+
+    <!-- Grille articles -->
+    @if (filteredItems().length === 0) {
+      <div class="shop-state container">
+        <span style="font-size:3rem">🔍</span>
+        <p>Aucun article dans cette catégorie.</p>
+      </div>
+    } @else {
+      <div class="items-grid container">
+        @for (item of paginatedItems(); track item.item_id) {
+          <div class="item-card"
+            [class.item-card--owned]="item.owned"
+            [class.item-card--equipped]="item.equipped">
+
+            <!-- En-tête visuel -->
+            <div class="item-card__header" [class.item-card__header--bg]="item.item_type === 'background'" [class.item-card__header--badge]="item.item_type === 'badge'">
+              <span class="item-emoji">{{ getEmoji(item) }}</span>
+              @if (item.equipped) {
+                <span class="item-tag item-tag--equipped">⭐ Équipé</span>
+              } @else if (item.owned) {
+                <span class="item-tag item-tag--owned">✓ Possédé</span>
+              }
+            </div>
+
+            <!-- Contenu -->
+            <div class="item-card__body">
+              <h3 class="item-name">{{ item.name }}</h3>
+              @if (item.description) {
+                <p class="item-desc">{{ item.description }}</p>
+              }
+              <span class="item-type-tag" [class.item-type-tag--bg]="item.item_type === 'background'" [class.item-type-tag--badge]="item.item_type === 'badge'">
+                {{ item.item_type === 'background' ? '🖼️ Background' : '🏅 Badge' }}
+              </span>
+            </div>
+
+            <!-- Pied -->
+            <div class="item-card__footer">
+              @if (!item.owned) {
+                <span class="item-price" [class.item-price--affordable]="canBuy(item)">
+                  {{ item.price }} 🪙
+                </span>
+                <button
+                  class="btn-buy"
+                  [disabled]="!canBuy(item) || purchasing() === item.item_id"
+                  (click)="purchase(item)">
+                  @if (purchasing() === item.item_id) {
+                    <span class="loading-dot"></span>
+                  } @else if (!item.available) {
+                    Indisponible
+                  } @else if (userCoins() < item.price) {
+                    Fonds insuffisants
+                  } @else {
+                    Acheter
+                  }
+                </button>
+              } @else {
+                @if (item.item_type === 'background' && !item.equipped) {
+                  <button class="btn-equip" (click)="equipBg(item)">Équiper</button>
+                } @else if (item.item_type === 'badge' && !item.equipped) {
+                  <div class="badge-slots">
+                    <span class="badge-slots__label">Slot :</span>
+                    @for (slot of [0,1,2,3,4,5]; track slot) {
+                      <button class="slot-btn" [title]="'Slot ' + (slot + 1)" (click)="equipBadge(item, slot)">
+                        {{ slot + 1 }}
+                      </button>
+                    }
+                  </div>
+                } @else if (item.equipped) {
+                  <span class="item-status item-status--equipped">Actuellement équipé</span>
+                } @else {
+                  <span class="item-status">Dans l'inventaire</span>
+                }
+              }
+            </div>
+
+          </div>
+        }
+      </div>
+
+      <!-- Pagination -->
+      @if (totalPages() > 1) {
+        <div class="pagination container">
+          <button class="pagination-btn" [disabled]="!canGoPrev()" (click)="prevPage()">◀</button>
+          <div class="pagination-pages">
+            @for (p of pagesArray(); track p) {
+              <button class="pagination-page" [class.pagination-page--active]="page() === p" (click)="goToPage(p)">{{ p }}</button>
+            }
+          </div>
+          <button class="pagination-btn" [disabled]="!canGoNext()" (click)="nextPage()">▶</button>
+          <span class="pagination-info">{{ page() }}/{{ totalPages() }}</span>
+        </div>
+      }
+    }
+  }
+
 </div>

--- a/web/frontend/src/app/features/shop/shop.component.scss
+++ b/web/frontend/src/app/features/shop/shop.component.scss
@@ -1,0 +1,485 @@
+.shop-page {
+  min-height: calc(100vh - 68px);
+  padding: var(--spacing-xl) 0 var(--spacing-2xl);
+}
+
+/* ===== HEADER ===== */
+.shop-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  &__content {
+    .section-label {
+      display: inline-block;
+      font-family: var(--font-heading);
+      font-size: 0.75rem;
+      letter-spacing: 0.2em;
+      color: var(--color-accent);
+      margin-bottom: 0.25rem;
+    }
+
+    h1 { margin: 0; line-height: 1; }
+
+    .subtitle {
+      margin: 0.4rem 0 0;
+      font-size: 0.95rem;
+    }
+  }
+
+  &__balance {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(212, 175, 55, 0.08);
+    border: 1px solid rgba(212, 175, 55, 0.35);
+    border-radius: var(--radius-md);
+    padding: 0.6rem 1.2rem;
+    flex-shrink: 0;
+
+    .balance-value {
+      font-family: var(--font-heading);
+      font-size: 1.6rem;
+      color: var(--color-gold);
+    }
+
+    .balance-unit {
+      font-size: 0.8rem;
+      color: rgba(212, 175, 55, 0.7);
+      font-weight: 600;
+      letter-spacing: 0.05em;
+    }
+  }
+}
+
+/* ===== NOTIFICATION ===== */
+.notification {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1.25rem;
+  border-radius: var(--radius-md);
+  margin-bottom: var(--spacing-md);
+  font-size: 0.95rem;
+  font-weight: 500;
+  animation: fadeInDown 0.3s ease;
+
+  &--success {
+    background: rgba(34, 197, 94, 0.1);
+    border: 1px solid rgba(34, 197, 94, 0.3);
+    color: #4ade80;
+  }
+
+  &--error {
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    color: #f87171;
+  }
+}
+
+/* ===== LOADING / ERROR STATES ===== */
+.shop-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 30vh;
+  gap: var(--spacing-md);
+  color: var(--color-text-dim);
+  text-align: center;
+
+  &--error { color: #f87171; }
+}
+
+/* ===== STATS BAR ===== */
+.shop-stats {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-md);
+}
+
+.stat-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  background: rgba(255, 107, 53, 0.06);
+  border: 1px solid rgba(255, 107, 53, 0.15);
+  border-radius: var(--radius-full);
+  font-size: 0.875rem;
+  color: var(--color-text-dim);
+
+  strong {
+    color: var(--color-text);
+    font-weight: 700;
+  }
+
+  &--owned {
+    background: rgba(212, 175, 55, 0.07);
+    border-color: rgba(212, 175, 55, 0.2);
+
+    strong { color: var(--color-gold); }
+  }
+}
+
+/* ===== FILTERS ===== */
+.shop-filters {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-lg);
+}
+
+.filter-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1.1rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-full);
+  color: var(--color-text-dim);
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all var(--transition-fast);
+
+  &:hover:not(.filter-btn--active) {
+    border-color: rgba(255, 107, 53, 0.3);
+    color: var(--color-text);
+  }
+
+  &--active {
+    background: rgba(255, 107, 53, 0.15);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+    font-weight: 600;
+  }
+}
+
+/* ===== ITEMS GRID ===== */
+.items-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+
+  @media (max-width: 600px) {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: var(--spacing-sm);
+  }
+}
+
+/* ===== ITEM CARD ===== */
+.item-card {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(135deg, rgba(26, 26, 37, 0.7), rgba(20, 20, 30, 0.5));
+  border: 1px solid rgba(255, 107, 53, 0.1);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: transform var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
+
+  &:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 107, 53, 0.3);
+    box-shadow: var(--shadow-md);
+  }
+
+  &--owned {
+    border-color: rgba(212, 175, 55, 0.2);
+
+    &:hover { border-color: rgba(212, 175, 55, 0.45); }
+  }
+
+  &--equipped {
+    border-color: rgba(255, 107, 53, 0.5);
+    box-shadow: 0 0 16px rgba(255, 107, 53, 0.15);
+
+    &:hover { border-color: var(--color-accent); }
+  }
+
+  &__header {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100px;
+
+    &--bg {
+      background: linear-gradient(135deg, rgba(99, 102, 241, 0.25), rgba(168, 85, 247, 0.2));
+    }
+
+    &--badge {
+      background: linear-gradient(135deg, rgba(255, 107, 53, 0.2), rgba(247, 147, 30, 0.15));
+    }
+  }
+
+  &__body {
+    padding: 0.875rem 1rem 0.5rem;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  &__footer {
+    padding: 0.75rem 1rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+}
+
+/* ===== ITEM ELEMENTS ===== */
+.item-emoji {
+  font-size: 2.8rem;
+  line-height: 1;
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.5));
+}
+
+.item-tag {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-full);
+  letter-spacing: 0.03em;
+
+  &--owned {
+    background: rgba(212, 175, 55, 0.15);
+    border: 1px solid rgba(212, 175, 55, 0.4);
+    color: var(--color-gold);
+  }
+
+  &--equipped {
+    background: rgba(255, 107, 53, 0.2);
+    border: 1px solid rgba(255, 107, 53, 0.5);
+    color: var(--color-accent);
+  }
+}
+
+.item-name {
+  font-size: 1rem;
+  margin: 0;
+  color: var(--color-text);
+  line-height: 1.3;
+}
+
+.item-desc {
+  font-size: 0.8rem;
+  color: var(--color-text-dim);
+  margin: 0;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.item-type-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--radius-full);
+  margin-top: auto;
+  width: fit-content;
+
+  &--bg {
+    background: rgba(99, 102, 241, 0.1);
+    border: 1px solid rgba(99, 102, 241, 0.25);
+    color: #a5b4fc;
+  }
+
+  &--badge {
+    background: rgba(255, 107, 53, 0.1);
+    border: 1px solid rgba(255, 107, 53, 0.25);
+    color: var(--color-accent);
+  }
+}
+
+.item-price {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-darker);
+
+  &--affordable { color: var(--color-gold); }
+}
+
+.item-status {
+  font-size: 0.8rem;
+  color: var(--color-text-darker);
+
+  &--equipped {
+    color: var(--color-accent);
+    font-weight: 600;
+  }
+}
+
+/* ===== BUTTONS ===== */
+.btn-buy {
+  padding: 0.4rem 0.9rem;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-2));
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+  font-weight: 700;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(255, 107, 53, 0.4);
+  }
+
+  &:disabled {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--color-text-darker);
+    font-weight: 500;
+  }
+}
+
+.btn-equip {
+  padding: 0.4rem 0.9rem;
+  background: rgba(212, 175, 55, 0.1);
+  color: var(--color-gold);
+  border: 1px solid rgba(212, 175, 55, 0.35);
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    background: rgba(212, 175, 55, 0.2);
+    border-color: var(--color-gold);
+  }
+}
+
+/* ===== BADGE SLOTS ===== */
+.badge-slots {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+
+  &__label {
+    font-size: 0.75rem;
+    color: var(--color-text-dim);
+  }
+}
+
+.slot-btn {
+  width: 28px;
+  height: 28px;
+  background: rgba(255, 107, 53, 0.08);
+  border: 1px solid rgba(255, 107, 53, 0.2);
+  border-radius: var(--radius-sm);
+  color: var(--color-accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: rgba(255, 107, 53, 0.2);
+    border-color: var(--color-accent);
+    transform: translateY(-1px);
+  }
+}
+
+/* ===== LOADING DOT ===== */
+.loading-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+/* ===== PAGINATION ===== */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.pagination-btn {
+  width: 36px;
+  height: 36px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-dim);
+  font-size: 0.8rem;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover:not(:disabled) {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+}
+
+.pagination-pages {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.pagination-page {
+  min-width: 36px;
+  height: 36px;
+  padding: 0 0.5rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-dim);
+  font-size: 0.85rem;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover:not(.pagination-page--active) {
+    border-color: rgba(255, 107, 53, 0.3);
+    color: var(--color-text);
+  }
+
+  &--active {
+    background: rgba(255, 107, 53, 0.15);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+    font-weight: 700;
+  }
+}
+
+.pagination-info {
+  font-size: 0.8rem;
+  color: var(--color-text-darker);
+  margin-left: 0.25rem;
+}

--- a/web/frontend/src/app/features/shop/shop.component.ts
+++ b/web/frontend/src/app/features/shop/shop.component.ts
@@ -1,9 +1,148 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, signal, computed, inject, ChangeDetectionStrategy } from '@angular/core';
+import { ShopService } from '../../core/services/shop.service';
+import type { ShopItem, ShopFilter } from '../../core/models/shop.model';
+
+const ITEMS_PER_PAGE = 12;
 
 @Component({
   selector: 'app-shop',
   standalone: true,
+  imports: [],
   templateUrl: './shop.component.html',
+  styleUrl: './shop.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ShopComponent {}
+export class ShopComponent implements OnInit {
+  private readonly shopService = inject(ShopService);
+
+  readonly items = signal<ShopItem[]>([]);
+  readonly userCoins = signal(0);
+  readonly isLoading = signal(true);
+  readonly hasError = signal(false);
+  readonly filter = signal<ShopFilter>('all');
+  readonly page = signal(1);
+  readonly purchasing = signal<string | null>(null);
+  readonly notification = signal<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  readonly filters: ShopFilter[] = ['all', 'background', 'badge', 'owned'];
+
+  readonly filteredItems = computed(() => {
+    const f = this.filter();
+    const all = this.items();
+    const filtered = f === 'all' ? all
+      : f === 'owned' ? all.filter(i => i.owned)
+      : all.filter(i => i.item_type === f);
+    return [...filtered].sort((a, b) => {
+      if (a.owned !== b.owned) return a.owned ? 1 : -1;
+      return a.price - b.price;
+    });
+  });
+
+  readonly totalPages = computed(() => Math.max(1, Math.ceil(this.filteredItems().length / ITEMS_PER_PAGE)));
+  readonly paginatedItems = computed(() => {
+    const p = this.page();
+    return this.filteredItems().slice((p - 1) * ITEMS_PER_PAGE, p * ITEMS_PER_PAGE);
+  });
+  readonly canGoPrev = computed(() => this.page() > 1);
+  readonly canGoNext = computed(() => this.page() < this.totalPages());
+
+  readonly totalCount = computed(() => this.items().length);
+  readonly ownedCount = computed(() => this.items().filter(i => i.owned).length);
+  readonly bgCount = computed(() => this.items().filter(i => i.item_type === 'background').length);
+  readonly badgeCount = computed(() => this.items().filter(i => i.item_type === 'badge').length);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading.set(true);
+    this.hasError.set(false);
+    this.shopService.getShopItems().subscribe({
+      next: ({ items, user_coins }) => {
+        this.items.set(items);
+        this.userCoins.set(user_coins);
+        this.isLoading.set(false);
+      },
+      error: () => {
+        this.hasError.set(true);
+        this.isLoading.set(false);
+      },
+    });
+  }
+
+  setFilter(f: ShopFilter): void {
+    this.filter.set(f);
+    this.page.set(1);
+  }
+
+  canBuy(item: ShopItem): boolean {
+    return item.available && !item.owned && this.userCoins() >= item.price;
+  }
+
+  purchase(item: ShopItem): void {
+    if (!this.canBuy(item)) return;
+    this.purchasing.set(item.item_id);
+    this.shopService.purchaseItem(item.item_id).subscribe({
+      next: ({ new_balance, message }) => {
+        this.userCoins.set(new_balance);
+        this.items.update(list => list.map(i => i.item_id === item.item_id ? { ...i, owned: true } : i));
+        this.purchasing.set(null);
+        this.notify('success', message);
+      },
+      error: (err) => {
+        this.purchasing.set(null);
+        this.notify('error', err.error?.message ?? 'Erreur lors de l\'achat');
+      },
+    });
+  }
+
+  equipBg(item: ShopItem): void {
+    this.shopService.equipBackground(item.item_id).subscribe({
+      next: ({ message }) => {
+        this.items.update(list => list.map(i => ({
+          ...i,
+          equipped: i.item_type === 'background' ? i.item_id === item.item_id : i.equipped,
+        })));
+        this.notify('success', message);
+      },
+      error: (err) => this.notify('error', err.error?.message ?? 'Erreur'),
+    });
+  }
+
+  equipBadge(item: ShopItem, slot: number): void {
+    this.shopService.equipBadge(item.item_id, slot).subscribe({
+      next: ({ message }) => {
+        this.items.update(list => list.map(i => ({
+          ...i,
+          equipped: i.item_id === item.item_id ? true : i.equipped,
+        })));
+        this.notify('success', message);
+      },
+      error: (err) => this.notify('error', err.error?.message ?? 'Erreur'),
+    });
+  }
+
+  prevPage(): void { if (this.canGoPrev()) this.page.update(p => p - 1); }
+  nextPage(): void { if (this.canGoNext()) this.page.update(p => p + 1); }
+  goToPage(p: number): void { this.page.set(p); }
+
+  pagesArray(): number[] { return Array.from({ length: this.totalPages() }, (_, i) => i + 1); }
+
+  getEmoji(item: ShopItem): string {
+    return item.emoji ?? (item.item_type === 'background' ? '🖼️' : '🏅');
+  }
+
+  filterLabel(f: ShopFilter): string {
+    return { all: 'Tous', background: 'Backgrounds', badge: 'Badges', owned: 'Mes achats' }[f];
+  }
+
+  filterIcon(f: ShopFilter): string {
+    return { all: '🛍️', background: '🖼️', badge: '🏅', owned: '📦' }[f];
+  }
+
+  private notify(type: 'success' | 'error', message: string): void {
+    this.notification.set({ type, message });
+    setTimeout(() => this.notification.set(null), 4000);
+  }
+}


### PR DESCRIPTION
## Résumé

Intégration de la boutique MazWorld côté frontend et backend.

- **Modèles** : `ShopItem`, `ShopResponse`, `PurchaseResponse`, `EquipResponse`, `ShopFilter`
- **`ShopService`** : `GET /api/shop`, `POST /api/shop/purchase`, equip background/badge
- **`ShopComponent`** (Angular 21, signals, OnPush) :
  - Grille paginée (12 items/page) avec filtres tous/backgrounds/badges/possédés
  - Achat avec vérification de solde en temps réel
  - Équipement background (slot unique) et badges (6 slots)
  - Toast de notification succès/erreur
- **`ShopFixtures`** Symfony : 5 backgrounds + 5 badges, groupe `shop` (compatible `--append`)
- Barrel exports `models/index.ts` et `services/index.ts` mis à jour

## SUs incluses

- SU #78 — Affichage items boutique ✅

## Plan de test

- [ ] `php bin/console doctrine:fixtures:load --append --group=shop`
- [ ] `/shop` → 10 articles affichés (5 bg, 5 badges)
- [ ] Filtres Tous / Backgrounds / Badges / Mes achats
- [ ] Achat avec solde suffisant → solde actualisé, statut "Possédé"
- [ ] Achat avec solde insuffisant → bouton désactivé
- [ ] Équiper un background → statut "Équipé"
- [ ] Équiper un badge sur un slot 1-6 → toast confirmation

Closes #60
Closes #78