### PR TITLE
feat(inventory): endpoint GET /api/inventory (SU #70)

### DIFF
--- a/web/backend/src/Controller/API/InventoryController.php
+++ b/web/backend/src/Controller/API/InventoryController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Repository\ShopItemRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/inventory', name: 'api_inventory_')]
+class InventoryController extends AbstractApiController
+{
+    public function __construct(
+        private readonly ShopItemRepository $shopItemRepository,
+    ) {}
+
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function getInventory(): JsonResponse
+    {
+        try {
+            $user = $this->getCurrentUser();
+
+            if (!$user) {
+                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            }
+
+            $equippedBackground = $user->getEquippedBackground();
+
+            $equippedBadgeSlots = [];
+            foreach ($user->getEquippedBadges() as $badge) {
+                $equippedBadgeSlots[$badge->getSlotNumber()] = $badge->getBadgeId();
+            }
+            ksort($equippedBadgeSlots);
+
+            $items = [];
+            foreach ($user->getInventory() as $inventoryItem) {
+                $shopItem = $this->shopItemRepository->find($inventoryItem->getItemId());
+
+                if (!$shopItem) {
+                    continue;
+                }
+
+                $slot = null;
+                $equipped = false;
+
+                if ($inventoryItem->getItemType() === 'background') {
+                    $equipped = $inventoryItem->getItemId() === $equippedBackground;
+                } elseif ($inventoryItem->getItemType() === 'badge') {
+                    $slot = array_search($inventoryItem->getItemId(), $equippedBadgeSlots);
+                    $equipped = $slot !== false;
+                    $slot = $equipped ? (int)$slot : null;
+                }
+
+                $items[] = [
+                    'item_id'      => $inventoryItem->getItemId(),
+                    'item_type'    => $inventoryItem->getItemType(),
+                    'name'         => $shopItem->getName(),
+                    'description'  => $shopItem->getDescription(),
+                    'emoji'        => $shopItem->getEmoji(),
+                    'equipped'     => $equipped,
+                    'slot'         => $slot,
+                    'purchased_at' => $inventoryItem->getPurchasedAt()->format('c'),
+                ];
+            }
+
+            usort($items, fn($a, $b) => $b['equipped'] <=> $a['equipped'] ?: strcmp($a['item_type'], $b['item_type']));
+
+            return new JsonResponse([
+                'items'            => $items,
+                'equipped_background' => $equippedBackground,
+                'equipped_badges'  => $equippedBadgeSlots,
+                'user_coins'       => $user->getCoins(),
+            ]);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}


### PR DESCRIPTION
## Résumé

Ajout de `InventoryController` avec `GET /api/inventory` :

- Items possédés enrichis avec nom, description et emoji depuis `ShopItem`
- Statut `equipped` + numéro de `slot` pour les badges équipés
- Map `equipped_background` et `equipped_badges` (slot → item_id)
- Triés : équipés d'abord, puis par type (background avant badge)

## Plan de test

- [ ] `GET /api/inventory` authentifié → retourne les items achetés avec détails
- [ ] Champ `equipped: true` sur le background actif
- [ ] Champ `equipped: true` + `slot: N` sur les badges équipés
- [ ] `GET /api/inventory` sans auth → 401

Closes #70