### PR TITLE
feat(inventory): affichage inventaire web (SU #70 & #71)

### DIFF
--- a/web/backend/src/Controller/API/InventoryController.php
+++ b/web/backend/src/Controller/API/InventoryController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Repository\ShopItemRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/inventory', name: 'api_inventory_')]
+class InventoryController extends AbstractApiController
+{
+    public function __construct(
+        private readonly ShopItemRepository $shopItemRepository,
+    ) {}
+
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function getInventory(): JsonResponse
+    {
+        try {
+            $user = $this->getCurrentUser();
+
+            if (!$user) {
+                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            }
+
+            $equippedBackground = $user->getEquippedBackground();
+
+            $equippedBadgeSlots = [];
+            foreach ($user->getEquippedBadges() as $badge) {
+                $equippedBadgeSlots[$badge->getSlotNumber()] = $badge->getBadgeId();
+            }
+            ksort($equippedBadgeSlots);
+
+            $items = [];
+            foreach ($user->getInventory() as $inventoryItem) {
+                $shopItem = $this->shopItemRepository->find($inventoryItem->getItemId());
+
+                if (!$shopItem) {
+                    continue;
+                }
+
+                $slot = null;
+                $equipped = false;
+
+                if ($inventoryItem->getItemType() === 'background') {
+                    $equipped = $inventoryItem->getItemId() === $equippedBackground;
+                } elseif ($inventoryItem->getItemType() === 'badge') {
+                    $slot = array_search($inventoryItem->getItemId(), $equippedBadgeSlots);
+                    $equipped = $slot !== false;
+                    $slot = $equipped ? (int)$slot : null;
+                }
+
+                $items[] = [
+                    'item_id'      => $inventoryItem->getItemId(),
+                    'item_type'    => $inventoryItem->getItemType(),
+                    'name'         => $shopItem->getName(),
+                    'description'  => $shopItem->getDescription(),
+                    'emoji'        => $shopItem->getEmoji(),
+                    'equipped'     => $equipped,
+                    'slot'         => $slot,
+                    'purchased_at' => $inventoryItem->getPurchasedAt()->format('c'),
+                ];
+            }
+
+            usort($items, fn($a, $b) => $b['equipped'] <=> $a['equipped'] ?: strcmp($a['item_type'], $b['item_type']));
+
+            return new JsonResponse([
+                'items'            => $items,
+                'equipped_background' => $equippedBackground,
+                'equipped_badges'  => $equippedBadgeSlots,
+                'user_coins'       => $user->getCoins(),
+            ]);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/web/frontend/src/app/app.routes.ts
+++ b/web/frontend/src/app/app.routes.ts
@@ -38,6 +38,12 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'inventory',
+    loadComponent: () => import('./features/inventory/inventory.component').then(m => m.InventoryComponent),
+    title: 'Inventaire — MazWorld',
+    canActivate: [authGuard],
+  },
+  {
     path: 'leaderboard',
     loadComponent: () => import('./features/leaderboard/leaderboard.component').then(m => m.LeaderboardComponent),
     title: 'Classement — MazWorld',

--- a/web/frontend/src/app/core/models/index.ts
+++ b/web/frontend/src/app/core/models/index.ts
@@ -2,3 +2,4 @@ export * from './user.model';
 export * from './profile.model';
 export * from './travel.model';
 export * from './shop.model';
+export * from './inventory.model';

--- a/web/frontend/src/app/core/models/inventory.model.ts
+++ b/web/frontend/src/app/core/models/inventory.model.ts
@@ -1,0 +1,24 @@
+export type InventoryItemType = 'background' | 'badge';
+
+export interface InventoryItem {
+  item_id: string;
+  item_type: InventoryItemType;
+  name: string;
+  description: string | null;
+  emoji: string | null;
+  equipped: boolean;
+  slot: number | null;
+  purchased_at: string;
+}
+
+export interface InventoryResponse {
+  items: InventoryItem[];
+  equipped_background: string | null;
+  equipped_badges: Record<number, string>;
+  user_coins: number;
+}
+
+export interface UnequipResponse {
+  success: boolean;
+  message: string;
+}

--- a/web/frontend/src/app/core/services/index.ts
+++ b/web/frontend/src/app/core/services/index.ts
@@ -3,3 +3,4 @@ export * from './auth-storage.service';
 export * from './profile.service';
 export * from './travel.service';
 export * from './shop.service';
+export * from './inventory.service';

--- a/web/frontend/src/app/core/services/inventory.service.ts
+++ b/web/frontend/src/app/core/services/inventory.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import type { InventoryResponse, UnequipResponse } from '../models/inventory.model';
+import type { EquipResponse } from '../models/shop.model';
+
+@Injectable({ providedIn: 'root' })
+export class InventoryService {
+  private readonly http = inject(HttpClient);
+  private readonly base = environment.apiUrl;
+
+  getInventory(): Observable<InventoryResponse> {
+    return this.http.get<InventoryResponse>(`${this.base}/api/inventory`);
+  }
+
+  equipBackground(itemId: string): Observable<EquipResponse> {
+    return this.http.post<EquipResponse>(`${this.base}/api/profile/equip/background`, { item_id: itemId });
+  }
+
+  equipBadge(badgeId: string, slot: number): Observable<EquipResponse> {
+    return this.http.post<EquipResponse>(`${this.base}/api/profile/equip/badge`, { badge_id: badgeId, slot });
+  }
+
+  unequipBadge(slot: number): Observable<UnequipResponse> {
+    return this.http.post<UnequipResponse>(`${this.base}/api/profile/unequip/badge`, { slot });
+  }
+}

--- a/web/frontend/src/app/features/inventory/inventory.component.html
+++ b/web/frontend/src/app/features/inventory/inventory.component.html
@@ -1,0 +1,171 @@
+<div class="inventory-page">
+
+  <!-- Header -->
+  <div class="inventory-header container">
+    <div class="inventory-header__content">
+      <span class="section-label">INVENTAIRE</span>
+      <h1>Mon Inventaire</h1>
+      <p class="subtitle">Gérez vos backgrounds et badges équipés</p>
+    </div>
+    <div class="inventory-header__balance">
+      <span>💰</span>
+      <span class="balance-value">{{ userCoins() }}</span>
+      <span class="balance-unit">MC</span>
+    </div>
+  </div>
+
+  <!-- Notification -->
+  @if (notification(); as notif) {
+    <div class="notification container" [class.notification--success]="notif.type === 'success'" [class.notification--error]="notif.type === 'error'">
+      <span>{{ notif.type === 'success' ? '✅' : '❌' }}</span>
+      <span>{{ notif.message }}</span>
+    </div>
+  }
+
+  <!-- Loading -->
+  @if (isLoading()) {
+    <div class="inventory-state">
+      <div class="loading"></div>
+      <p>Chargement de l'inventaire…</p>
+    </div>
+  }
+
+  <!-- Error -->
+  @else if (hasError()) {
+    <div class="inventory-state inventory-state--error">
+      <span>⚠️</span>
+      <p>Impossible de charger l'inventaire.</p>
+      <button class="btn btn-primary btn--sm" (click)="load()">Réessayer</button>
+    </div>
+  }
+
+  @else if (items().length === 0) {
+    <div class="inventory-state container">
+      <span style="font-size:3rem">🎒</span>
+      <p>Votre inventaire est vide.</p>
+      <a class="btn-primary" href="/shop">Visiter la boutique</a>
+    </div>
+  }
+
+  @else {
+    <!-- Onglets -->
+    <div class="inventory-tabs container">
+      <button class="tab-btn" [class.tab-btn--active]="activeTab() === 'background'" (click)="activeTab.set('background')">
+        🖼️ Backgrounds <span class="tab-count">{{ backgrounds().length }}</span>
+      </button>
+      <button class="tab-btn" [class.tab-btn--active]="activeTab() === 'badge'" (click)="activeTab.set('badge')">
+        🏅 Badges <span class="tab-count">{{ badges().length }}</span>
+      </button>
+    </div>
+
+    <!-- ===== TAB BACKGROUNDS ===== -->
+    @if (activeTab() === 'background') {
+      @if (backgrounds().length === 0) {
+        <div class="inventory-state container">
+          <span style="font-size:2.5rem">🖼️</span>
+          <p>Aucun background dans l'inventaire.</p>
+        </div>
+      } @else {
+        <div class="items-grid container">
+          @for (item of backgrounds(); track item.item_id) {
+            <div class="item-card" [class.item-card--equipped]="item.equipped">
+
+              <div class="item-card__header item-card__header--bg">
+                <span class="item-emoji">{{ getEmoji(item) }}</span>
+                @if (item.equipped) {
+                  <span class="item-tag item-tag--equipped">⭐ Équipé</span>
+                }
+              </div>
+
+              <div class="item-card__body">
+                <h3 class="item-name">{{ item.name }}</h3>
+                @if (item.description) {
+                  <p class="item-desc">{{ item.description }}</p>
+                }
+              </div>
+
+              <div class="item-card__footer">
+                @if (item.equipped) {
+                  <span class="item-status item-status--equipped">Actuellement équipé</span>
+                } @else {
+                  <button class="btn-equip" (click)="equipBg(item)">Équiper</button>
+                }
+              </div>
+
+            </div>
+          }
+        </div>
+      }
+    }
+
+    <!-- ===== TAB BADGES ===== -->
+    @if (activeTab() === 'badge') {
+
+      <!-- Slots visuels -->
+      <div class="badge-slots-section container">
+        <h2 class="section-title">Slots équipés</h2>
+        <div class="badge-slots-visual">
+          @for (slot of slots; track slot) {
+            <div class="badge-slot-card" [class.badge-slot-card--filled]="getBadgeInSlot(slot)">
+              @if (getBadgeInSlot(slot); as badge) {
+                <span class="slot-emoji">{{ getEmoji(badge) }}</span>
+                <span class="slot-name">{{ badge.name }}</span>
+                <button class="slot-unequip" (click)="unequipBadge(slot)" title="Déséquiper">✕</button>
+              } @else {
+                <span class="slot-empty">{{ slot + 1 }}</span>
+                <span class="slot-label">Vide</span>
+              }
+            </div>
+          }
+        </div>
+      </div>
+
+      <!-- Liste badges possédés -->
+      @if (badges().length === 0) {
+        <div class="inventory-state container">
+          <span style="font-size:2.5rem">🏅</span>
+          <p>Aucun badge dans l'inventaire.</p>
+        </div>
+      } @else {
+        <div class="section-title container">Mes badges</div>
+        <div class="items-grid container">
+          @for (item of badges(); track item.item_id) {
+            <div class="item-card" [class.item-card--equipped]="item.equipped">
+
+              <div class="item-card__header item-card__header--badge">
+                <span class="item-emoji">{{ getEmoji(item) }}</span>
+                @if (item.equipped) {
+                  <span class="item-tag item-tag--equipped">⭐ Slot {{ (item.slot ?? 0) + 1 }}</span>
+                }
+              </div>
+
+              <div class="item-card__body">
+                <h3 class="item-name">{{ item.name }}</h3>
+                @if (item.description) {
+                  <p class="item-desc">{{ item.description }}</p>
+                }
+              </div>
+
+              <div class="item-card__footer">
+                @if (item.equipped) {
+                  <button class="btn-unequip" (click)="unequipBadge(item.slot!)">Déséquiper</button>
+                } @else {
+                  <div class="badge-equip-slots">
+                    <span class="badge-equip-label">Slot :</span>
+                    @for (slot of slots; track slot) {
+                      <button class="slot-btn" [class.slot-btn--taken]="!!getBadgeInSlot(slot)" [title]="getBadgeInSlot(slot) ? 'Remplace ' + getBadgeInSlot(slot)!.name : 'Slot ' + (slot + 1)" (click)="equipBadge(item, slot)">
+                        {{ slot + 1 }}
+                      </button>
+                    }
+                  </div>
+                }
+              </div>
+
+            </div>
+          }
+        </div>
+      }
+    }
+  }
+
+</div>

--- a/web/frontend/src/app/features/inventory/inventory.component.scss
+++ b/web/frontend/src/app/features/inventory/inventory.component.scss
@@ -1,0 +1,418 @@
+.inventory-page {
+  min-height: calc(100vh - 68px);
+  padding: var(--spacing-xl) 0 var(--spacing-2xl);
+}
+
+/* ===== HEADER ===== */
+.inventory-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  &__content {
+    .section-label {
+      display: inline-block;
+      font-family: var(--font-heading);
+      font-size: 0.75rem;
+      letter-spacing: 0.2em;
+      color: var(--color-accent);
+      margin-bottom: 0.25rem;
+    }
+
+    h1 { margin: 0; line-height: 1; }
+    .subtitle { margin: 0.4rem 0 0; font-size: 0.95rem; }
+  }
+
+  &__balance {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(212, 175, 55, 0.08);
+    border: 1px solid rgba(212, 175, 55, 0.35);
+    border-radius: var(--radius-md);
+    padding: 0.6rem 1.2rem;
+    flex-shrink: 0;
+
+    .balance-value {
+      font-family: var(--font-heading);
+      font-size: 1.6rem;
+      color: var(--color-gold);
+    }
+
+    .balance-unit {
+      font-size: 0.8rem;
+      color: rgba(212, 175, 55, 0.7);
+      font-weight: 600;
+      letter-spacing: 0.05em;
+    }
+  }
+}
+
+/* ===== NOTIFICATION ===== */
+.notification {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1.25rem;
+  border-radius: var(--radius-md);
+  margin-bottom: var(--spacing-md);
+  font-size: 0.95rem;
+  font-weight: 500;
+  animation: fadeInDown 0.3s ease;
+
+  &--success {
+    background: rgba(34, 197, 94, 0.1);
+    border: 1px solid rgba(34, 197, 94, 0.3);
+    color: #4ade80;
+  }
+
+  &--error {
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    color: #f87171;
+  }
+}
+
+/* ===== STATES ===== */
+.inventory-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 30vh;
+  gap: var(--spacing-md);
+  color: var(--color-text-dim);
+  text-align: center;
+
+  &--error { color: #f87171; }
+}
+
+/* ===== TABS ===== */
+.inventory-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: var(--spacing-lg);
+}
+
+.tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.25rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-md);
+  color: var(--color-text-dim);
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: all var(--transition-fast);
+
+  &:hover:not(.tab-btn--active) {
+    border-color: rgba(255, 107, 53, 0.3);
+    color: var(--color-text);
+  }
+
+  &--active {
+    background: rgba(255, 107, 53, 0.12);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+    font-weight: 600;
+  }
+}
+
+.tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  background: rgba(255, 107, 53, 0.15);
+  border-radius: var(--radius-full);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+/* ===== SECTION TITLE ===== */
+.section-title {
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  color: var(--color-text-dim);
+  margin-bottom: var(--spacing-md);
+  padding-bottom: var(--spacing-sm);
+  border-bottom: 1px solid rgba(255, 107, 53, 0.1);
+}
+
+/* ===== BADGE SLOTS VISUAL ===== */
+.badge-slots-section {
+  margin-bottom: var(--spacing-xl);
+}
+
+.badge-slots-visual {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--spacing-sm);
+
+  @media (max-width: 768px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media (max-width: 480px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.badge-slot-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 1rem 0.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px dashed rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-md);
+  min-height: 110px;
+  transition: all var(--transition-fast);
+  text-align: center;
+
+  &--filled {
+    background: rgba(255, 107, 53, 0.06);
+    border-style: solid;
+    border-color: rgba(255, 107, 53, 0.3);
+  }
+}
+
+.slot-emoji {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.slot-name {
+  font-size: 0.72rem;
+  color: var(--color-text-dim);
+  line-height: 1.3;
+}
+
+.slot-empty {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  color: rgba(255, 255, 255, 0.15);
+}
+
+.slot-label {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.2);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.slot-unequip {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.35rem;
+  width: 20px;
+  height: 20px;
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 50%;
+  color: #f87171;
+  font-size: 0.65rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    background: rgba(239, 68, 68, 0.3);
+    border-color: #ef4444;
+  }
+}
+
+/* ===== ITEMS GRID ===== */
+.items-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+
+  @media (max-width: 600px) {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: var(--spacing-sm);
+  }
+}
+
+/* ===== ITEM CARD ===== */
+.item-card {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(135deg, rgba(26, 26, 37, 0.7), rgba(20, 20, 30, 0.5));
+  border: 1px solid rgba(255, 107, 53, 0.1);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: transform var(--transition-fast), border-color var(--transition-fast);
+
+  &:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 107, 53, 0.3);
+  }
+
+  &--equipped {
+    border-color: rgba(255, 107, 53, 0.5);
+    box-shadow: 0 0 16px rgba(255, 107, 53, 0.15);
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100px;
+    position: relative;
+
+    &--bg { background: linear-gradient(135deg, rgba(99, 102, 241, 0.25), rgba(168, 85, 247, 0.2)); }
+    &--badge { background: linear-gradient(135deg, rgba(255, 107, 53, 0.2), rgba(247, 147, 30, 0.15)); }
+  }
+
+  &__body {
+    padding: 0.875rem 1rem 0.5rem;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  &__footer {
+    padding: 0.75rem 1rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+}
+
+.item-emoji {
+  font-size: 2.8rem;
+  line-height: 1;
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.5));
+}
+
+.item-tag {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-full);
+
+  &--equipped {
+    background: rgba(255, 107, 53, 0.2);
+    border: 1px solid rgba(255, 107, 53, 0.5);
+    color: var(--color-accent);
+  }
+}
+
+.item-name {
+  font-size: 1rem;
+  margin: 0;
+  color: var(--color-text);
+}
+
+.item-desc {
+  font-size: 0.8rem;
+  color: var(--color-text-dim);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.item-status {
+  font-size: 0.8rem;
+  color: var(--color-text-darker);
+
+  &--equipped {
+    color: var(--color-accent);
+    font-weight: 600;
+  }
+}
+
+/* ===== BUTTONS ===== */
+.btn-equip {
+  padding: 0.4rem 0.9rem;
+  background: rgba(212, 175, 55, 0.1);
+  color: var(--color-gold);
+  border: 1px solid rgba(212, 175, 55, 0.35);
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    background: rgba(212, 175, 55, 0.2);
+    border-color: var(--color-gold);
+  }
+}
+
+.btn-unequip {
+  padding: 0.4rem 0.9rem;
+  background: rgba(239, 68, 68, 0.08);
+  color: #f87171;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    background: rgba(239, 68, 68, 0.18);
+    border-color: #ef4444;
+  }
+}
+
+.badge-equip-slots {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.badge-equip-label {
+  font-size: 0.75rem;
+  color: var(--color-text-dim);
+}
+
+.slot-btn {
+  width: 28px;
+  height: 28px;
+  background: rgba(255, 107, 53, 0.08);
+  border: 1px solid rgba(255, 107, 53, 0.2);
+  border-radius: var(--radius-sm);
+  color: var(--color-accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover { background: rgba(255, 107, 53, 0.2); border-color: var(--color-accent); }
+
+  &--taken {
+    background: rgba(239, 68, 68, 0.08);
+    border-color: rgba(239, 68, 68, 0.25);
+    color: #f87171;
+
+    &:hover { background: rgba(239, 68, 68, 0.18); border-color: #ef4444; }
+  }
+}

--- a/web/frontend/src/app/features/inventory/inventory.component.ts
+++ b/web/frontend/src/app/features/inventory/inventory.component.ts
@@ -1,0 +1,111 @@
+import { Component, OnInit, signal, computed, inject, ChangeDetectionStrategy } from '@angular/core';
+import { InventoryService } from '../../core/services/inventory.service';
+import type { InventoryItem } from '../../core/models/inventory.model';
+
+@Component({
+  selector: 'app-inventory',
+  standalone: true,
+  imports: [],
+  templateUrl: './inventory.component.html',
+  styleUrl: './inventory.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InventoryComponent implements OnInit {
+  private readonly inventoryService = inject(InventoryService);
+
+  readonly items = signal<InventoryItem[]>([]);
+  readonly equippedBackground = signal<string | null>(null);
+  readonly equippedBadges = signal<Record<number, string>>({});
+  readonly userCoins = signal(0);
+  readonly isLoading = signal(true);
+  readonly hasError = signal(false);
+  readonly notification = signal<{ type: 'success' | 'error'; message: string } | null>(null);
+  readonly activeTab = signal<'background' | 'badge'>('background');
+
+  readonly backgrounds = computed(() => this.items().filter(i => i.item_type === 'background'));
+  readonly badges = computed(() => this.items().filter(i => i.item_type === 'badge'));
+  readonly slots = [0, 1, 2, 3, 4, 5];
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading.set(true);
+    this.hasError.set(false);
+    this.inventoryService.getInventory().subscribe({
+      next: ({ items, equipped_background, equipped_badges, user_coins }) => {
+        this.items.set(items);
+        this.equippedBackground.set(equipped_background);
+        this.equippedBadges.set(equipped_badges);
+        this.userCoins.set(user_coins);
+        this.isLoading.set(false);
+      },
+      error: () => {
+        this.hasError.set(true);
+        this.isLoading.set(false);
+      },
+    });
+  }
+
+  equipBg(item: InventoryItem): void {
+    if (item.equipped) return;
+    this.inventoryService.equipBackground(item.item_id).subscribe({
+      next: ({ message }) => {
+        this.equippedBackground.set(item.item_id);
+        this.items.update(list => list.map(i => ({
+          ...i,
+          equipped: i.item_type === 'background' ? i.item_id === item.item_id : i.equipped,
+        })));
+        this.notify('success', message);
+      },
+      error: (err) => this.notify('error', err.error?.message ?? 'Erreur'),
+    });
+  }
+
+  equipBadge(item: InventoryItem, slot: number): void {
+    this.inventoryService.equipBadge(item.item_id, slot).subscribe({
+      next: ({ message }) => {
+        const badges = { ...this.equippedBadges(), [slot]: item.item_id };
+        this.equippedBadges.set(badges);
+        this.items.update(list => list.map(i => {
+          if (i.item_type !== 'badge') return i;
+          if (i.item_id === item.item_id) return { ...i, equipped: true, slot };
+          if (i.slot === slot) return { ...i, equipped: false, slot: null };
+          return i;
+        }));
+        this.notify('success', message);
+      },
+      error: (err) => this.notify('error', err.error?.message ?? 'Erreur'),
+    });
+  }
+
+  unequipBadge(slot: number): void {
+    this.inventoryService.unequipBadge(slot).subscribe({
+      next: ({ message }) => {
+        const badges = { ...this.equippedBadges() };
+        delete badges[slot];
+        this.equippedBadges.set(badges);
+        this.items.update(list => list.map(i =>
+          i.item_type === 'badge' && i.slot === slot ? { ...i, equipped: false, slot: null } : i
+        ));
+        this.notify('success', message);
+      },
+      error: (err) => this.notify('error', err.error?.message ?? 'Erreur'),
+    });
+  }
+
+  getBadgeInSlot(slot: number): InventoryItem | undefined {
+    const id = this.equippedBadges()[slot];
+    return id ? this.badges().find(b => b.item_id === id) : undefined;
+  }
+
+  getEmoji(item: InventoryItem): string {
+    return item.emoji ?? (item.item_type === 'background' ? '🖼️' : '🏅');
+  }
+
+  private notify(type: 'success' | 'error', message: string): void {
+    this.notification.set({ type, message });
+    setTimeout(() => this.notification.set(null), 4000);
+  }
+}

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -13,9 +13,10 @@
     <!-- Nav desktop -->
     <nav class="site-header__nav" aria-label="Navigation principale">
       @if (auth.isAuthenticated()) {
-        <a routerLink="/map"   routerLinkActive="active"><span aria-hidden="true">🗺️</span> Carte</a>
-        <a routerLink="/shop"  routerLinkActive="active"><span aria-hidden="true">🛒</span> Boutique</a>
-        <a routerLink="/stats" routerLinkActive="active"><span aria-hidden="true">📊</span> Stats</a>
+        <a routerLink="/map"       routerLinkActive="active"><span aria-hidden="true">🗺️</span> Carte</a>
+        <a routerLink="/shop"      routerLinkActive="active"><span aria-hidden="true">🛒</span> Boutique</a>
+        <a routerLink="/inventory" routerLinkActive="active"><span aria-hidden="true">🎒</span> Inventaire</a>
+        <a routerLink="/stats"     routerLinkActive="active"><span aria-hidden="true">📊</span> Stats</a>
       }
       <a routerLink="/leaderboard" routerLinkActive="active"><span aria-hidden="true">🏆</span> Classement</a>
       <a routerLink="/commands"    routerLinkActive="active"><span aria-hidden="true">📜</span> Commandes</a>
@@ -76,6 +77,7 @@
       @if (auth.isAuthenticated()) {
         <a routerLink="/map"       routerLinkActive="active" (click)="closeMobileMenu()">🗺️ Carte</a>
         <a routerLink="/shop"      routerLinkActive="active" (click)="closeMobileMenu()">🛒 Boutique</a>
+        <a routerLink="/inventory" routerLinkActive="active" (click)="closeMobileMenu()">🎒 Inventaire</a>
         <a routerLink="/stats"     routerLinkActive="active" (click)="closeMobileMenu()">📊 Stats</a>
         <a routerLink="/profile"   routerLinkActive="active" (click)="closeMobileMenu()">👤 Mon profil</a>
         <a routerLink="/dashboard" routerLinkActive="active" (click)="closeMobileMenu()">🏠 Dashboard</a>


### PR DESCRIPTION
## Résumé

- Modèles TypeScript : `InventoryItem`, `InventoryResponse`, `UnequipResponse`
- `InventoryService` : `GET /api/inventory`, equip background, equip/unequip badge
- `InventoryComponent` Angular 21 (signals, OnPush) :
  - Onglets **Backgrounds** / **Badges**
  - Grille visuelle des **6 slots** de badges avec bouton déséquiper par slot
  - Équipement background (bouton "Équiper", statut "Actuellement équipé")
  - Équipement badge avec sélection de slot (slots occupés mis en évidence en rouge)
  - Déséquipement direct depuis la carte badge ou depuis les slots visuels
  - Toast de notification succès/erreur
- Route `/inventory` avec `authGuard`
- Lien 🎒 Inventaire dans la nav desktop + mobile
- Barrel exports `models/index.ts` et `services/index.ts` mis à jour
- Inclut le backend `InventoryController` (cherry-pick de SU #70)

## Plan de test

- [ ] `/inventory` → affiche les items achetés en boutique
- [ ] Onglet Backgrounds → équiper un background → statut "Actuellement équipé"
- [ ] Onglet Badges → slot visuel mis à jour après équipement
- [ ] Slot occupé affiché en rouge dans les boutons de slot
- [ ] Bouton ✕ sur un slot → déséquipe le badge
- [ ] Déséquiper depuis la carte badge → slot libéré
- [ ] Inventaire vide → message + lien vers boutique

Closes #70
Closes #71