### PR TITLE
feat(leaderboard): affichage paginé du classement MazCoins (SU #81 & #82)

### DIFF
--- a/web/frontend/src/app/core/models/index.ts
+++ b/web/frontend/src/app/core/models/index.ts
@@ -3,3 +3,4 @@ export * from './profile.model';
 export * from './travel.model';
 export * from './shop.model';
 export * from './inventory.model';
+export * from './leaderboard.model';

--- a/web/frontend/src/app/core/models/leaderboard.model.ts
+++ b/web/frontend/src/app/core/models/leaderboard.model.ts
@@ -1,0 +1,17 @@
+export interface LeaderboardEntry {
+  rank: number;
+  discord_id: string;
+  username: string;
+  avatar: string | null;
+  coins: number;
+}
+
+export interface LeaderboardResponse {
+  entries: LeaderboardEntry[];
+  total: number;
+  page: number;
+  limit: number;
+  user_rank?: number;
+}
+
+export type LeaderboardCategory = 'coins';

--- a/web/frontend/src/app/core/services/index.ts
+++ b/web/frontend/src/app/core/services/index.ts
@@ -4,3 +4,4 @@ export * from './profile.service';
 export * from './travel.service';
 export * from './shop.service';
 export * from './inventory.service';
+export * from './leaderboard.service';

--- a/web/frontend/src/app/core/services/leaderboard.service.ts
+++ b/web/frontend/src/app/core/services/leaderboard.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import type { LeaderboardResponse, LeaderboardCategory } from '../models/leaderboard.model';
+
+@Injectable({ providedIn: 'root' })
+export class LeaderboardService {
+  private readonly http = inject(HttpClient);
+  private readonly base = environment.apiUrl;
+
+  getLeaderboard(
+    category: LeaderboardCategory = 'coins',
+    page: number = 1,
+    limit: number = 20
+  ): Observable<LeaderboardResponse> {
+    const params = new HttpParams()
+      .set('page', page)
+      .set('limit', limit);
+    return this.http.get<LeaderboardResponse>(`${this.base}/api/leaderboard`, { params });
+  }
+
+  getMyRank(): Observable<{ rank: number }> {
+    return this.http.get<{ rank: number }>(`${this.base}/api/leaderboard/me`);
+  }
+}

--- a/web/frontend/src/app/features/leaderboard/leaderboard.component.html
+++ b/web/frontend/src/app/features/leaderboard/leaderboard.component.html
@@ -1,3 +1,76 @@
-<div class="container">
-  <h2>Classement — à venir</h2>
+<div class="leaderboard-page">
+
+  <!-- Header -->
+  <div class="leaderboard-header container">
+    <div class="leaderboard-header__content">
+      <span class="section-label">CLASSEMENT</span>
+      <h1>Classement MazCoins</h1>
+      <p class="subtitle">Les meilleurs joueurs du serveur</p>
+    </div>
+    @if (userRank() !== null) {
+      <div class="leaderboard-header__rank">
+        <span class="rank-label">Votre rang</span>
+        <span class="rank-value">{{ getRankEmoji(userRank()!) }}</span>
+      </div>
+    }
+  </div>
+
+  <!-- Loading -->
+  @if (isLoading()) {
+    <div class="leaderboard-state container">
+      <div class="loading"></div>
+      <p>Chargement du classement…</p>
+    </div>
+  }
+
+  <!-- Error -->
+  @else if (hasError()) {
+    <div class="leaderboard-state leaderboard-state--error container">
+      <span>⚠️</span>
+      <p>Impossible de charger le classement.</p>
+      <button class="btn btn-primary btn--sm" (click)="load()">Réessayer</button>
+    </div>
+  }
+
+  <!-- Empty -->
+  @else if (entries().length === 0) {
+    <div class="leaderboard-state container">
+      <span style="font-size:3rem">📊</span>
+      <p>Aucun joueur dans le classement pour le moment.</p>
+    </div>
+  }
+
+  @else {
+    <!-- Table -->
+    <div class="leaderboard-table container">
+      <div class="table-head">
+        <span class="col-rank">Rang</span>
+        <span class="col-player">Joueur</span>
+        <span class="col-coins">🪙 MazCoins</span>
+      </div>
+
+      @for (entry of entries(); track entry.discord_id) {
+        <div class="table-row" [class]="getRankClass(entry.rank)">
+          <span class="col-rank">
+            <span class="rank-badge">{{ getRankEmoji(entry.rank) }}</span>
+          </span>
+          <span class="col-player">
+            <img [src]="getAvatarUrl(entry)" [alt]="entry.username" class="player-avatar" width="40" height="40">
+            <span class="player-name">{{ entry.username }}</span>
+          </span>
+          <span class="col-coins">{{ entry.coins.toLocaleString() }}</span>
+        </div>
+      }
+    </div>
+
+    <!-- Pagination -->
+    @if (totalPages() > 1) {
+      <div class="pagination container">
+        <button class="page-btn" [disabled]="!hasPrev()" (click)="prevPage()">← Précédent</button>
+        <span class="page-info">Page {{ currentPage() }} / {{ totalPages() }}</span>
+        <button class="page-btn" [disabled]="!hasNext()" (click)="nextPage()">Suivant →</button>
+      </div>
+    }
+  }
+
 </div>

--- a/web/frontend/src/app/features/leaderboard/leaderboard.component.scss
+++ b/web/frontend/src/app/features/leaderboard/leaderboard.component.scss
@@ -1,0 +1,224 @@
+.leaderboard-page {
+  min-height: calc(100vh - 68px);
+  padding: var(--spacing-xl) 0 var(--spacing-2xl);
+}
+
+/* ===== HEADER ===== */
+.leaderboard-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-xl);
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  &__content {
+    .section-label {
+      display: inline-block;
+      font-family: var(--font-heading);
+      font-size: 0.75rem;
+      letter-spacing: 0.2em;
+      color: var(--color-accent);
+      margin-bottom: 0.25rem;
+    }
+
+    h1 { margin: 0; line-height: 1; }
+    .subtitle { margin: 0.4rem 0 0; font-size: 0.95rem; }
+  }
+
+  &__rank {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    background: rgba(212, 175, 55, 0.08);
+    border: 1px solid rgba(212, 175, 55, 0.35);
+    border-radius: var(--radius-md);
+    padding: 0.75rem 1.5rem;
+    flex-shrink: 0;
+
+    .rank-label {
+      font-size: 0.7rem;
+      color: rgba(212, 175, 55, 0.7);
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .rank-value {
+      font-family: var(--font-heading);
+      font-size: 1.8rem;
+      color: var(--color-gold);
+      line-height: 1;
+    }
+  }
+}
+
+/* ===== STATES ===== */
+.leaderboard-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 30vh;
+  gap: var(--spacing-md);
+  color: var(--color-text-dim);
+  text-align: center;
+
+  &--error { color: #f87171; }
+}
+
+/* ===== TABLE ===== */
+.leaderboard-table {
+  background: linear-gradient(135deg, rgba(26, 26, 37, 0.7), rgba(20, 20, 30, 0.5));
+  border: 1px solid rgba(255, 107, 53, 0.1);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  margin-bottom: var(--spacing-lg);
+}
+
+.table-head {
+  display: grid;
+  grid-template-columns: 100px 1fr 160px;
+  padding: 0.875rem 1.5rem;
+  background: rgba(255, 107, 53, 0.06);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  font-family: var(--font-heading);
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  color: var(--color-text-dim);
+  text-transform: uppercase;
+
+  @media (max-width: 600px) {
+    grid-template-columns: 72px 1fr 110px;
+    padding: 0.75rem 1rem;
+  }
+}
+
+.table-row {
+  display: grid;
+  grid-template-columns: 100px 1fr 160px;
+  padding: 1rem 1.5rem;
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  transition: background var(--transition-fast);
+
+  &:last-child { border-bottom: none; }
+
+  &:hover {
+    background: rgba(255, 107, 53, 0.04);
+  }
+
+  &.row--gold {
+    background: linear-gradient(90deg, rgba(212, 175, 55, 0.1) 0%, transparent 70%);
+    &:hover { background: linear-gradient(90deg, rgba(212, 175, 55, 0.15) 0%, transparent 70%); }
+
+    .rank-badge { font-size: 1.6rem; }
+  }
+
+  &.row--silver {
+    background: linear-gradient(90deg, rgba(192, 192, 192, 0.08) 0%, transparent 70%);
+    .rank-badge { font-size: 1.5rem; }
+  }
+
+  &.row--bronze {
+    background: linear-gradient(90deg, rgba(205, 127, 50, 0.08) 0%, transparent 70%);
+    .rank-badge { font-size: 1.4rem; }
+  }
+
+  @media (max-width: 600px) {
+    grid-template-columns: 72px 1fr 110px;
+    padding: 0.75rem 1rem;
+  }
+}
+
+.col-rank {
+  .rank-badge {
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: var(--color-text);
+  }
+}
+
+.col-player {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+}
+
+.player-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(255, 255, 255, 0.08);
+  flex-shrink: 0;
+
+  @media (max-width: 600px) {
+    width: 32px;
+    height: 32px;
+  }
+}
+
+.player-name {
+  font-weight: 600;
+  color: var(--color-text);
+  font-size: 1rem;
+
+  @media (max-width: 600px) {
+    font-size: 0.875rem;
+  }
+}
+
+.col-coins {
+  text-align: right;
+  font-family: var(--font-heading);
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--color-gold);
+
+  @media (max-width: 600px) {
+    font-size: 0.875rem;
+  }
+}
+
+/* ===== PAGINATION ===== */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-lg);
+
+  .page-info {
+    font-size: 0.9rem;
+    color: var(--color-text-dim);
+    min-width: 120px;
+    text-align: center;
+  }
+}
+
+.page-btn {
+  padding: 0.6rem 1.25rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: all var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 107, 53, 0.12);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+}

--- a/web/frontend/src/app/features/leaderboard/leaderboard.component.ts
+++ b/web/frontend/src/app/features/leaderboard/leaderboard.component.ts
@@ -1,9 +1,84 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, signal, computed, inject, ChangeDetectionStrategy } from '@angular/core';
+import { LeaderboardService } from '../../core/services/leaderboard.service';
+import type { LeaderboardEntry } from '../../core/models/leaderboard.model';
 
 @Component({
   selector: 'app-leaderboard',
   standalone: true,
+  imports: [],
   templateUrl: './leaderboard.component.html',
+  styleUrl: './leaderboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LeaderboardComponent {}
+export class LeaderboardComponent implements OnInit {
+  private readonly leaderboardService = inject(LeaderboardService);
+
+  readonly entries = signal<LeaderboardEntry[]>([]);
+  readonly isLoading = signal(true);
+  readonly hasError = signal(false);
+  readonly currentPage = signal(1);
+  readonly totalEntries = signal(0);
+  readonly userRank = signal<number | null>(null);
+
+  readonly limit = 20;
+
+  readonly totalPages = computed(() => Math.ceil(this.totalEntries() / this.limit));
+  readonly hasPrev = computed(() => this.currentPage() > 1);
+  readonly hasNext = computed(() => this.currentPage() < this.totalPages());
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading.set(true);
+    this.hasError.set(false);
+    this.leaderboardService.getLeaderboard('coins', this.currentPage(), this.limit).subscribe({
+      next: ({ entries, total, user_rank }) => {
+        this.entries.set(entries);
+        this.totalEntries.set(total);
+        if (user_rank != null) this.userRank.set(user_rank);
+        this.isLoading.set(false);
+      },
+      error: () => {
+        this.hasError.set(true);
+        this.isLoading.set(false);
+      },
+    });
+  }
+
+  prevPage(): void {
+    if (this.hasPrev()) {
+      this.currentPage.update(p => p - 1);
+      this.load();
+    }
+  }
+
+  nextPage(): void {
+    if (this.hasNext()) {
+      this.currentPage.update(p => p + 1);
+      this.load();
+    }
+  }
+
+  getRankEmoji(rank: number): string {
+    if (rank === 1) return '🥇';
+    if (rank === 2) return '🥈';
+    if (rank === 3) return '🥉';
+    return `#${rank}`;
+  }
+
+  getRankClass(rank: number): string {
+    if (rank === 1) return 'row--gold';
+    if (rank === 2) return 'row--silver';
+    if (rank === 3) return 'row--bronze';
+    return '';
+  }
+
+  getAvatarUrl(entry: LeaderboardEntry): string {
+    if (entry.avatar) {
+      return `https://cdn.discordapp.com/avatars/${entry.discord_id}/${entry.avatar}.png?size=64`;
+    }
+    return 'https://cdn.discordapp.com/embed/avatars/0.png';
+  }
+}


### PR DESCRIPTION
## Summary

- Modèle `LeaderboardEntry` / `LeaderboardResponse` dans `core/models/leaderboard.model.ts`
- Service `LeaderboardService` — GET `/api/leaderboard` (pagination) + `/api/leaderboard/me`
- Composant `LeaderboardComponent` avec signals Angular 21 : chargement paginé, rang utilisateur, podium or/argent/bronze
- Template et styles MazWorld design system (table grid, rank gradients, pagination)

Closes #81, #82