### PR TITLE
feat(stats+dashboard+home): statistiques admin, dashboard temps réel, UX home

### DIFF
--- a/web/backend/src/Controller/API/StatsController.php
+++ b/web/backend/src/Controller/API/StatsController.php
@@ -3,14 +3,15 @@
 namespace App\Controller\API;
 
 use App\Entity\ShopItem;
-use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/api/stats', name: 'api_stats_')]
+#[IsGranted('ROLE_ADMIN')]
 class StatsController extends AbstractController
 {
     public function __construct(

--- a/web/frontend/src/app/app.routes.ts
+++ b/web/frontend/src/app/app.routes.ts
@@ -1,5 +1,5 @@
 import { Routes } from '@angular/router';
-import { authGuard, guestGuard } from './core/guards/auth.guard';
+import { authGuard, guestGuard, adminGuard } from './core/guards/auth.guard';
 
 export const routes: Routes = [
   {
@@ -52,7 +52,7 @@ export const routes: Routes = [
     path: 'stats',
     loadComponent: () => import('./features/stats/stats.component').then(m => m.StatsComponent),
     title: 'Statistiques — MazWorld',
-    canActivate: [authGuard],
+    canActivate: [adminGuard],
   },
   {
     path: 'commands',

--- a/web/frontend/src/app/core/guards/auth.guard.ts
+++ b/web/frontend/src/app/core/guards/auth.guard.ts
@@ -15,3 +15,11 @@ export const guestGuard: CanActivateFn = () => {
   if (!auth.isAuthenticated()) return true;
   return inject(Router).createUrlTree(['/dashboard']);
 };
+
+export const adminGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  if (!auth.isAuthenticated()) return inject(Router).createUrlTree(['/']);
+  const roles = auth.currentUser()?.roles ?? [];
+  if (roles.includes('ROLE_ADMIN')) return true;
+  return inject(Router).createUrlTree(['/dashboard']);
+};

--- a/web/frontend/src/app/core/models/index.ts
+++ b/web/frontend/src/app/core/models/index.ts
@@ -4,3 +4,4 @@ export * from './travel.model';
 export * from './shop.model';
 export * from './inventory.model';
 export * from './leaderboard.model';
+export * from './stats.model';

--- a/web/frontend/src/app/core/models/stats.model.ts
+++ b/web/frontend/src/app/core/models/stats.model.ts
@@ -1,0 +1,19 @@
+export interface GlobalStats {
+  total_users: number;
+  total_cities: number;
+  total_coins_circulation: number;
+  active_users_today: number;
+  active_users_week: number;
+}
+
+export interface EconomyStats {
+  average_coins_per_user: number;
+  richest_user_coins: number;
+  total_shop_purchases: number;
+  most_popular_item: string;
+}
+
+export interface AllStatsResponse {
+  global: GlobalStats;
+  economy: EconomyStats;
+}

--- a/web/frontend/src/app/core/services/index.ts
+++ b/web/frontend/src/app/core/services/index.ts
@@ -5,3 +5,4 @@ export * from './travel.service';
 export * from './shop.service';
 export * from './inventory.service';
 export * from './leaderboard.service';
+export * from './stats.service';

--- a/web/frontend/src/app/core/services/stats.service.ts
+++ b/web/frontend/src/app/core/services/stats.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import type { AllStatsResponse } from '../models/stats.model';
+
+@Injectable({ providedIn: 'root' })
+export class StatsService {
+  private readonly http = inject(HttpClient);
+  private readonly base = environment.apiUrl;
+
+  getAllStats(): Observable<AllStatsResponse> {
+    return this.http.get<AllStatsResponse>(`${this.base}/api/stats`);
+  }
+}

--- a/web/frontend/src/app/features/dashboard/dashboard.component.html
+++ b/web/frontend/src/app/features/dashboard/dashboard.component.html
@@ -1,22 +1,33 @@
-@if (auth.currentUser(); as user) {
-  <div class="dashboard-page container">
+<div class="dashboard-page container">
 
+  <!-- Header profil -->
+  @if (profile(); as p) {
     <header class="dashboard-header">
-      <app-avatar [src]="auth.userAvatar()" [alt]="user.username" size="lg" />
+      <app-avatar [src]="auth.userAvatar()" [alt]="p.username" size="lg" />
       <div class="dashboard-header__info">
-        <span class="dashboard-header__name">{{ user.username }}</span>
-        <div class="dashboard-header__roles">
-          @for (role of user.roles; track role) {
-            <app-badge variant="info">{{ role }}</app-badge>
-          }
-        </div>
+        <span class="dashboard-header__name">{{ p.username }}</span>
+        @if (rank() !== null) {
+          <span class="dashboard-header__rank">Rang #{{ rank() }}</span>
+        }
       </div>
     </header>
 
     <section class="dashboard-stats">
-      <app-stat-card icon="🏙️" label="Ville actuelle" [value]="user.current_city" />
-      <app-stat-card icon="🪙" label="MazCoins" [value]="user.coins" variant="gold" />
+      <app-stat-card icon="🪙" label="MazCoins" [value]="p.coins.toLocaleString('fr-FR')" variant="gold" />
+      <app-stat-card icon="🏙️" label="Ville actuelle" [value]="p.current_city_name" />
+      <app-stat-card icon="🗺️" label="Villes visitées" [value]="p.visited_cities_count" />
+      <app-stat-card icon="🎒" label="Items en inventaire" [value]="p.inventory_count" />
     </section>
+  } @else if (isLoading()) {
+    <div class="dashboard-loading">
+      <div class="loading"></div>
+      <p>Chargement du tableau de bord…</p>
+    </div>
+  } @else {
+    <div class="dashboard-loading">
+      <span>⚠️</span>
+      <p>Impossible de charger les données.</p>
+    </div>
+  }
 
-  </div>
-}
+</div>

--- a/web/frontend/src/app/features/dashboard/dashboard.component.scss
+++ b/web/frontend/src/app/features/dashboard/dashboard.component.scss
@@ -1,7 +1,9 @@
 .dashboard-page {
-  padding: var(--spacing-xl) 0;
+  min-height: calc(100vh - 68px);
+  padding: var(--spacing-xl) 0 var(--spacing-2xl);
 }
 
+/* ===== HEADER ===== */
 .dashboard-header {
   display: flex;
   align-items: center;
@@ -11,7 +13,7 @@
   &__info {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: 0.35rem;
   }
 
   &__name {
@@ -21,15 +23,29 @@
     line-height: 1;
   }
 
-  &__roles {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
+  &__rank {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--color-gold);
+    letter-spacing: 0.05em;
   }
 }
 
+/* ===== STATS ===== */
 .dashboard-stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: var(--spacing-md);
+}
+
+/* ===== LOADING ===== */
+.dashboard-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 30vh;
+  gap: var(--spacing-md);
+  color: var(--color-text-dim);
+  text-align: center;
 }

--- a/web/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/web/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -1,17 +1,41 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, signal, inject, ChangeDetectionStrategy } from '@angular/core';
 import { AuthService } from '../../core/services/auth.service';
+import { ProfileService } from '../../core/services/profile.service';
+import { LeaderboardService } from '../../core/services/leaderboard.service';
 import { StatCardComponent } from '../../shared/components/ui/stat-card/stat-card.component';
-import { BadgeComponent } from '../../shared/components/ui/badge/badge.component';
 import { AvatarComponent } from '../../shared/components/ui/avatar/avatar.component';
+import { BadgeComponent } from '../../shared/components/ui/badge/badge.component';
+import type { UserProfile } from '../../core/models/profile.model';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [StatCardComponent, BadgeComponent, AvatarComponent],
+  imports: [StatCardComponent, AvatarComponent, BadgeComponent],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DashboardComponent {
+export class DashboardComponent implements OnInit {
   protected readonly auth = inject(AuthService);
+  private readonly profileService = inject(ProfileService);
+  private readonly leaderboardService = inject(LeaderboardService);
+
+  readonly profile = signal<UserProfile | null>(null);
+  readonly rank = signal<number | null>(null);
+  readonly isLoading = signal(true);
+
+  ngOnInit(): void {
+    this.profileService.getMyProfile().subscribe({
+      next: (p) => {
+        this.profile.set(p);
+        this.isLoading.set(false);
+      },
+      error: () => this.isLoading.set(false),
+    });
+
+    this.leaderboardService.getMyRank().subscribe({
+      next: ({ rank }) => this.rank.set(rank),
+      error: () => {},
+    });
+  }
 }

--- a/web/frontend/src/app/features/home/home.component.html
+++ b/web/frontend/src/app/features/home/home.component.html
@@ -1,15 +1,19 @@
 <main class="home-page">
 
-  <!-- Hero -->
+  <!-- ===== HERO ===== -->
   <section class="hero container">
     <div class="hero__content">
-      <p class="hero__eyebrow">Discord RPG</p>
+      <div class="hero__badge">
+        <span class="hero__badge-dot"></span>
+        Discord RPG · Version Alpha
+      </div>
       <h1 class="hero__title">
-        <span class="text-gradient">MazWorld</span>
+        <span class="hero__title-line">Voyageur aujourd'hui,</span>
+        <span class="hero__title-line hero__title-line--accent">Magnat demain.</span>
       </h1>
       <p class="hero__subtitle">
-        Voyagez de ville en ville, accumulez des MazCoins et gravissez le classement
-        au fil de vos aventures Discord.
+        Voyagez entre 6 villes, accumulez des MazCoins et gravissez
+        le classement au fil de vos aventures Discord.
       </p>
       <div class="hero__actions">
         @if (auth.isAuthenticated()) {
@@ -29,77 +33,87 @@
     <div class="hero__visual" aria-hidden="true">
       <div class="hero__orb hero__orb--1"></div>
       <div class="hero__orb hero__orb--2"></div>
-    </div>
-  </section>
-
-  <!-- Features -->
-  <section class="features container">
-    <div class="features__grid">
-      <div class="feature-card">
-        <span class="feature-card__icon">🗺️</span>
-        <h3>Carte interactive</h3>
-        <p>Voyagez entre les villes, découvrez de nouveaux territoires et construisez votre empire.</p>
-      </div>
-      <div class="feature-card">
-        <span class="feature-card__icon">🪙</span>
-        <h3>MazCoins</h3>
-        <p>Gagnez des MazCoins en interagissant sur Discord. Dépensez-les dans la boutique.</p>
-      </div>
-      <div class="feature-card">
-        <span class="feature-card__icon">🏆</span>
-        <h3>Classement</h3>
-        <p>Affrontez la communauté et hissez-vous en haut du classement mondial.</p>
-      </div>
-      <div class="feature-card">
-        <span class="feature-card__icon">🤖</span>
-        <h3>Bot Discord</h3>
-        <p>Invitez le bot sur votre serveur et jouez directement depuis Discord.</p>
+      <div class="hero__cities-float">
+        @for (city of cities; track city.id) {
+          <span class="float-city">{{ city.emoji }}</span>
+        }
       </div>
     </div>
   </section>
 
-  <!-- Villes -->
+  <div class="section-divider"></div>
+
+  <!-- ===== FEATURES ===== -->
+  <section class="features">
+    <div class="container">
+      <div class="features__header">
+        <span class="section-label">Fonctionnalités</span>
+        <h2>Tout ce qui vous attend</h2>
+      </div>
+      <div class="features__grid">
+        @for (f of features; track f.icon; let i = $index) {
+          <div class="feature-card">
+            <span class="feature-card__num">{{ (i + 1).toString().padStart(2, '0') }}</span>
+            <span class="feature-card__icon">{{ f.icon }}</span>
+            <h3>{{ f.title }}</h3>
+            <p>{{ f.desc }}</p>
+          </div>
+        }
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ===== DESTINATIONS ===== -->
   <section class="cities-section">
-    <div class="cities-section__header container">
-      <span class="section-label">DESTINATIONS</span>
-      <h2>6 villes vous attendent</h2>
-      <p class="subtitle">Chaque destination offre ses propres jobs, richesses et secrets à découvrir.</p>
-    </div>
-    <div class="cities-grid container">
-      @for (city of cities; track city.id) {
-        <div class="city-card">
-          <span class="city-card__emoji">{{ city.emoji }}</span>
-          <span class="city-card__name">{{ city.name }}</span>
-          <span class="city-card__theme">{{ city.theme }}</span>
-        </div>
-      }
-    </div>
-    <div class="cities-cta container">
-      <button class="btn-discord" (click)="login()">
-        <svg viewBox="0 0 71 55" fill="none" aria-hidden="true" width="18" height="18">
-          <path d="M60.1045 4.8978C55.5792 2.8214 50.7265 1.2916 45.6527 0.41542C45.5603 0.39851 45.468 0.440769 45.4204 0.525289C44.7963 1.6353 44.105 3.0834 43.6209 4.2216C38.1637 3.4046 32.7345 3.4046 27.3892 4.2216C26.905 3.0581 26.1886 1.6353 25.5617 0.525289C25.5141 0.443589 25.4218 0.40133 25.3294 0.41542C20.2584 1.2888 15.4057 2.8186 10.8776 4.8978C10.8384 4.9147 10.8048 4.9429 10.7825 4.9795C1.57795 18.7309 -0.943561 32.1443 0.293408 45.3914C0.299005 45.4562 0.335386 45.5182 0.385761 45.5576C6.45866 50.0174 12.3413 52.7249 18.1147 54.5195C18.2071 54.5477 18.305 54.5139 18.3638 54.4378C19.7295 52.5728 20.9469 50.6063 21.9907 48.5383C22.0523 48.4172 21.9935 48.2735 21.8676 48.2256C19.9366 47.4931 18.0979 46.6 16.3292 45.5858C16.1893 45.5041 16.1781 45.304 16.3068 45.2082C16.679 44.9293 17.0513 44.6391 17.4067 44.3461C17.471 44.2926 17.5606 44.2813 17.6362 44.3151C29.2558 49.6202 41.8354 49.6202 53.3179 44.3151C53.3935 44.2785 53.4831 44.2898 53.5502 44.3433C53.9057 44.6363 54.2779 44.9293 54.6529 45.2082C54.7816 45.304 54.7732 45.5041 54.6333 45.5858C52.8646 46.6197 51.0259 47.4931 49.0921 48.2228C48.9662 48.2707 48.9102 48.4172 48.9718 48.5383C50.038 50.6034 51.2554 52.5699 52.5959 54.435C52.6519 54.5139 52.7526 54.5477 52.845 54.5195C58.6464 52.7249 64.529 50.0174 70.6019 45.5576C70.6551 45.5182 70.6887 45.459 70.6943 45.3942C72.1747 30.0791 68.2147 16.7757 60.1968 4.9823C60.1772 4.9429 60.1437 4.9147 60.1045 4.8978ZM23.7259 37.3253C20.2276 37.3253 17.3451 34.1136 17.3451 30.1693C17.3451 26.225 20.1717 23.0133 23.7259 23.0133C27.308 23.0133 30.1626 26.2532 30.1066 30.1693C30.1066 34.1136 27.28 37.3253 23.7259 37.3253ZM47.3178 37.3253C43.8196 37.3253 40.9371 34.1136 40.9371 30.1693C40.9371 26.225 43.7636 23.0133 47.3178 23.0133C50.9 23.0133 53.7545 26.2532 53.6986 30.1693C53.6986 34.1136 50.9 37.3253 47.3178 37.3253Z" fill="currentColor"/>
-        </svg>
-        Connexion Discord pour explorer
-      </button>
+    <div class="container">
+      <div class="cities-section__header">
+        <span class="section-label">Destinations</span>
+        <h2>6 villes vous attendent</h2>
+        <p class="subtitle">Chaque destination offre ses propres jobs, richesses et secrets.</p>
+      </div>
+      <div class="cities-grid">
+        @for (city of cities; track city.id) {
+          <div class="city-card city-card--{{ city.id }}">
+            <span class="city-card__emoji">{{ city.emoji }}</span>
+            <span class="city-card__name">{{ city.name }}</span>
+            <span class="city-card__theme">{{ city.theme }}</span>
+          </div>
+        }
+      </div>
+      <div class="cities-cta">
+        <button class="btn-discord" (click)="login()">
+          <svg viewBox="0 0 71 55" fill="none" aria-hidden="true" width="18" height="18">
+            <path d="M60.1045 4.8978C55.5792 2.8214 50.7265 1.2916 45.6527 0.41542C45.5603 0.39851 45.468 0.440769 45.4204 0.525289C44.7963 1.6353 44.105 3.0834 43.6209 4.2216C38.1637 3.4046 32.7345 3.4046 27.3892 4.2216C26.905 3.0581 26.1886 1.6353 25.5617 0.525289C25.5141 0.443589 25.4218 0.40133 25.3294 0.41542C20.2584 1.2888 15.4057 2.8186 10.8776 4.8978C10.8384 4.9147 10.8048 4.9429 10.7825 4.9795C1.57795 18.7309 -0.943561 32.1443 0.293408 45.3914C0.299005 45.4562 0.335386 45.5182 0.385761 45.5576C6.45866 50.0174 12.3413 52.7249 18.1147 54.5195C18.2071 54.5477 18.305 54.5139 18.3638 54.4378C19.7295 52.5728 20.9469 50.6063 21.9907 48.5383C22.0523 48.4172 21.9935 48.2735 21.8676 48.2256C19.9366 47.4931 18.0979 46.6 16.3292 45.5858C16.1893 45.5041 16.1781 45.304 16.3068 45.2082C16.679 44.9293 17.0513 44.6391 17.4067 44.3461C17.471 44.2926 17.5606 44.2813 17.6362 44.3151C29.2558 49.6202 41.8354 49.6202 53.3179 44.3151C53.3935 44.2785 53.4831 44.2898 53.5502 44.3433C53.9057 44.6363 54.2779 44.9293 54.6529 45.2082C54.7816 45.304 54.7732 45.5041 54.6333 45.5858C52.8646 46.6197 51.0259 47.4931 49.0921 48.2228C48.9662 48.2707 48.9102 48.4172 48.9718 48.5383C50.038 50.6034 51.2554 52.5699 52.5959 54.435C52.6519 54.5139 52.7526 54.5477 52.845 54.5195C58.6464 52.7249 64.529 50.0174 70.6019 45.5576C70.6551 45.5182 70.6887 45.459 70.6943 45.3942C72.1747 30.0791 68.2147 16.7757 60.1968 4.9823C60.1772 4.9429 60.1437 4.9147 60.1045 4.8978ZM23.7259 37.3253C20.2276 37.3253 17.3451 34.1136 17.3451 30.1693C17.3451 26.225 20.1717 23.0133 23.7259 23.0133C27.308 23.0133 30.1626 26.2532 30.1066 30.1693C30.1066 34.1136 27.28 37.3253 23.7259 37.3253ZM47.3178 37.3253C43.8196 37.3253 40.9371 34.1136 40.9371 30.1693C40.9371 26.225 43.7636 23.0133 47.3178 23.0133C50.9 23.0133 53.7545 26.2532 53.6986 30.1693C53.6986 34.1136 50.9 37.3253 47.3178 37.3253Z" fill="currentColor"/>
+          </svg>
+          Rejoindre l'aventure
+        </button>
+      </div>
     </div>
   </section>
 
-  <!-- Économie -->
+  <div class="section-divider"></div>
+
+  <!-- ===== ÉCONOMIE ===== -->
   <section class="economy-section container">
     <div class="economy-section__header">
-      <span class="section-label">ÉCONOMIE</span>
-      <h2>Comment ça fonctionne</h2>
+      <span class="section-label">Comment ça marche</span>
+      <h2>Accumulez, voyagez, progressez.</h2>
     </div>
     <div class="economy-flow">
-      @for (step of economySteps; track step.emoji; let last = $last) {
+      @for (step of economySteps; track step.emoji; let i = $index; let last = $last) {
         <div class="flow-step">
-          <div class="flow-step__circle">{{ step.emoji }}</div>
+          <div class="flow-step__top">
+            <div class="flow-step__circle">
+              <span class="flow-step__num">{{ i + 1 }}</span>
+              {{ step.emoji }}
+            </div>
+            @if (!last) { <div class="flow-connector"></div> }
+          </div>
           <h3 class="flow-step__title">{{ step.title }}</h3>
           <p class="flow-step__desc">{{ step.desc }}</p>
         </div>
-        @if (!last) {
-          <span class="flow-arrow" aria-hidden="true">→</span>
-        }
       }
     </div>
   </section>

--- a/web/frontend/src/app/features/home/home.component.html
+++ b/web/frontend/src/app/features/home/home.component.html
@@ -58,4 +58,50 @@
     </div>
   </section>
 
+  <!-- Villes -->
+  <section class="cities-section">
+    <div class="cities-section__header container">
+      <span class="section-label">DESTINATIONS</span>
+      <h2>6 villes vous attendent</h2>
+      <p class="subtitle">Chaque destination offre ses propres jobs, richesses et secrets à découvrir.</p>
+    </div>
+    <div class="cities-grid container">
+      @for (city of cities; track city.id) {
+        <div class="city-card">
+          <span class="city-card__emoji">{{ city.emoji }}</span>
+          <span class="city-card__name">{{ city.name }}</span>
+          <span class="city-card__theme">{{ city.theme }}</span>
+        </div>
+      }
+    </div>
+    <div class="cities-cta container">
+      <button class="btn-discord" (click)="login()">
+        <svg viewBox="0 0 71 55" fill="none" aria-hidden="true" width="18" height="18">
+          <path d="M60.1045 4.8978C55.5792 2.8214 50.7265 1.2916 45.6527 0.41542C45.5603 0.39851 45.468 0.440769 45.4204 0.525289C44.7963 1.6353 44.105 3.0834 43.6209 4.2216C38.1637 3.4046 32.7345 3.4046 27.3892 4.2216C26.905 3.0581 26.1886 1.6353 25.5617 0.525289C25.5141 0.443589 25.4218 0.40133 25.3294 0.41542C20.2584 1.2888 15.4057 2.8186 10.8776 4.8978C10.8384 4.9147 10.8048 4.9429 10.7825 4.9795C1.57795 18.7309 -0.943561 32.1443 0.293408 45.3914C0.299005 45.4562 0.335386 45.5182 0.385761 45.5576C6.45866 50.0174 12.3413 52.7249 18.1147 54.5195C18.2071 54.5477 18.305 54.5139 18.3638 54.4378C19.7295 52.5728 20.9469 50.6063 21.9907 48.5383C22.0523 48.4172 21.9935 48.2735 21.8676 48.2256C19.9366 47.4931 18.0979 46.6 16.3292 45.5858C16.1893 45.5041 16.1781 45.304 16.3068 45.2082C16.679 44.9293 17.0513 44.6391 17.4067 44.3461C17.471 44.2926 17.5606 44.2813 17.6362 44.3151C29.2558 49.6202 41.8354 49.6202 53.3179 44.3151C53.3935 44.2785 53.4831 44.2898 53.5502 44.3433C53.9057 44.6363 54.2779 44.9293 54.6529 45.2082C54.7816 45.304 54.7732 45.5041 54.6333 45.5858C52.8646 46.6197 51.0259 47.4931 49.0921 48.2228C48.9662 48.2707 48.9102 48.4172 48.9718 48.5383C50.038 50.6034 51.2554 52.5699 52.5959 54.435C52.6519 54.5139 52.7526 54.5477 52.845 54.5195C58.6464 52.7249 64.529 50.0174 70.6019 45.5576C70.6551 45.5182 70.6887 45.459 70.6943 45.3942C72.1747 30.0791 68.2147 16.7757 60.1968 4.9823C60.1772 4.9429 60.1437 4.9147 60.1045 4.8978ZM23.7259 37.3253C20.2276 37.3253 17.3451 34.1136 17.3451 30.1693C17.3451 26.225 20.1717 23.0133 23.7259 23.0133C27.308 23.0133 30.1626 26.2532 30.1066 30.1693C30.1066 34.1136 27.28 37.3253 23.7259 37.3253ZM47.3178 37.3253C43.8196 37.3253 40.9371 34.1136 40.9371 30.1693C40.9371 26.225 43.7636 23.0133 47.3178 23.0133C50.9 23.0133 53.7545 26.2532 53.6986 30.1693C53.6986 34.1136 50.9 37.3253 47.3178 37.3253Z" fill="currentColor"/>
+        </svg>
+        Connexion Discord pour explorer
+      </button>
+    </div>
+  </section>
+
+  <!-- Économie -->
+  <section class="economy-section container">
+    <div class="economy-section__header">
+      <span class="section-label">ÉCONOMIE</span>
+      <h2>Comment ça fonctionne</h2>
+    </div>
+    <div class="economy-flow">
+      @for (step of economySteps; track step.emoji; let last = $last) {
+        <div class="flow-step">
+          <div class="flow-step__circle">{{ step.emoji }}</div>
+          <h3 class="flow-step__title">{{ step.title }}</h3>
+          <p class="flow-step__desc">{{ step.desc }}</p>
+        </div>
+        @if (!last) {
+          <span class="flow-arrow" aria-hidden="true">→</span>
+        }
+      }
+    </div>
+  </section>
+
 </main>

--- a/web/frontend/src/app/features/home/home.component.scss
+++ b/web/frontend/src/app/features/home/home.component.scss
@@ -128,6 +128,143 @@
   }
 }
 
+/* ===== SECTION LABELS PARTAGÉS ===== */
+.section-label {
+  display: inline-block;
+  font-family: var(--font-heading);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  color: var(--color-accent);
+  margin-bottom: 0.25rem;
+}
+
+/* ===== CITIES SECTION ===== */
+.cities-section {
+  padding: var(--spacing-2xl) 0 var(--spacing-xl);
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(255, 107, 53, 0.3), transparent);
+  }
+
+  &__header {
+    margin-bottom: var(--spacing-xl);
+    h2    { margin: 0; font-size: clamp(1.6rem, 4vw, 2.2rem); }
+    .subtitle { margin: 0.4rem 0 0; color: var(--color-text-dim); font-size: 0.95rem; }
+  }
+}
+
+.cities-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+
+  @media (max-width: 900px) { grid-template-columns: repeat(3, 1fr); }
+  @media (max-width: 500px) { grid-template-columns: repeat(2, 1fr); }
+}
+
+.city-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: var(--spacing-lg) var(--spacing-sm);
+  background: linear-gradient(135deg, rgba(26, 26, 37, 0.6), rgba(20, 20, 30, 0.4));
+  border: 1px solid rgba(255, 107, 53, 0.08);
+  border-radius: var(--radius-lg);
+  transition: all var(--transition-normal);
+  text-align: center;
+
+  &:hover {
+    border-color: rgba(255, 107, 53, 0.25);
+    transform: translateY(-3px);
+  }
+
+  &__emoji { font-size: 2.25rem; line-height: 1; }
+  &__name  { font-weight: 700; font-size: 0.9rem; color: var(--color-text); }
+  &__theme { font-size: 0.72rem; color: var(--color-accent); font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; }
+}
+
+.cities-cta {
+  display: flex;
+  justify-content: center;
+  padding-top: var(--spacing-md);
+  padding-bottom: var(--spacing-lg);
+}
+
+/* ===== ECONOMY SECTION ===== */
+.economy-section {
+  padding: var(--spacing-2xl) 0;
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(255, 107, 53, 0.2), transparent);
+  }
+
+  &__header {
+    margin-bottom: var(--spacing-xl);
+    h2 { margin: 0; font-size: clamp(1.6rem, 4vw, 2.2rem); }
+  }
+}
+
+.economy-flow {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-md);
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+.flow-step {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.75rem;
+
+  &__circle {
+    width: 72px;
+    height: 72px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    background: rgba(255, 107, 53, 0.07);
+    border: 1px solid rgba(255, 107, 53, 0.18);
+    border-radius: 50%;
+  }
+
+  &__title { font-family: var(--font-heading); font-size: 1.05rem; margin: 0; }
+  &__desc  { font-size: 0.85rem; color: var(--color-text-dim); line-height: 1.6; margin: 0; max-width: 180px; }
+}
+
+.flow-arrow {
+  font-size: 1.4rem;
+  color: rgba(255, 107, 53, 0.3);
+  margin-top: 22px;
+  flex-shrink: 0;
+
+  @media (max-width: 768px) { transform: rotate(90deg); margin: 0; }
+}
+
+/* ===== RESPONSIVE ===== */
 @media (max-width: 768px) {
   .hero {
     min-height: auto;

--- a/web/frontend/src/app/features/home/home.component.scss
+++ b/web/frontend/src/app/features/home/home.component.scss
@@ -1,276 +1,551 @@
+/* =====================================================
+   HOME PAGE — MazWorld
+   Dark RPG Discord identity, generous spacing
+   ===================================================== */
+
 .home-page {
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
-/* ===== HERO ===== */
+/* =====================================================
+   HERO
+   ===================================================== */
 .hero {
   position: relative;
   display: flex;
   align-items: center;
-  min-height: calc(100vh - 64px);
-  padding: var(--spacing-2xl) 0;
+  min-height: calc(100svh - 64px);
+  padding: 6rem 0 8rem;
+
+  /* Gradient fade that bleeds into the next section */
+  &::after {
+    content: '';
+    position: absolute;
+    inset-x: 0;
+    bottom: 0;
+    height: 220px;
+    background: linear-gradient(to bottom, transparent, #0d0d16);
+    pointer-events: none;
+  }
+
+  /* Subtle dot grid pattern overlay for texture */
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(rgba(255, 107, 53, 0.12) 1px, transparent 1px);
+    background-size: 40px 40px;
+    mask-image: radial-gradient(ellipse 80% 80% at 50% 50%, black 30%, transparent 100%);
+    opacity: 0.4;
+    pointer-events: none;
+  }
 
   &__content {
     position: relative;
     z-index: 1;
     max-width: 640px;
-    animation: fadeInUp 0.6s ease both;
+    animation: fadeInUp 0.8s ease both;
   }
 
-  &__eyebrow {
-    font-size: 0.85rem;
-    font-weight: 600;
-    letter-spacing: 0.15em;
-    text-transform: uppercase;
+  &__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1.1rem;
+    border: 1px solid rgba(255, 107, 53, 0.35);
+    border-radius: var(--radius-full);
+    background: rgba(255, 107, 53, 0.07);
+    backdrop-filter: blur(8px);
+    font-size: 0.78rem;
+    font-weight: 700;
     color: var(--color-accent);
-    margin-bottom: var(--spacing-sm);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 2rem;
+  }
+
+  &__badge-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    box-shadow: 0 0 8px var(--color-accent);
+    animation: pulse 2s ease-in-out infinite;
   }
 
   &__title {
-    font-size: clamp(3.5rem, 8vw, 6rem);
-    line-height: 1;
-    margin-bottom: var(--spacing-md);
+    display: flex;
+    flex-direction: column;
+    line-height: 1.05;
+    margin: 0 0 2rem;
+    font-family: var(--font-heading);
+
+    &-line       { display: block; font-size: clamp(2.2rem, 5vw, 4rem); color: rgba(255,255,255,0.85); }
+    &-line--accent {
+      font-size: clamp(3rem, 7.5vw, 6rem);
+      background: linear-gradient(135deg, var(--color-accent) 0%, var(--color-gold) 60%, #fff 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      filter: drop-shadow(0 0 30px rgba(255, 107, 53, 0.3));
+    }
   }
 
   &__subtitle {
-    font-size: 1.15rem;
-    color: var(--color-text-dim);
-    max-width: 500px;
-    margin-bottom: var(--spacing-xl);
-    line-height: 1.7;
+    font-size: 1.1rem;
+    color: rgba(255, 255, 255, 0.5);
+    max-width: 480px;
+    margin-bottom: 2.5rem;
+    line-height: 1.8;
+    font-weight: 400;
   }
 
   &__actions {
     display: flex;
-    gap: var(--spacing-sm);
+    gap: 1rem;
     flex-wrap: wrap;
   }
 
+  /* Decorative visual side */
   &__visual {
     position: absolute;
     inset: 0;
     pointer-events: none;
+    z-index: 0;
   }
 
   &__orb {
     position: absolute;
     border-radius: 50%;
-    filter: blur(80px);
-    opacity: 0.25;
+    filter: blur(100px);
 
     &--1 {
-      width: 500px;
-      height: 500px;
-      background: radial-gradient(circle, var(--color-accent), transparent 70%);
-      right: -100px;
+      width: 700px;
+      height: 700px;
+      background: radial-gradient(circle, rgba(255, 107, 53, 0.18), transparent 70%);
+      right: -180px;
       top: 50%;
       transform: translateY(-50%);
-      animation: pulse 6s ease-in-out infinite;
+      animation: pulse 8s ease-in-out infinite;
     }
 
     &--2 {
-      width: 300px;
-      height: 300px;
-      background: radial-gradient(circle, var(--color-accent-2), transparent 70%);
-      right: 200px;
+      width: 350px;
+      height: 350px;
+      background: radial-gradient(circle, rgba(247, 147, 30, 0.14), transparent 70%);
+      right: 120px;
       bottom: 10%;
-      animation: pulse 8s ease-in-out infinite 2s;
+      animation: pulse 10s ease-in-out infinite 3s;
     }
+  }
+
+  &__cities-float {
+    position: absolute;
+    right: 7%;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 360px;
+    height: 360px;
+  }
+
+  .float-city {
+    position: absolute;
+    font-size: 2.5rem;
+    filter: drop-shadow(0 0 14px rgba(255, 107, 53, 0.3));
+    opacity: 0.6;
+
+    &:nth-child(1) { top: 0;     left: 50%;   transform: translateX(-50%);  animation: floatBob 5s   ease-in-out infinite 0s;   }
+    &:nth-child(2) { top: 18%;   right: 0;                                   animation: floatBob 5.5s ease-in-out infinite 0.5s; }
+    &:nth-child(3) { bottom: 18%;right: 0;                                   animation: floatBob 6s   ease-in-out infinite 1s;   }
+    &:nth-child(4) { bottom: 0;  left: 50%;   transform: translateX(-50%);  animation: floatBob 5.2s ease-in-out infinite 1.5s; }
+    &:nth-child(5) { bottom: 18%;left: 0;                                    animation: floatBob 5.8s ease-in-out infinite 2s;   }
+    &:nth-child(6) { top: 18%;   left: 0;                                    animation: floatBob 6.2s ease-in-out infinite 2.5s; }
   }
 }
 
-/* ===== FEATURES ===== */
+@keyframes floatBob {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-12px); }
+}
+
+/* =====================================================
+   SECTION DIVIDER — ligne accent entre sections
+   ===================================================== */
+.section-divider {
+  width: 100%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 107, 53, 0.2) 30%, rgba(255, 107, 53, 0.2) 70%, transparent);
+  margin: 0;
+}
+
+/* =====================================================
+   FEATURES
+   ===================================================== */
 .features {
-  padding: var(--spacing-2xl) 0;
+  padding: 7rem 0;
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 3.5rem;
+
+    .section-label {
+      display: inline-block;
+      font-family: var(--font-heading);
+      font-size: 0.72rem;
+      letter-spacing: 0.22em;
+      color: var(--color-accent);
+      text-transform: uppercase;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: clamp(1.8rem, 3.5vw, 2.6rem);
+      font-family: var(--font-heading);
+      color: var(--color-text);
+      line-height: 1.2;
+    }
+  }
 
   &__grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: var(--spacing-md);
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1.25rem;
+
+    @media (max-width: 960px) { grid-template-columns: repeat(2, 1fr); }
+    @media (max-width: 540px) { grid-template-columns: 1fr; }
   }
 }
 
 .feature-card {
-  padding: var(--spacing-lg);
-  background: linear-gradient(135deg, rgba(26, 26, 37, 0.6), rgba(20, 20, 30, 0.4));
-  border: 1px solid rgba(255, 107, 53, 0.08);
-  border-radius: var(--radius-lg);
-  transition: all var(--transition-normal);
-  animation: fadeInUp 0.6s ease both;
-
-  &:nth-child(2) { animation-delay: 0.1s; }
-  &:nth-child(3) { animation-delay: 0.2s; }
-  &:nth-child(4) { animation-delay: 0.3s; }
-
-  &:hover {
-    border-color: rgba(255, 107, 53, 0.25);
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-lg);
-  }
-
-  &__icon {
-    font-size: 2rem;
-    display: block;
-    margin-bottom: var(--spacing-sm);
-  }
-
-  h3 {
-    font-size: 1.2rem;
-    margin-bottom: 0.5rem;
-    color: var(--color-text);
-  }
-
-  p {
-    font-size: 0.9rem;
-    color: var(--color-text-dim);
-    line-height: 1.6;
-    margin: 0;
-  }
-}
-
-/* ===== SECTION LABELS PARTAGÉS ===== */
-.section-label {
-  display: inline-block;
-  font-family: var(--font-heading);
-  font-size: 0.75rem;
-  letter-spacing: 0.2em;
-  color: var(--color-accent);
-  margin-bottom: 0.25rem;
-}
-
-/* ===== CITIES SECTION ===== */
-.cities-section {
-  padding: var(--spacing-2xl) 0 var(--spacing-xl);
   position: relative;
+  padding: 2rem;
+  background: linear-gradient(145deg, rgba(22, 22, 34, 0.95), rgba(14, 14, 24, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition:
+    border-color var(--transition-normal),
+    transform var(--transition-normal),
+    box-shadow var(--transition-normal);
 
+  /* Accent corner glow on hover */
   &::before {
     content: '';
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(255, 107, 53, 0.3), transparent);
+    height: 2px;
+    background: linear-gradient(90deg, transparent, var(--color-accent), transparent);
+    opacity: 0;
+    transition: opacity var(--transition-normal);
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(ellipse at top left, rgba(255, 107, 53, 0.08), transparent 65%);
+    opacity: 0;
+    transition: opacity var(--transition-normal);
+  }
+
+  &:hover {
+    border-color: rgba(255, 107, 53, 0.2);
+    transform: translateY(-6px);
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+    &::before { opacity: 1; }
+    &::after  { opacity: 1; }
+  }
+
+  &__num {
+    display: block;
+    font-family: var(--font-heading);
+    font-size: 3.5rem;
+    color: rgba(255, 107, 53, 0.06);
+    line-height: 1;
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.04em;
+  }
+
+  &__icon {
+    font-size: 2rem;
+    display: block;
+    margin-bottom: 1rem;
+    filter: drop-shadow(0 2px 8px rgba(255, 107, 53, 0.2));
+  }
+
+  h3 {
+    font-size: 1.1rem;
+    font-family: var(--font-heading);
+    margin: 0 0 0.6rem;
+    color: var(--color-text);
+  }
+
+  p {
+    font-size: 0.875rem;
+    color: rgba(255, 255, 255, 0.45);
+    line-height: 1.7;
+    margin: 0;
+  }
+}
+
+/* =====================================================
+   CITIES
+   ===================================================== */
+.cities-section {
+  padding: 7rem 0;
+  position: relative;
+
+  /* Very subtle tinted band */
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background:
+      linear-gradient(to bottom, transparent 0%, rgba(255, 107, 53, 0.03) 15%, rgba(255, 107, 53, 0.03) 85%, transparent 100%);
+    pointer-events: none;
   }
 
   &__header {
-    margin-bottom: var(--spacing-xl);
-    h2    { margin: 0; font-size: clamp(1.6rem, 4vw, 2.2rem); }
-    .subtitle { margin: 0.4rem 0 0; color: var(--color-text-dim); font-size: 0.95rem; }
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 3.5rem;
+
+    .section-label {
+      display: inline-block;
+      font-family: var(--font-heading);
+      font-size: 0.72rem;
+      letter-spacing: 0.22em;
+      color: var(--color-accent);
+      text-transform: uppercase;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: clamp(1.8rem, 3.5vw, 2.6rem);
+      font-family: var(--font-heading);
+    }
+
+    .subtitle {
+      margin: 0;
+      color: rgba(255, 255, 255, 0.45);
+      font-size: 1rem;
+    }
   }
 }
 
 .cities-grid {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-lg);
+  gap: 1rem;
+  margin-bottom: 3rem;
 
-  @media (max-width: 900px) { grid-template-columns: repeat(3, 1fr); }
-  @media (max-width: 500px) { grid-template-columns: repeat(2, 1fr); }
+  @media (max-width: 960px) { grid-template-columns: repeat(3, 1fr); }
+  @media (max-width: 540px) { grid-template-columns: repeat(2, 1fr); }
 }
 
 .city-card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
-  padding: var(--spacing-lg) var(--spacing-sm);
-  background: linear-gradient(135deg, rgba(26, 26, 37, 0.6), rgba(20, 20, 30, 0.4));
-  border: 1px solid rgba(255, 107, 53, 0.08);
+  gap: 0.75rem;
+  padding: 2rem 1rem;
   border-radius: var(--radius-lg);
-  transition: all var(--transition-normal);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  cursor: default;
+  transition:
+    transform var(--transition-normal),
+    border-color var(--transition-normal),
+    box-shadow var(--transition-normal);
   text-align: center;
 
   &:hover {
-    border-color: rgba(255, 107, 53, 0.25);
-    transform: translateY(-3px);
+    transform: translateY(-6px);
+    border-color: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
   }
 
-  &__emoji { font-size: 2.25rem; line-height: 1; }
-  &__name  { font-weight: 700; font-size: 0.9rem; color: var(--color-text); }
-  &__theme { font-size: 0.72rem; color: var(--color-accent); font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; }
+  &__emoji {
+    font-size: 2.6rem;
+    line-height: 1;
+    filter: drop-shadow(0 3px 8px rgba(0, 0, 0, 0.5));
+  }
+
+  &__name  { font-weight: 700; font-size: 0.9rem; color: var(--color-text); font-family: var(--font-heading); }
+  &__theme { font-size: 0.68rem; font-weight: 600; letter-spacing: 0.07em; text-transform: uppercase; }
+
+  &--willowbrook  { background: linear-gradient(145deg, rgba(34,197,94,0.13),   rgba(16,185,129,0.03));  .city-card__theme { color: #4ade80; } }
+  &--ironhaven    { background: linear-gradient(145deg, rgba(100,116,139,0.18), rgba(71,85,105,0.04));   .city-card__theme { color: #94a3b8; } }
+  &--crystalport  { background: linear-gradient(145deg, rgba(59,130,246,0.15),  rgba(99,102,241,0.04));  .city-card__theme { color: #60a5fa; } }
+  &--shadowpeak   { background: linear-gradient(145deg, rgba(139,92,246,0.18),  rgba(109,40,217,0.04));  .city-card__theme { color: #a78bfa; } }
+  &--goldenfields { background: linear-gradient(145deg, rgba(212,175,55,0.18),  rgba(245,158,11,0.04));  .city-card__theme { color: var(--color-gold); } }
+  &--neonhub      { background: linear-gradient(145deg, rgba(6,182,212,0.15),   rgba(56,189,248,0.04));  .city-card__theme { color: #22d3ee; } }
 }
 
 .cities-cta {
   display: flex;
   justify-content: center;
-  padding-top: var(--spacing-md);
-  padding-bottom: var(--spacing-lg);
 }
 
-/* ===== ECONOMY SECTION ===== */
+/* =====================================================
+   ECONOMY
+   ===================================================== */
 .economy-section {
-  padding: var(--spacing-2xl) 0;
-  position: relative;
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(255, 107, 53, 0.2), transparent);
-  }
+  padding: 7rem 0 9rem;
 
   &__header {
-    margin-bottom: var(--spacing-xl);
-    h2 { margin: 0; font-size: clamp(1.6rem, 4vw, 2.2rem); }
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 4rem;
+
+    .section-label {
+      display: inline-block;
+      font-family: var(--font-heading);
+      font-size: 0.72rem;
+      letter-spacing: 0.22em;
+      color: var(--color-accent);
+      text-transform: uppercase;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: clamp(1.8rem, 3.5vw, 2.6rem);
+      font-family: var(--font-heading);
+    }
   }
 }
 
 .economy-flow {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--spacing-md);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  align-items: start;
 
   @media (max-width: 768px) {
-    flex-direction: column;
-    align-items: center;
+    grid-template-columns: 1fr;
+    gap: 3rem;
   }
 }
 
 .flow-step {
-  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  gap: 0.75rem;
+  padding: 0 1.5rem;
+
+  &__top {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 1.5rem;
+  }
 
   &__circle {
-    width: 72px;
-    height: 72px;
+    position: relative;
+    flex-shrink: 0;
+    width: 76px;
+    height: 76px;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 2rem;
-    background: rgba(255, 107, 53, 0.07);
-    border: 1px solid rgba(255, 107, 53, 0.18);
+    background: linear-gradient(145deg, rgba(255, 107, 53, 0.1), rgba(255, 107, 53, 0.04));
+    border: 1px solid rgba(255, 107, 53, 0.22);
     border-radius: 50%;
+    font-size: 1.9rem;
+    box-shadow: 0 0 30px rgba(255, 107, 53, 0.08);
+    transition:
+      background var(--transition-normal),
+      border-color var(--transition-normal),
+      box-shadow var(--transition-normal);
+
+    &:hover {
+      background: linear-gradient(145deg, rgba(255, 107, 53, 0.18), rgba(255, 107, 53, 0.07));
+      border-color: rgba(255, 107, 53, 0.45);
+      box-shadow: 0 0 40px rgba(255, 107, 53, 0.2);
+    }
   }
 
-  &__title { font-family: var(--font-heading); font-size: 1.05rem; margin: 0; }
-  &__desc  { font-size: 0.85rem; color: var(--color-text-dim); line-height: 1.6; margin: 0; max-width: 180px; }
+  &__num {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    width: 22px;
+    height: 22px;
+    background: var(--color-accent);
+    border-radius: 50%;
+    font-size: 0.65rem;
+    font-weight: 800;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-heading);
+    box-shadow: 0 2px 8px rgba(255, 107, 53, 0.5);
+  }
+
+  &__title {
+    font-family: var(--font-heading);
+    font-size: 1.05rem;
+    margin: 0 0 0.5rem;
+    color: var(--color-text);
+  }
+
+  &__desc {
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.45);
+    line-height: 1.7;
+    margin: 0;
+    max-width: 180px;
+  }
 }
 
-.flow-arrow {
-  font-size: 1.4rem;
-  color: rgba(255, 107, 53, 0.3);
-  margin-top: 22px;
-  flex-shrink: 0;
+.flow-connector {
+  flex: 1;
+  height: 1px;
+  margin: 0 0.75rem;
+  background: linear-gradient(90deg, rgba(255, 107, 53, 0.4), rgba(255, 107, 53, 0.08));
+  position: relative;
 
-  @media (max-width: 768px) { transform: rotate(90deg); margin: 0; }
+  &::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: rgba(255, 107, 53, 0.3);
+  }
+
+  @media (max-width: 768px) { display: none; }
 }
 
-/* ===== RESPONSIVE ===== */
+/* =====================================================
+   RESPONSIVE
+   ===================================================== */
 @media (max-width: 768px) {
   .hero {
     min-height: auto;
-    padding: var(--spacing-xl) 0;
+    padding: 4rem 0 5rem;
 
-    &__title { font-size: clamp(2.5rem, 10vw, 4rem); }
-    &__orb { display: none; }
+    &::before    { display: none; }
+    &__orb, &__cities-float { display: none; }
+    &__title-line       { font-size: clamp(1.8rem, 9vw, 2.6rem); }
+    &__title-line--accent { font-size: clamp(2.4rem, 11vw, 3.5rem); }
+    &__subtitle  { font-size: 0.95rem; }
   }
+
+  .features,
+  .cities-section,
+  .economy-section {
+    padding: 4.5rem 0;
+  }
+
+  .economy-section { padding-bottom: 5.5rem; }
 }

--- a/web/frontend/src/app/features/home/home.component.ts
+++ b/web/frontend/src/app/features/home/home.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { AuthService } from '../../core/services/auth.service';
+import { HOME_CITIES, HOME_FEATURES, HOME_ECONOMY_STEPS } from './home.data';
 
 @Component({
   selector: 'app-home',
@@ -13,21 +14,9 @@ import { AuthService } from '../../core/services/auth.service';
 export class HomeComponent {
   protected readonly auth = inject(AuthService);
 
-  readonly cities = [
-    { id: 'willowbrook',  emoji: '🌿', name: 'Willowbrook',  theme: 'Nature'      },
-    { id: 'ironhaven',    emoji: '⚒️', name: 'Ironhaven',    theme: 'Industriel'  },
-    { id: 'crystalport',  emoji: '⚓', name: 'Crystalport',  theme: 'Maritime'    },
-    { id: 'shadowpeak',   emoji: '🏔️', name: 'Shadowpeak',   theme: 'Montagne'    },
-    { id: 'goldenfields', emoji: '🌾', name: 'Goldenfields', theme: 'Plaines'     },
-    { id: 'neonhub',      emoji: '🌆', name: 'NeonHub',      theme: 'High-tech'   },
-  ];
-
-  readonly economySteps = [
-    { emoji: '💬', title: 'Interagissez',  desc: 'Chattez sur Discord et gagnez des MazCoins automatiquement.' },
-    { emoji: '🪙', title: 'Accumulez',     desc: 'Votre solde grandit à chaque message et commande.' },
-    { emoji: '🗺️', title: 'Voyagez',       desc: 'Dépensez vos coins pour voyager vers de nouvelles villes.' },
-    { emoji: '🛒', title: 'Personnalisez', desc: 'Achetez des backgrounds et badges dans la boutique.' },
-  ];
+  readonly cities       = HOME_CITIES;
+  readonly features     = HOME_FEATURES;
+  readonly economySteps = HOME_ECONOMY_STEPS;
 
   login(): void {
     this.auth.loginWithDiscord().subscribe();

--- a/web/frontend/src/app/features/home/home.component.ts
+++ b/web/frontend/src/app/features/home/home.component.ts
@@ -13,6 +13,22 @@ import { AuthService } from '../../core/services/auth.service';
 export class HomeComponent {
   protected readonly auth = inject(AuthService);
 
+  readonly cities = [
+    { id: 'willowbrook',  emoji: '🌿', name: 'Willowbrook',  theme: 'Nature'      },
+    { id: 'ironhaven',    emoji: '⚒️', name: 'Ironhaven',    theme: 'Industriel'  },
+    { id: 'crystalport',  emoji: '⚓', name: 'Crystalport',  theme: 'Maritime'    },
+    { id: 'shadowpeak',   emoji: '🏔️', name: 'Shadowpeak',   theme: 'Montagne'    },
+    { id: 'goldenfields', emoji: '🌾', name: 'Goldenfields', theme: 'Plaines'     },
+    { id: 'neonhub',      emoji: '🌆', name: 'NeonHub',      theme: 'High-tech'   },
+  ];
+
+  readonly economySteps = [
+    { emoji: '💬', title: 'Interagissez',  desc: 'Chattez sur Discord et gagnez des MazCoins automatiquement.' },
+    { emoji: '🪙', title: 'Accumulez',     desc: 'Votre solde grandit à chaque message et commande.' },
+    { emoji: '🗺️', title: 'Voyagez',       desc: 'Dépensez vos coins pour voyager vers de nouvelles villes.' },
+    { emoji: '🛒', title: 'Personnalisez', desc: 'Achetez des backgrounds et badges dans la boutique.' },
+  ];
+
   login(): void {
     this.auth.loginWithDiscord().subscribe();
   }

--- a/web/frontend/src/app/features/home/home.data.ts
+++ b/web/frontend/src/app/features/home/home.data.ts
@@ -1,0 +1,22 @@
+export const HOME_CITIES = [
+  { id: 'willowbrook',  emoji: '🌿', name: 'Willowbrook',  theme: 'Nature'     },
+  { id: 'ironhaven',    emoji: '⚒️', name: 'Ironhaven',    theme: 'Industriel' },
+  { id: 'crystalport',  emoji: '⚓', name: 'Crystalport',  theme: 'Maritime'   },
+  { id: 'shadowpeak',   emoji: '🏔️', name: 'Shadowpeak',   theme: 'Montagne'   },
+  { id: 'goldenfields', emoji: '🌾', name: 'Goldenfields', theme: 'Plaines'    },
+  { id: 'neonhub',      emoji: '🌆', name: 'NeonHub',      theme: 'High-tech'  },
+] as const;
+
+export const HOME_FEATURES = [
+  { icon: '🗺️', title: 'Carte interactive',  desc: 'Voyagez entre 6 villes interconnectées, chacune avec ses propres opportunités et métiers.' },
+  { icon: '🪙', title: 'MazCoins',           desc: 'Gagnez des MazCoins en interagissant sur Discord. Plus vous jouez, plus vous accumulez.' },
+  { icon: '🏆', title: 'Classement',         desc: 'Affrontez la communauté et grimpez dans le classement mondial des plus riches.' },
+  { icon: '🛒', title: 'Boutique & Badges',  desc: 'Personnalisez votre profil avec des backgrounds et badges achetés dans la boutique.' },
+] as const;
+
+export const HOME_ECONOMY_STEPS = [
+  { emoji: '💬', title: 'Interagissez',  desc: 'Chattez sur Discord et participez à la vie du serveur.' },
+  { emoji: '🪙', title: 'Accumulez',     desc: 'Chaque interaction vous rapporte des MazCoins automatiquement.' },
+  { emoji: '🗺️', title: 'Explorez',      desc: 'Voyagez vers de nouvelles villes et débloquez des territoires.' },
+  { emoji: '🛒', title: 'Personnalisez', desc: 'Dépensez vos coins pour des items et badges exclusifs.' },
+] as const;

--- a/web/frontend/src/app/features/map/map.component.html
+++ b/web/frontend/src/app/features/map/map.component.html
@@ -1,5 +1,14 @@
 <div class="map-page">
 
+  <!-- Header -->
+  <div class="map-header container">
+    <div class="map-header__content">
+      <span class="section-label">MAP</span>
+      <h1>Carte du monde</h1>
+      <p class="subtitle">6 villes interconnectées vous attendent</p>
+    </div>
+  </div>
+
   <!-- Loading -->
   @if (isLoading()) {
     <div class="map-state">
@@ -18,15 +27,6 @@
   }
 
   @else {
-    <!-- Header -->
-    <section class="map-header">
-      <div class="container">
-        <span class="section-label">MAP</span>
-        <h1>Carte du monde</h1>
-        <p class="subtitle">6 villes interconnectées vous attendent</p>
-      </div>
-    </section>
-
     <!-- Bannière voyage en cours -->
     @if (isTraveling()) {
       <div class="travel-banner container">

--- a/web/frontend/src/app/features/map/map.component.scss
+++ b/web/frontend/src/app/features/map/map.component.scss
@@ -19,27 +19,24 @@
 
 /* ===== HEADER ===== */
 .map-header {
-  padding: var(--spacing-xl) var(--spacing-lg);
-  text-align: center;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  padding: var(--spacing-xl) 0 var(--spacing-md);
 
-  .section-label {
-    display: block;
-    font-family: var(--font-heading);
-    font-size: 4rem;
-    color: rgba(255, 107, 53, 0.15);
-    line-height: 1;
-    margin-bottom: 0.5rem;
-  }
+  &__content {
+    .section-label {
+      display: inline-block;
+      font-family: var(--font-heading);
+      font-size: 0.75rem;
+      letter-spacing: 0.2em;
+      color: var(--color-accent);
+      margin-bottom: 0.25rem;
+    }
 
-  h1 {
-    font-size: clamp(2rem, 5vw, 3.5rem);
-    margin: 0 0 0.75rem;
-  }
-
-  .subtitle {
-    font-size: 1.05rem;
-    color: var(--color-text-dim);
-    margin: 0;
+    h1 { margin: 0; line-height: 1; }
+    .subtitle { margin: 0.4rem 0 0; font-size: 0.95rem; }
   }
 }
 

--- a/web/frontend/src/app/features/stats/stats.component.html
+++ b/web/frontend/src/app/features/stats/stats.component.html
@@ -1,3 +1,56 @@
-<div class="container">
-  <h2>Statistiques — à venir</h2>
+<div class="stats-page">
+
+  <!-- Header -->
+  <div class="stats-header container">
+    <span class="section-label">STATISTIQUES</span>
+    <h1>Vue d'ensemble du serveur</h1>
+    <p class="subtitle">Données en temps réel de l'univers MazWorld</p>
+  </div>
+
+  <!-- Loading -->
+  @if (isLoading()) {
+    <div class="stats-state container">
+      <div class="loading"></div>
+      <p>Chargement des statistiques…</p>
+    </div>
+  }
+
+  <!-- Error -->
+  @else if (hasError()) {
+    <div class="stats-state stats-state--error container">
+      <span>⚠️</span>
+      <p>Impossible de charger les statistiques.</p>
+      <button class="btn btn-primary btn--sm" (click)="load()">Réessayer</button>
+    </div>
+  }
+
+  @else {
+    <!-- Statistiques globales -->
+    @if (globalStats(); as g) {
+      <section class="stats-section container">
+        <h2 class="section-title">🌍 Statistiques globales</h2>
+        <div class="stats-grid">
+          <app-stat-card icon="👥" label="Joueurs" [value]="fmt(g.total_users)" />
+          <app-stat-card icon="🏙️" label="Villes" [value]="fmt(g.total_cities)" />
+          <app-stat-card icon="🪙" label="Coins en circulation" [value]="fmt(g.total_coins_circulation)" variant="gold" />
+          <app-stat-card icon="🟢" label="Actifs aujourd'hui" [value]="fmt(g.active_users_today)" variant="accent" />
+          <app-stat-card icon="📅" label="Actifs cette semaine" [value]="fmt(g.active_users_week)" />
+        </div>
+      </section>
+    }
+
+    <!-- Économie -->
+    @if (economyStats(); as e) {
+      <section class="stats-section container">
+        <h2 class="section-title">💰 Économie</h2>
+        <div class="stats-grid stats-grid--4">
+          <app-stat-card icon="📈" label="Moyenne par joueur" [value]="fmt(e.average_coins_per_user) + ' 🪙'" />
+          <app-stat-card icon="👑" label="Record de richesse" [value]="fmt(e.richest_user_coins) + ' 🪙'" variant="gold" />
+          <app-stat-card icon="🛒" label="Achats boutique" [value]="fmt(e.total_shop_purchases)" />
+          <app-stat-card icon="⭐" label="Item populaire" [value]="e.most_popular_item || 'N/A'" variant="accent" />
+        </div>
+      </section>
+    }
+  }
+
 </div>

--- a/web/frontend/src/app/features/stats/stats.component.scss
+++ b/web/frontend/src/app/features/stats/stats.component.scss
@@ -1,0 +1,68 @@
+.stats-page {
+  min-height: calc(100vh - 68px);
+  padding: var(--spacing-xl) 0 var(--spacing-2xl);
+}
+
+/* ===== HEADER ===== */
+.stats-header {
+  margin-bottom: var(--spacing-xl);
+
+  .section-label {
+    display: inline-block;
+    font-family: var(--font-heading);
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    color: var(--color-accent);
+    margin-bottom: 0.25rem;
+  }
+
+  h1 { margin: 0; line-height: 1; }
+  .subtitle { margin: 0.4rem 0 0; font-size: 0.95rem; }
+}
+
+/* ===== STATES ===== */
+.stats-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 30vh;
+  gap: var(--spacing-md);
+  color: var(--color-text-dim);
+  text-align: center;
+
+  &--error { color: #f87171; }
+}
+
+/* ===== SECTIONS ===== */
+.stats-section {
+  margin-bottom: var(--spacing-2xl);
+}
+
+.section-title {
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  color: var(--color-text-dim);
+  margin-bottom: var(--spacing-md);
+  padding-bottom: var(--spacing-sm);
+  border-bottom: 1px solid rgba(255, 107, 53, 0.1);
+}
+
+/* ===== GRIDS ===== */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-md);
+
+  &--4 { grid-template-columns: repeat(4, 1fr); }
+
+  @media (max-width: 900px) {
+    grid-template-columns: repeat(2, 1fr);
+    &--4 { grid-template-columns: repeat(2, 1fr); }
+  }
+
+  @media (max-width: 500px) {
+    grid-template-columns: 1fr;
+    &--4 { grid-template-columns: 1fr; }
+  }
+}

--- a/web/frontend/src/app/features/stats/stats.component.ts
+++ b/web/frontend/src/app/features/stats/stats.component.ts
@@ -1,9 +1,47 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, signal, inject, ChangeDetectionStrategy } from '@angular/core';
+import { StatsService } from '../../core/services/stats.service';
+import { StatCardComponent } from '../../shared/components/ui/stat-card/stat-card.component';
+import type { GlobalStats, EconomyStats } from '../../core/models/stats.model';
 
 @Component({
   selector: 'app-stats',
   standalone: true,
+  imports: [StatCardComponent],
   templateUrl: './stats.component.html',
+  styleUrl: './stats.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class StatsComponent {}
+export class StatsComponent implements OnInit {
+  private readonly statsService = inject(StatsService);
+
+  readonly globalStats = signal<GlobalStats | null>(null);
+  readonly economyStats = signal<EconomyStats | null>(null);
+  readonly isLoading = signal(true);
+  readonly hasError = signal(false);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading.set(true);
+    this.hasError.set(false);
+    this.statsService.getAllStats().subscribe({
+      next: ({ global, economy }) => {
+        this.globalStats.set(global);
+        this.economyStats.set(economy);
+        this.isLoading.set(false);
+      },
+      error: () => {
+        this.hasError.set(true);
+        this.isLoading.set(false);
+      },
+    });
+  }
+
+  fmt(value: number): string {
+    if (value >= 1_000_000) return (value / 1_000_000).toFixed(1) + 'M';
+    if (value >= 1_000) return (value / 1_000).toFixed(1) + 'K';
+    return value.toLocaleString('fr-FR');
+  }
+}

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -16,7 +16,9 @@
         <a routerLink="/map"       routerLinkActive="active"><span aria-hidden="true">🗺️</span> Carte</a>
         <a routerLink="/shop"      routerLinkActive="active"><span aria-hidden="true">🛒</span> Boutique</a>
         <a routerLink="/inventory" routerLinkActive="active"><span aria-hidden="true">🎒</span> Inventaire</a>
-        <a routerLink="/stats"     routerLinkActive="active"><span aria-hidden="true">📊</span> Stats</a>
+        @if (auth.currentUser()?.roles?.includes('ROLE_ADMIN')) {
+          <a routerLink="/stats" routerLinkActive="active"><span aria-hidden="true">📊</span> Stats</a>
+        }
       }
       <a routerLink="/leaderboard" routerLinkActive="active"><span aria-hidden="true">🏆</span> Classement</a>
       <a routerLink="/commands"    routerLinkActive="active"><span aria-hidden="true">📜</span> Commandes</a>
@@ -78,7 +80,9 @@
         <a routerLink="/map"       routerLinkActive="active" (click)="closeMobileMenu()">🗺️ Carte</a>
         <a routerLink="/shop"      routerLinkActive="active" (click)="closeMobileMenu()">🛒 Boutique</a>
         <a routerLink="/inventory" routerLinkActive="active" (click)="closeMobileMenu()">🎒 Inventaire</a>
-        <a routerLink="/stats"     routerLinkActive="active" (click)="closeMobileMenu()">📊 Stats</a>
+        @if (auth.currentUser()?.roles?.includes('ROLE_ADMIN')) {
+          <a routerLink="/stats" routerLinkActive="active" (click)="closeMobileMenu()">📊 Stats</a>
+        }
         <a routerLink="/profile"   routerLinkActive="active" (click)="closeMobileMenu()">👤 Mon profil</a>
         <a routerLink="/dashboard" routerLinkActive="active" (click)="closeMobileMenu()">🏠 Dashboard</a>
       }


### PR DESCRIPTION
## Résumé

- Page `/stats` admin-only : cards GlobalStats + EconomyStats via `StatsController` (Symfony, `ROLE_ADMIN`) et `StatsService` (Angular)
- Guard `adminGuard` Angular + `#[IsGranted('ROLE_ADMIN')]` côté backend — lien Stats affiché dans le header uniquement pour les admins
- Dashboard enrichi avec données de profil temps réel (avatar, ville actuelle, coins, villes visitées, items inventaire) + rang classement
- Carte : header toujours visible (déplacé hors du bloc conditionnel chargement/erreur)
- Home page : hero avec dot-grid, badge pill et titre dégradé accent→gold, sections aérées (7rem), fonctionnalités numérotées, villes thématisées, flow économie numéroté — données statiques extraites dans `home.data.ts`

## Issues fermées

Closes #61, #79