### PR TITLE
fix(dashboard): retrait import BadgeComponent non utilisé (SU #79)

### DIFF
--- a/web/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/web/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -4,13 +4,12 @@ import { ProfileService } from '../../core/services/profile.service';
 import { LeaderboardService } from '../../core/services/leaderboard.service';
 import { StatCardComponent } from '../../shared/components/ui/stat-card/stat-card.component';
 import { AvatarComponent } from '../../shared/components/ui/avatar/avatar.component';
-import { BadgeComponent } from '../../shared/components/ui/badge/badge.component';
 import type { UserProfile } from '../../core/models/profile.model';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [StatCardComponent, AvatarComponent, BadgeComponent],
+  imports: [StatCardComponent, AvatarComponent],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Résumé

Suppression de l'import `BadgeComponent` dans `DashboardComponent` — non utilisé dans le template, générait un warning Angular NG8113.

## Périmètre

SU #79 — correctif