### PR TITLE
feat(records): page records personnels et historique (#62)

### DIFF
--- a/web/backend/config/packages/security.yaml
+++ b/web/backend/config/packages/security.yaml
@@ -38,6 +38,7 @@ security:
         - { path: ^/api/commands, roles: ROLE_USER }
         - { path: ^/api/shop/purchase, roles: ROLE_USER }
         - { path: ^/api/leaderboard/me, roles: ROLE_USER }
+        - { path: ^/api/records, roles: ROLE_USER }
         - { path: ^/api, roles: PUBLIC_ACCESS }
 
 when@test:

--- a/web/backend/src/Controller/API/RecordsController.php
+++ b/web/backend/src/Controller/API/RecordsController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\ShopItem;
+use App\Entity\UserInventory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/records', name: 'api_records_')]
+class RecordsController extends AbstractApiController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager
+    ) {}
+
+    #[Route('', name: 'me', methods: ['GET'])]
+    public function getMyRecords(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        try {
+            $em = $this->entityManager;
+
+            // ===== COINS =====
+            $totalUsers = (int)$em->createQuery('SELECT COUNT(u) FROM App\Entity\User u')->getSingleScalarResult();
+            $rank = (int)$em->createQuery('SELECT COUNT(u) FROM App\Entity\User u WHERE u.coins > :coins')
+                ->setParameter('coins', $user->getCoins())
+                ->getSingleScalarResult() + 1;
+            $percentile = $totalUsers > 1
+                ? (int)round((($totalUsers - $rank) / ($totalUsers - 1)) * 100)
+                : 100;
+
+            // ===== EXPLORATION =====
+            $allCities = $em->createQuery('SELECT c FROM App\Entity\City c ORDER BY c.name ASC')->getResult();
+            $totalCities = count($allCities);
+
+            $visitedMap = [];
+            foreach ($user->getVisitedCities() as $vc) {
+                $visitedMap[$vc->getCity()->getCityId()] = $vc->getFirstVisit()->format('c');
+            }
+
+            $visitedCities = [];
+            $allCitiesData = [];
+            foreach ($allCities as $city) {
+                $cid = $city->getCityId();
+                $isVisited = isset($visitedMap[$cid]);
+                $entry = [
+                    'city_id'     => $cid,
+                    'name'        => $city->getName(),
+                    'emoji'       => $city->getEmoji(),
+                    'theme'       => $city->getTheme(),
+                    'visited'     => $isVisited,
+                    'first_visit' => $isVisited ? $visitedMap[$cid] : null,
+                ];
+                $allCitiesData[] = $entry;
+                if ($isVisited) {
+                    $visitedCities[] = $entry;
+                }
+            }
+            usort($visitedCities, fn($a, $b) => $a['first_visit'] <=> $b['first_visit']);
+
+            // ===== COLLECTION =====
+            $inventoryCount = (int)$em->createQuery('SELECT COUNT(i) FROM App\Entity\UserInventory i WHERE i.user = :user')
+                ->setParameter('user', $user)
+                ->getSingleScalarResult();
+
+            $badgesCount = $user->getEquippedBadges()->count();
+
+            $recentItem = null;
+            try {
+                $latestInventory = $em->createQuery('
+                    SELECT i FROM App\Entity\UserInventory i
+                    WHERE i.user = :user
+                    ORDER BY i.purchased_at DESC
+                ')->setParameter('user', $user)->setMaxResults(1)->getOneOrNullResult();
+
+                if ($latestInventory instanceof UserInventory) {
+                    $shopItem = $em->getRepository(ShopItem::class)->findOneBy(['item_id' => $latestInventory->getItemId()]);
+                    $recentItem = $shopItem?->getName();
+                }
+            } catch (\Throwable) {}
+
+            // ===== ACTIVITY =====
+            $joinedAt = $user->getCreatedAt()->format('c');
+            $lastActivity = ($user->getUpdatedAt() ?? $user->getCreatedAt())->format('c');
+            $joinedDate = new \DateTime($joinedAt);
+            $daysActive = (int)$joinedDate->diff(new \DateTime())->days;
+
+            return new JsonResponse([
+                'coins' => [
+                    'current'     => $user->getCoins(),
+                    'rank'        => $rank,
+                    'total_users' => $totalUsers,
+                    'percentile'  => $percentile,
+                ],
+                'exploration' => [
+                    'visited_count' => count($visitedCities),
+                    'total_cities'  => $totalCities,
+                    'cities'        => $allCitiesData,
+                ],
+                'collection' => [
+                    'inventory_count' => $inventoryCount,
+                    'badges_count'    => $badgesCount,
+                    'recent_item'     => $recentItem,
+                ],
+                'activity' => [
+                    'joined_at'     => $joinedAt,
+                    'last_activity' => $lastActivity,
+                    'days_active'   => $daysActive,
+                ],
+            ]);
+        } catch (\Throwable $e) {
+            return new JsonResponse(
+                ['error' => 'Internal error', 'message' => $e->getMessage()],
+                Response::HTTP_INTERNAL_SERVER_ERROR
+            );
+        }
+    }
+}

--- a/web/frontend/src/app/app.config.ts
+++ b/web/frontend/src/app/app.config.ts
@@ -1,10 +1,14 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
+import { ApplicationConfig, LOCALE_ID, provideBrowserGlobalErrorListeners } from '@angular/core';
+import { registerLocaleData } from '@angular/common';
 import { provideRouter, withComponentInputBinding, withViewTransitions } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import localeFr from '@angular/common/locales/fr';
 
 import { routes } from './app.routes';
 import { jwtInterceptor } from './core/interceptors/jwt.interceptor';
+
+registerLocaleData(localeFr);
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -12,5 +16,6 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes, withComponentInputBinding(), withViewTransitions()),
     provideHttpClient(withInterceptors([jwtInterceptor])),
     provideAnimationsAsync(),
+    { provide: LOCALE_ID, useValue: 'fr-FR' },
   ],
 };

--- a/web/frontend/src/app/app.routes.ts
+++ b/web/frontend/src/app/app.routes.ts
@@ -49,6 +49,12 @@ export const routes: Routes = [
     title: 'Classement — MazWorld',
   },
   {
+    path: 'records',
+    loadComponent: () => import('./features/records/records.component').then(m => m.RecordsComponent),
+    title: 'Records — MazWorld',
+    canActivate: [authGuard],
+  },
+  {
     path: 'stats',
     loadComponent: () => import('./features/stats/stats.component').then(m => m.StatsComponent),
     title: 'Statistiques — MazWorld',

--- a/web/frontend/src/app/core/models/index.ts
+++ b/web/frontend/src/app/core/models/index.ts
@@ -5,3 +5,4 @@ export * from './shop.model';
 export * from './inventory.model';
 export * from './leaderboard.model';
 export * from './stats.model';
+export * from './records.model';

--- a/web/frontend/src/app/core/models/records.model.ts
+++ b/web/frontend/src/app/core/models/records.model.ts
@@ -1,0 +1,40 @@
+export interface RecordsCoins {
+  current: number;
+  rank: number;
+  total_users: number;
+  percentile: number;
+}
+
+export interface CityRecord {
+  city_id: string;
+  name: string;
+  emoji: string | null;
+  theme: string | null;
+  visited: boolean;
+  first_visit: string | null;
+}
+
+export interface RecordsExploration {
+  visited_count: number;
+  total_cities: number;
+  cities: CityRecord[];
+}
+
+export interface RecordsCollection {
+  inventory_count: number;
+  badges_count: number;
+  recent_item: string | null;
+}
+
+export interface RecordsActivity {
+  joined_at: string;
+  last_activity: string;
+  days_active: number;
+}
+
+export interface PersonalRecords {
+  coins: RecordsCoins;
+  exploration: RecordsExploration;
+  collection: RecordsCollection;
+  activity: RecordsActivity;
+}

--- a/web/frontend/src/app/core/services/index.ts
+++ b/web/frontend/src/app/core/services/index.ts
@@ -6,3 +6,4 @@ export * from './shop.service';
 export * from './inventory.service';
 export * from './leaderboard.service';
 export * from './stats.service';
+export * from './records.service';

--- a/web/frontend/src/app/core/services/records.service.ts
+++ b/web/frontend/src/app/core/services/records.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import type { PersonalRecords } from '../models/records.model';
+
+@Injectable({ providedIn: 'root' })
+export class RecordsService {
+  private readonly http = inject(HttpClient);
+  private readonly base = environment.apiUrl;
+
+  getMyRecords(): Observable<PersonalRecords> {
+    return this.http.get<PersonalRecords>(`${this.base}/api/records`);
+  }
+}

--- a/web/frontend/src/app/features/records/records.component.html
+++ b/web/frontend/src/app/features/records/records.component.html
@@ -1,0 +1,167 @@
+<div class="records-page">
+
+  <!-- Header -->
+  <div class="records-header container">
+    <span class="section-label">Records personnels</span>
+    <h1>Vos records & historique</h1>
+    <p class="subtitle">Retracez votre parcours sur MazWorld, catégorie par catégorie.</p>
+  </div>
+
+  @if (isLoading()) {
+    <div class="records-state container">
+      <div class="loading"></div>
+      <p>Chargement de vos records…</p>
+    </div>
+  } @else if (hasError()) {
+    <div class="records-state records-state--error container">
+      <span class="records-state__icon">⚠️</span>
+      <p>Impossible de charger vos records.</p>
+      <button class="btn-primary" (click)="load()">Réessayer</button>
+    </div>
+  } @else if (records(); as r) {
+
+    <!-- ===== COINS ===== -->
+    <section class="records-section container">
+      <div class="rec-block">
+        <div class="rec-block__label">
+          <span class="rec-icon">🪙</span>
+          <span class="section-label">MazCoins</span>
+        </div>
+
+        <div class="coins-hero">
+          <div class="coins-hero__main">
+            <span class="coins-hero__value text-gradient">{{ fmt(r.coins.current) }}</span>
+            <span class="coins-hero__unit">MZC</span>
+          </div>
+          <div class="coins-hero__meta">
+            <span class="rank-badge">🏆 #{{ r.coins.rank }} mondial</span>
+            <span class="coins-hero__sub">sur {{ r.coins.total_users }} joueurs</span>
+          </div>
+        </div>
+
+        <div class="percentile-bar">
+          <div class="percentile-bar__header">
+            <span>Meilleur que {{ r.coins.percentile }}% des joueurs</span>
+            <span class="percentile-bar__pct">{{ r.coins.percentile }}e percentile</span>
+          </div>
+          <div class="percentile-bar__track">
+            <div class="percentile-bar__fill" [style.width.%]="r.coins.percentile"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="records-divider container"></div>
+
+    <!-- ===== EXPLORATION ===== -->
+    <section class="records-section container">
+      <div class="rec-block">
+        <div class="rec-block__label">
+          <span class="rec-icon">🗺️</span>
+          <span class="section-label">Exploration</span>
+        </div>
+
+        <div class="exploration-progress">
+          <div class="exploration-progress__counter">
+            <span class="exploration-progress__num">{{ r.exploration.visited_count }}</span>
+            <span class="exploration-progress__sep">/</span>
+            <span class="exploration-progress__total">{{ r.exploration.total_cities }}</span>
+          </div>
+          <div class="exploration-progress__label">villes découvertes</div>
+          <div class="exploration-progress__track">
+            <div class="exploration-progress__fill" [style.width.%]="explorationPct()"></div>
+          </div>
+          <div class="exploration-progress__pct">{{ explorationPct() }}% exploré</div>
+        </div>
+
+        <div class="cities-grid-rec">
+          @for (city of r.exploration.cities; track city.city_id) {
+            <div class="city-rec" [class.city-rec--visited]="city.visited" [class.city-rec--locked]="!city.visited">
+              <div class="city-rec__inner">
+                <span class="city-rec__emoji">{{ city.visited ? (city.emoji ?? '🏙️') : '🔒' }}</span>
+                <span class="city-rec__name">{{ city.visited ? city.name : '???' }}</span>
+                @if (city.visited && city.first_visit) {
+                  <span class="city-rec__date">{{ city.first_visit | date:'d MMM yy' }}</span>
+                } @else if (!city.visited) {
+                  <span class="city-rec__locked-label">Non découverte</span>
+                }
+              </div>
+              @if (city.visited) {
+                <span class="city-rec__check">✓</span>
+              }
+            </div>
+          }
+        </div>
+      </div>
+    </section>
+
+    <div class="records-divider container"></div>
+
+    <!-- ===== COLLECTION ===== -->
+    <section class="records-section container">
+      <div class="rec-block">
+        <div class="rec-block__label">
+          <span class="rec-icon">🛒</span>
+          <span class="section-label">Collection</span>
+        </div>
+
+        <div class="collection-stats">
+          <div class="collection-stat">
+            <span class="collection-stat__value">{{ r.collection.inventory_count }}</span>
+            <span class="collection-stat__icon">📦</span>
+            <span class="collection-stat__label">Items possédés</span>
+          </div>
+          <div class="collection-stat collection-stat--gold">
+            <span class="collection-stat__value">{{ r.collection.badges_count }}</span>
+            <span class="collection-stat__icon">🏅</span>
+            <span class="collection-stat__label">Badges équipés</span>
+          </div>
+          @if (r.collection.recent_item) {
+            <div class="collection-stat collection-stat--accent">
+              <span class="collection-stat__value collection-stat__value--sm">{{ r.collection.recent_item }}</span>
+              <span class="collection-stat__icon">✨</span>
+              <span class="collection-stat__label">Dernier achat</span>
+            </div>
+          }
+        </div>
+
+        @if (r.collection.inventory_count === 0) {
+          <p class="records-empty">Aucun item acheté — visitez la boutique pour personnaliser votre profil !</p>
+        }
+      </div>
+    </section>
+
+    <div class="records-divider container"></div>
+
+    <!-- ===== ACTIVITÉ ===== -->
+    <section class="records-section container">
+      <div class="rec-block">
+        <div class="rec-block__label">
+          <span class="rec-icon">📅</span>
+          <span class="section-label">Activité</span>
+        </div>
+
+        <div class="activity-timeline">
+          <div class="timeline-item">
+            <div class="timeline-item__dot"></div>
+            <div class="timeline-item__body">
+              <span class="timeline-item__title">Membre depuis</span>
+              <span class="timeline-item__value">{{ r.activity.joined_at | date:'d MMMM yyyy' }}</span>
+            </div>
+            <span class="timeline-item__badge">{{ r.activity.days_active }} jours</span>
+          </div>
+          <div class="timeline-item__line"></div>
+          <div class="timeline-item">
+            <div class="timeline-item__dot timeline-item__dot--accent"></div>
+            <div class="timeline-item__body">
+              <span class="timeline-item__title">Dernière activité</span>
+              <span class="timeline-item__value">{{ r.activity.last_activity | date:'d MMMM yyyy' }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  }
+
+</div>

--- a/web/frontend/src/app/features/records/records.component.scss
+++ b/web/frontend/src/app/features/records/records.component.scss
@@ -1,0 +1,425 @@
+.records-page {
+  min-height: calc(100vh - 68px);
+  padding: var(--spacing-xl) 0 var(--spacing-2xl);
+}
+
+/* ===== HEADER ===== */
+.records-header {
+  margin-bottom: var(--spacing-2xl);
+
+  .section-label {
+    display: inline-block;
+    font-family: var(--font-heading);
+    font-size: 0.72rem;
+    letter-spacing: 0.22em;
+    color: var(--color-accent);
+    text-transform: uppercase;
+    margin-bottom: 0.25rem;
+  }
+
+  h1      { margin: 0; line-height: 1.1; }
+  .subtitle { margin: 0.5rem 0 0; font-size: 0.95rem; color: var(--color-text-dim); }
+}
+
+/* ===== STATES ===== */
+.records-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 35vh;
+  gap: var(--spacing-md);
+  color: var(--color-text-dim);
+  text-align: center;
+
+  &__icon { font-size: 2.5rem; }
+  &--error { color: #f87171; }
+}
+
+/* ===== SECTION LAYOUT ===== */
+.records-section {
+  padding: var(--spacing-xl) 0;
+}
+
+.records-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 107, 53, 0.15) 30%, rgba(255, 107, 53, 0.15) 70%, transparent);
+}
+
+/* ===== BLOCK WRAPPER ===== */
+.rec-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xl);
+
+  &__label {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+
+    .section-label {
+      display: inline-block;
+      font-family: var(--font-heading);
+      font-size: 0.72rem;
+      letter-spacing: 0.22em;
+      color: var(--color-accent);
+      text-transform: uppercase;
+    }
+  }
+}
+
+.rec-icon {
+  font-size: 1.2rem;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 107, 53, 0.08);
+  border: 1px solid rgba(255, 107, 53, 0.15);
+  border-radius: var(--radius-md);
+  flex-shrink: 0;
+}
+
+/* ===== COINS HERO ===== */
+.coins-hero {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-xl);
+  flex-wrap: wrap;
+
+  &__main {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  &__value {
+    font-family: var(--font-heading);
+    font-size: clamp(3rem, 8vw, 5.5rem);
+    line-height: 1;
+  }
+
+  &__unit {
+    font-family: var(--font-heading);
+    font-size: 1.2rem;
+    color: var(--color-text-dim);
+  }
+
+  &__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding-bottom: 0.5rem;
+  }
+
+  &__sub {
+    font-size: 0.8rem;
+    color: var(--color-text-dim);
+  }
+}
+
+.rank-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.8rem;
+  background: rgba(255, 107, 53, 0.1);
+  border: 1px solid rgba(255, 107, 53, 0.25);
+  border-radius: var(--radius-full);
+  font-family: var(--font-heading);
+  font-size: 0.9rem;
+  color: var(--color-accent);
+  width: fit-content;
+}
+
+/* ===== PERCENTILE BAR ===== */
+.percentile-bar {
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.82rem;
+    color: var(--color-text-dim);
+    margin-bottom: 0.6rem;
+  }
+
+  &__pct { color: var(--color-accent); font-weight: 600; }
+
+  &__track {
+    height: 8px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-full);
+    overflow: hidden;
+  }
+
+  &__fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--color-accent), var(--color-gold));
+    border-radius: var(--radius-full);
+    transition: width 1s ease;
+    min-width: 3px;
+    position: relative;
+
+    &::after {
+      content: '';
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 4px;
+      background: rgba(255, 255, 255, 0.6);
+      border-radius: var(--radius-full);
+    }
+  }
+}
+
+/* ===== EXPLORATION ===== */
+.exploration-progress {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-rows: auto auto;
+  align-items: center;
+  gap: 0.4rem 1.5rem;
+
+  &__counter {
+    grid-row: 1;
+    grid-column: 1;
+    display: flex;
+    align-items: baseline;
+    gap: 0.2rem;
+    font-family: var(--font-heading);
+  }
+
+  &__num   { font-size: 2.5rem; color: var(--color-accent); line-height: 1; }
+  &__sep   { font-size: 1.2rem; color: var(--color-text-dim); }
+  &__total { font-size: 1.5rem; color: var(--color-text-dim); }
+
+  &__label {
+    grid-row: 2;
+    grid-column: 1;
+    font-size: 0.8rem;
+    color: var(--color-text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+  }
+
+  &__track {
+    grid-row: 1 / 3;
+    grid-column: 2;
+    height: 10px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-full);
+    overflow: hidden;
+  }
+
+  &__fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--color-accent), var(--color-gold));
+    border-radius: var(--radius-full);
+    transition: width 1s ease;
+    min-width: 3px;
+  }
+
+  &__pct {
+    grid-row: 1 / 3;
+    grid-column: 3;
+    font-family: var(--font-heading);
+    font-size: 1.1rem;
+    color: var(--color-text);
+    white-space: nowrap;
+  }
+}
+
+/* ===== CITIES GRID ===== */
+.cities-grid-rec {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-sm);
+
+  @media (max-width: 600px) { grid-template-columns: repeat(2, 1fr); }
+}
+
+.city-rec {
+  position: relative;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+  transition: transform var(--transition-normal), border-color var(--transition-normal);
+
+  &--visited {
+    border-color: rgba(255, 107, 53, 0.2);
+    background: linear-gradient(145deg, rgba(255, 107, 53, 0.07), rgba(14, 14, 24, 0.6));
+
+    &:hover { transform: translateY(-3px); border-color: rgba(255, 107, 53, 0.35); }
+  }
+
+  &--locked {
+    background: rgba(10, 10, 18, 0.6);
+    opacity: 0.5;
+    cursor: default;
+    filter: grayscale(0.4);
+  }
+
+  &__inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 1.5rem 1rem;
+    text-align: center;
+  }
+
+  &__emoji { font-size: 2rem; line-height: 1; }
+
+  &__name {
+    font-weight: 700;
+    font-size: 0.875rem;
+    color: var(--color-text);
+    font-family: var(--font-heading);
+  }
+
+  &__date {
+    font-size: 0.7rem;
+    color: var(--color-accent);
+    font-weight: 600;
+  }
+
+  &__locked-label {
+    font-size: 0.65rem;
+    color: var(--color-text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  &__check {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 20px;
+    height: 20px;
+    background: var(--color-accent);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.65rem;
+    font-weight: 800;
+    color: #fff;
+  }
+}
+
+/* ===== COLLECTION ===== */
+.collection-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-md);
+
+  @media (max-width: 600px) { grid-template-columns: repeat(2, 1fr); }
+}
+
+.collection-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg) var(--spacing-md);
+  background: linear-gradient(145deg, rgba(26, 26, 37, 0.9), rgba(14, 14, 24, 0.6));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  text-align: center;
+  transition: border-color var(--transition-normal);
+
+  &:hover { border-color: rgba(255, 107, 53, 0.2); }
+
+  &--gold {
+    border-color: rgba(212, 175, 55, 0.18);
+    background: linear-gradient(145deg, rgba(212, 175, 55, 0.07), rgba(14, 14, 24, 0.6));
+    .collection-stat__value { color: var(--color-gold); }
+  }
+
+  &--accent {
+    border-color: rgba(255, 107, 53, 0.18);
+    background: linear-gradient(145deg, rgba(255, 107, 53, 0.07), rgba(14, 14, 24, 0.6));
+    .collection-stat__value { color: var(--color-accent); }
+  }
+
+  &__icon  { font-size: 2rem; }
+  &__value {
+    font-family: var(--font-heading);
+    font-size: 2rem;
+    color: var(--color-text);
+    line-height: 1;
+    &--sm { font-size: 1rem; line-height: 1.3; }
+  }
+  &__label { font-size: 0.78rem; color: var(--color-text-dim); text-transform: uppercase; letter-spacing: 0.06em; }
+}
+
+/* ===== ACTIVITY TIMELINE ===== */
+.activity-timeline {
+  display: flex;
+  flex-direction: column;
+}
+
+.timeline-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: linear-gradient(145deg, rgba(26, 26, 37, 0.7), rgba(14, 14, 24, 0.4));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-lg);
+
+  &__dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.2);
+    border: 2px solid rgba(255, 255, 255, 0.1);
+    flex-shrink: 0;
+
+    &--accent {
+      background: var(--color-accent);
+      border-color: rgba(255, 107, 53, 0.4);
+      box-shadow: 0 0 8px rgba(255, 107, 53, 0.4);
+    }
+  }
+
+  &__line {
+    width: 2px;
+    height: 1.5rem;
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0.06), rgba(255, 107, 53, 0.15));
+    margin-left: calc(var(--spacing-lg) + 5px);
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    flex: 1;
+  }
+
+  &__title { font-size: 0.78rem; color: var(--color-text-dim); text-transform: uppercase; letter-spacing: 0.06em; }
+  &__value { font-family: var(--font-heading); font-size: 1.05rem; color: var(--color-text); }
+
+  &__badge {
+    font-family: var(--font-heading);
+    font-size: 0.9rem;
+    color: var(--color-accent);
+    background: rgba(255, 107, 53, 0.1);
+    border: 1px solid rgba(255, 107, 53, 0.2);
+    border-radius: var(--radius-full);
+    padding: 0.2rem 0.7rem;
+    flex-shrink: 0;
+  }
+}
+
+/* ===== EMPTY ===== */
+.records-empty {
+  color: var(--color-text-dim);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: var(--spacing-xl);
+  border: 1px dashed rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-lg);
+}

--- a/web/frontend/src/app/features/records/records.component.ts
+++ b/web/frontend/src/app/features/records/records.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit, signal, computed, inject, ChangeDetectionStrategy } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { RecordsService } from '../../core/services/records.service';
+import type { PersonalRecords } from '../../core/models/records.model';
+
+@Component({
+  selector: 'app-records',
+  standalone: true,
+  imports: [DatePipe],
+  templateUrl: './records.component.html',
+  styleUrl: './records.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RecordsComponent implements OnInit {
+  private readonly recordsService = inject(RecordsService);
+
+  readonly records = signal<PersonalRecords | null>(null);
+  readonly isLoading = signal(true);
+  readonly hasError = signal(false);
+
+  readonly explorationPct = computed(() => {
+    const r = this.records();
+    if (!r || r.exploration.total_cities === 0) return 0;
+    return Math.round((r.exploration.visited_count / r.exploration.total_cities) * 100);
+  });
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading.set(true);
+    this.hasError.set(false);
+    this.recordsService.getMyRecords().subscribe({
+      next: (data) => {
+        this.records.set(data);
+        this.isLoading.set(false);
+      },
+      error: () => {
+        this.hasError.set(true);
+        this.isLoading.set(false);
+      },
+    });
+  }
+
+  fmt(value: number): string {
+    if (value >= 1_000_000) return (value / 1_000_000).toFixed(1) + 'M';
+    if (value >= 1_000) return (value / 1_000).toFixed(1) + 'K';
+    return value.toLocaleString('fr-FR');
+  }
+}

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -16,6 +16,7 @@
         <a routerLink="/map"       routerLinkActive="active"><span aria-hidden="true">🗺️</span> Carte</a>
         <a routerLink="/shop"      routerLinkActive="active"><span aria-hidden="true">🛒</span> Boutique</a>
         <a routerLink="/inventory" routerLinkActive="active"><span aria-hidden="true">🎒</span> Inventaire</a>
+        <a routerLink="/records"   routerLinkActive="active"><span aria-hidden="true">📈</span> Records</a>
         @if (auth.currentUser()?.roles?.includes('ROLE_ADMIN')) {
           <a routerLink="/stats" routerLinkActive="active"><span aria-hidden="true">📊</span> Stats</a>
         }
@@ -80,6 +81,7 @@
         <a routerLink="/map"       routerLinkActive="active" (click)="closeMobileMenu()">🗺️ Carte</a>
         <a routerLink="/shop"      routerLinkActive="active" (click)="closeMobileMenu()">🛒 Boutique</a>
         <a routerLink="/inventory" routerLinkActive="active" (click)="closeMobileMenu()">🎒 Inventaire</a>
+        <a routerLink="/records"   routerLinkActive="active" (click)="closeMobileMenu()">📈 Records</a>
         @if (auth.currentUser()?.roles?.includes('ROLE_ADMIN')) {
           <a routerLink="/stats" routerLinkActive="active" (click)="closeMobileMenu()">📊 Stats</a>
         }


### PR DESCRIPTION
## Résumé

- Page `/records` : visualisation des records personnels du joueur (MazCoins, exploration, collection, activité)
- Endpoint `GET /api/records` avec rang, percentile, liste de toutes les villes (visitées / verrouillées), stats collection, dates d'activité
- Locale `fr-FR` enregistrée globalement dans Angular (`registerLocaleData` + `LOCALE_ID`)
- Sécurité : règle `ROLE_USER` explicite pour `^/api/records` dans `security.yaml`

Closes #62