### PR TITLE
feat(commands): page liste des commandes Discord (#64)

### DIFF
--- a/web/frontend/src/app/features/commands/commands.component.html
+++ b/web/frontend/src/app/features/commands/commands.component.html
@@ -1,3 +1,76 @@
-<div class="container">
-  <h2>Commandes — à venir</h2>
+<div class="commands-page">
+
+  <!-- Header -->
+  <div class="commands-header container">
+    <span class="section-label">Bot Discord</span>
+    <h1>Commandes <span class="text-gradient">MazWorld</span></h1>
+    <p class="subtitle">Toutes les commandes slash disponibles sur votre serveur Discord.</p>
+  </div>
+
+  <!-- Tip banner -->
+  <div class="commands-tip container">
+    <span class="commands-tip__icon">💡</span>
+    <span>Tapez <strong>/</strong> dans Discord pour accéder aux commandes. Elles sont disponibles sur tout serveur où le bot est présent.</span>
+  </div>
+
+  <!-- Categories -->
+  @for (cat of categories; track cat.id) {
+    <section class="cmd-category container">
+
+      <div class="cmd-category__header">
+        <span class="cmd-category__icon">{{ cat.emoji }}</span>
+        <span class="cmd-category__title">{{ cat.label }}</span>
+        <span class="cmd-category__count">{{ commandsFor(cat.id).length }} commande{{ commandsFor(cat.id).length > 1 ? 's' : '' }}</span>
+      </div>
+
+      <div class="cmd-grid">
+        @for (cmd of commandsFor(cat.id); track cmd.name) {
+          <div class="cmd-card">
+
+            <div class="cmd-card__top">
+              <span class="cmd-card__emoji">{{ cmd.emoji }}</span>
+              <span class="cmd-card__name">/{{ cmd.name }}</span>
+            </div>
+
+            <p class="cmd-card__desc">{{ cmd.description }}</p>
+
+            @if (cmd.options?.length) {
+              <div class="cmd-options">
+                @for (opt of cmd.options!; track opt.name) {
+                  <div class="cmd-option">
+                    <span class="cmd-option__name">{{ opt.name }}</span>
+                    <span class="cmd-option__badge" [class.cmd-option__badge--required]="opt.required" [class.cmd-option__badge--optional]="!opt.required">
+                      {{ opt.required ? 'requis' : 'optionnel' }}
+                    </span>
+                    @if (opt.choices) {
+                      <span class="cmd-option__detail">
+                        @for (c of opt.choices; track c) {
+                          <span class="cmd-choice">{{ c }}</span>
+                        }
+                      </span>
+                    } @else if (opt.range) {
+                      <span class="cmd-option__detail">{{ opt.range.min }}–{{ opt.range.max }} {{ opt.range.unit }}</span>
+                    } @else {
+                      <span class="cmd-option__detail">{{ opt.description }}</span>
+                    }
+                  </div>
+                }
+              </div>
+            }
+
+            @if (cmd.meta?.length) {
+              <div class="cmd-meta">
+                @for (m of cmd.meta!; track m.label) {
+                  <span class="cmd-meta-tag">{{ m.icon }} {{ m.label }}</span>
+                }
+              </div>
+            }
+
+          </div>
+        }
+      </div>
+
+    </section>
+  }
+
 </div>

--- a/web/frontend/src/app/features/commands/commands.component.scss
+++ b/web/frontend/src/app/features/commands/commands.component.scss
@@ -1,0 +1,229 @@
+.commands-page {
+  min-height: calc(100vh - 68px);
+  padding: var(--spacing-xl) 0 var(--spacing-2xl);
+}
+
+/* ===== HEADER ===== */
+.commands-header {
+  margin-bottom: var(--spacing-2xl);
+
+  .section-label {
+    display: inline-block;
+    font-family: var(--font-heading);
+    font-size: 0.72rem;
+    letter-spacing: 0.22em;
+    color: var(--color-accent);
+    text-transform: uppercase;
+    margin-bottom: 0.25rem;
+  }
+
+  h1      { margin: 0; line-height: 1.1; }
+  .subtitle { margin: 0.5rem 0 0; font-size: 0.95rem; color: var(--color-text-dim); }
+}
+
+/* ===== CATEGORY SECTION ===== */
+.cmd-category {
+  margin-bottom: var(--spacing-2xl);
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-lg);
+    padding-bottom: var(--spacing-sm);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  &__icon {
+    font-size: 1.3rem;
+    width: 38px;
+    height: 38px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 107, 53, 0.08);
+    border: 1px solid rgba(255, 107, 53, 0.15);
+    border-radius: var(--radius-md);
+    flex-shrink: 0;
+  }
+
+  &__title {
+    font-family: var(--font-heading);
+    font-size: 1rem;
+    color: var(--color-text);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+
+  &__count {
+    margin-left: auto;
+    font-size: 0.75rem;
+    color: var(--color-text-dim);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius-full);
+    padding: 0.15rem 0.6rem;
+  }
+}
+
+/* ===== COMMAND GRID ===== */
+.cmd-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--spacing-md);
+
+  @media (max-width: 480px) { grid-template-columns: 1fr; }
+}
+
+/* ===== COMMAND CARD ===== */
+.cmd-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+  background: linear-gradient(145deg, rgba(26, 26, 37, 0.9), rgba(14, 14, 24, 0.6));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--transition-normal), transform var(--transition-normal);
+
+  &:hover {
+    border-color: rgba(255, 107, 53, 0.2);
+    transform: translateY(-2px);
+  }
+
+  &__top {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+  }
+
+  &__emoji {
+    font-size: 1.4rem;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+
+  &__name {
+    font-family: var(--font-heading);
+    font-size: 1.05rem;
+    color: var(--color-accent);
+    letter-spacing: 0.02em;
+  }
+
+  &__desc {
+    font-size: 0.875rem;
+    color: var(--color-text-dim);
+    line-height: 1.55;
+    flex: 1;
+  }
+}
+
+/* ===== OPTIONS ===== */
+.cmd-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cmd-option {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+
+  &__name {
+    font-family: var(--font-mono, monospace);
+    font-size: 0.78rem;
+    color: var(--color-text);
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-sm);
+    padding: 0.1rem 0.45rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  &__badge {
+    font-size: 0.65rem;
+    font-family: var(--font-heading);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.1rem 0.4rem;
+    border-radius: var(--radius-full);
+    flex-shrink: 0;
+
+    &--required {
+      color: var(--color-accent);
+      background: rgba(255, 107, 53, 0.12);
+      border: 1px solid rgba(255, 107, 53, 0.2);
+    }
+
+    &--optional {
+      color: var(--color-text-dim);
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.07);
+    }
+  }
+
+  &__detail {
+    color: var(--color-text-dim);
+    font-size: 0.78rem;
+    line-height: 1.4;
+  }
+}
+
+/* ===== CHOICES ===== */
+.cmd-choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.2rem;
+}
+
+.cmd-choice {
+  font-size: 0.72rem;
+  font-family: var(--font-heading);
+  color: var(--color-text);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  padding: 0.1rem 0.4rem;
+}
+
+/* ===== META TAGS ===== */
+.cmd-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding-top: var(--spacing-sm);
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.cmd-meta-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  color: var(--color-text-dim);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-full);
+  padding: 0.2rem 0.65rem;
+}
+
+/* ===== INTRO BANNER ===== */
+.commands-tip {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: rgba(255, 107, 53, 0.06);
+  border: 1px solid rgba(255, 107, 53, 0.15);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--spacing-2xl);
+  font-size: 0.875rem;
+  color: var(--color-text-dim);
+
+  &__icon { font-size: 1.3rem; flex-shrink: 0; }
+  strong  { color: var(--color-text); }
+}

--- a/web/frontend/src/app/features/commands/commands.component.ts
+++ b/web/frontend/src/app/features/commands/commands.component.ts
@@ -1,9 +1,17 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { COMMAND_CATEGORIES, BOT_COMMANDS, type BotCommand } from './commands.data';
 
 @Component({
   selector: 'app-commands',
   standalone: true,
   templateUrl: './commands.component.html',
+  styleUrl: './commands.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CommandsComponent {}
+export class CommandsComponent {
+  readonly categories = COMMAND_CATEGORIES;
+
+  commandsFor(categoryId: string): BotCommand[] {
+    return BOT_COMMANDS.filter(c => c.category === categoryId);
+  }
+}

--- a/web/frontend/src/app/features/commands/commands.data.ts
+++ b/web/frontend/src/app/features/commands/commands.data.ts
@@ -1,0 +1,112 @@
+export interface CommandOption {
+  name: string;
+  description: string;
+  required: boolean;
+  type: 'string' | 'integer' | 'user';
+  choices?: string[];
+  range?: { min: number; max: number; unit: string };
+}
+
+export interface CommandMeta {
+  icon: string;
+  label: string;
+}
+
+export interface BotCommand {
+  name: string;
+  description: string;
+  category: string;
+  emoji: string;
+  options?: CommandOption[];
+  meta?: CommandMeta[];
+}
+
+export const COMMAND_CATEGORIES = [
+  { id: 'profil',       label: 'Profil',       emoji: '👤' },
+  { id: 'recompenses',  label: 'Récompenses',  emoji: '🎁' },
+  { id: 'jeux',         label: 'Jeux',         emoji: '🎰' },
+  { id: 'exploration',  label: 'Exploration',  emoji: '🗺️' },
+] as const;
+
+export const BOT_COMMANDS: BotCommand[] = [
+  {
+    name: 'profile',
+    description: 'Affiche votre carte de profil personnalisée avec vos stats, équipements et MazCoins.',
+    category: 'profil',
+    emoji: '🪪',
+    options: [
+      {
+        name: 'utilisateur',
+        description: 'Voir le profil d\'un autre joueur',
+        required: false,
+        type: 'user',
+      },
+    ],
+  },
+  {
+    name: 'inventory',
+    description: 'Consultez votre inventaire, équipez ou retirez vos backgrounds et badges.',
+    category: 'profil',
+    emoji: '🎒',
+  },
+  {
+    name: 'shop',
+    description: 'Accédez à la boutique pour acheter des backgrounds et badges avec vos MazCoins.',
+    category: 'profil',
+    emoji: '🛒',
+  },
+  {
+    name: 'daily',
+    description: 'Réclamez votre récompense quotidienne de MazCoins. Une seule fois par 24 heures.',
+    category: 'recompenses',
+    emoji: '📅',
+    meta: [
+      { icon: '⏱️', label: 'Cooldown : 24h' },
+      { icon: '🪙', label: 'Récompense : 5 MZC' },
+    ],
+  },
+  {
+    name: 'work',
+    description: 'Travaillez dans votre ville actuelle pour gagner des MazCoins. Le montant varie selon le job.',
+    category: 'recompenses',
+    emoji: '💼',
+    meta: [
+      { icon: '⏱️', label: 'Cooldown : 1h' },
+      { icon: '🪙', label: 'Récompense : 20–30 MZC' },
+    ],
+  },
+  {
+    name: 'coinflip',
+    description: 'Pariez vos MazCoins sur pile ou face — doublez ou perdez votre mise.',
+    category: 'jeux',
+    emoji: '🪙',
+    options: [
+      {
+        name: 'choix',
+        description: 'Pile ou face',
+        required: true,
+        type: 'string',
+        choices: ['pile', 'face'],
+      },
+      {
+        name: 'mise',
+        description: 'Montant à parier',
+        required: true,
+        type: 'integer',
+        range: { min: 10, max: 500, unit: 'MZC' },
+      },
+    ],
+  },
+  {
+    name: 'map',
+    description: 'Consultez la carte interactive et lancez un voyage vers une ville adjacente.',
+    category: 'exploration',
+    emoji: '🗺️',
+  },
+  {
+    name: 'cityinfo',
+    description: 'Découvrez les détails de votre ville actuelle : jobs disponibles, description et thème.',
+    category: 'exploration',
+    emoji: '🏙️',
+  },
+];


### PR DESCRIPTION
## Résumé

- Page publique `/commands` listant les 8 commandes slash de l'univers RPG MazWorld
- Groupées par catégorie (Profil, Récompenses, Jeux, Exploration)
- Données statiques dans `commands.data.ts` — pas de backend requis
- Options avec badge requis/optionnel, choix et plages de valeurs
- Liens déjà présents dans le header (desktop + mobile)

Closes #64