### PR TITLE
feat(servers): récupération et affichage des serveurs Discord admin (SU #83, #84 & #85)

### DIFF
--- a/web/backend/config/packages/security.yaml
+++ b/web/backend/config/packages/security.yaml
@@ -39,6 +39,8 @@ security:
         - { path: ^/api/shop/purchase, roles: ROLE_USER }
         - { path: ^/api/leaderboard/me, roles: ROLE_USER }
         - { path: ^/api/records, roles: ROLE_USER }
+        - { path: ^/api/servers, roles: ROLE_USER }
+        - { path: ^/api/bot/status, roles: PUBLIC_ACCESS }
         - { path: ^/api, roles: PUBLIC_ACCESS }
 
 when@test:

--- a/web/backend/config/services.yaml
+++ b/web/backend/config/services.yaml
@@ -10,6 +10,8 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+        bind:
+            string $discordClientId: '%env(DISCORD_CLIENT_ID)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
@@ -25,3 +27,4 @@ services:
             $clientId: '%env(DISCORD_CLIENT_ID)%'
             $clientSecret: '%env(DISCORD_CLIENT_SECRET)%'
             $redirectUri: '%env(DISCORD_REDIRECT_URI)%'
+            $botToken: '%env(DISCORD_BOT_TOKEN)%'

--- a/web/backend/src/Controller/API/ServersController.php
+++ b/web/backend/src/Controller/API/ServersController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Service\Discord\DiscordApiClient;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api', name: 'api_servers_')]
+class ServersController extends AbstractApiController
+{
+    public function __construct(
+        private readonly DiscordApiClient $discord,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly string $discordClientId
+    ) {}
+
+    #[Route('/servers', name: 'list', methods: ['GET'])]
+    public function listServers(): JsonResponse
+    {
+        $user = $this->getCurrentUser();
+
+        if (!$user) {
+            return $this->unauthorizedResponse();
+        }
+
+        $accessToken = $user->getOauthAccessToken();
+        if (!$accessToken) {
+            return $this->errorResponse('No OAuth token available. Please log in again.');
+        }
+
+        if ($user->isAccessTokenExpired()) {
+            $refreshToken = $user->getOauthRefreshToken();
+            if (!$refreshToken) {
+                return $this->errorResponse('OAuth token expired. Please log in again.', Response::HTTP_UNAUTHORIZED);
+            }
+
+            try {
+                $newTokens = $this->discord->refreshTokens($refreshToken);
+                $user->setOauthAccessToken($newTokens->accessToken);
+                $user->setOauthRefreshToken($newTokens->refreshToken);
+                $user->setOauthTokenExpiresAt(time() + $newTokens->expiresIn);
+                $this->entityManager->flush();
+                $accessToken = $newTokens->accessToken;
+            } catch (\Throwable) {
+                return $this->errorResponse('OAuth token expired. Please log in again.', Response::HTTP_UNAUTHORIZED);
+            }
+        }
+
+        try {
+            $guilds = $this->discord->getCurrentUserGuilds($accessToken);
+
+            $adminGuilds = array_filter($guilds, fn($guild) =>
+                $guild->owner
+                || ($guild->permissions & 0x8)   // ADMINISTRATOR
+                || ($guild->permissions & 0x20)  // MANAGE_GUILD
+            );
+
+            $result = array_map(function ($guild) {
+                $botPresent = $this->discord->isBotInGuild($guild->id);
+                $inviteUrl  = $botPresent ? null : $this->buildInviteUrl($guild->id);
+
+                return [
+                    'id'           => $guild->id,
+                    'name'         => $guild->name,
+                    'icon'         => $guild->getIconUrl(64),
+                    'owner'        => $guild->owner,
+                    'member_count' => $guild->approximate_member_count,
+                    'bot_present'  => $botPresent,
+                    'invite_url'   => $inviteUrl,
+                ];
+            }, $adminGuilds);
+
+            usort($result, fn($a, $b) => $b['bot_present'] <=> $a['bot_present']);
+
+            return new JsonResponse($result);
+        } catch (\Throwable $e) {
+            return $this->errorResponse('Failed to fetch servers: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[Route('/bot/status', name: 'bot_status', methods: ['GET'])]
+    public function botStatus(): JsonResponse
+    {
+        $info = $this->discord->getBotInfo();
+
+        if ($info === null) {
+            return new JsonResponse(['online' => false, 'username' => null, 'bot_id' => null]);
+        }
+
+        return new JsonResponse($info);
+    }
+
+    private function buildInviteUrl(string $guildId): string
+    {
+        $params = [
+            'client_id'   => $this->discordClientId,
+            'scope'       => 'bot applications.commands',
+            'permissions' => '414464674816',
+            'guild_id'    => $guildId,
+        ];
+
+        return 'https://discord.com/oauth2/authorize?' . http_build_query($params);
+    }
+}

--- a/web/backend/src/Service/Discord/DiscordApiClient.php
+++ b/web/backend/src/Service/Discord/DiscordApiClient.php
@@ -16,7 +16,8 @@ class DiscordApiClient
         private readonly HttpClientInterface $httpClient,
         private readonly string $clientId,
         private readonly string $clientSecret,
-        private readonly string $redirectUri
+        private readonly string $redirectUri,
+        private readonly string $botToken = ''
     ) {}
 
     public function getAuthorizationUrl(string $state, array $scopes = ['identify', 'email', 'guilds']): string
@@ -97,16 +98,38 @@ class DiscordApiClient
         return DiscordGuildDTO::fromArrayList($response->toArray());
     }
 
-    public function isBotInGuild(string $botToken, string $guildId): bool
+    public function isBotInGuild(string $guildId): bool
     {
         try {
             $response = $this->httpClient->request('GET', self::API_URL . '/guilds/' . $guildId, [
-                'headers' => ['Authorization' => 'Bot ' . $botToken],
+                'headers' => ['Authorization' => 'Bot ' . $this->botToken],
             ]);
 
             return $response->getStatusCode() === 200;
         } catch (\Exception) {
             return false;
+        }
+    }
+
+    public function getBotInfo(): ?array
+    {
+        try {
+            $response = $this->httpClient->request('GET', self::API_URL . '/users/@me', [
+                'headers' => ['Authorization' => 'Bot ' . $this->botToken],
+            ]);
+
+            if ($response->getStatusCode() !== 200) {
+                return null;
+            }
+
+            $data = $response->toArray();
+            return [
+                'online'   => true,
+                'username' => $data['username'] ?? null,
+                'bot_id'   => $data['id'] ?? null,
+            ];
+        } catch (\Exception) {
+            return null;
         }
     }
 

--- a/web/frontend/src/app/app.routes.ts
+++ b/web/frontend/src/app/app.routes.ts
@@ -65,5 +65,11 @@ export const routes: Routes = [
     loadComponent: () => import('./features/commands/commands.component').then(m => m.CommandsComponent),
     title: 'Commandes — MazWorld',
   },
+  {
+    path: 'servers',
+    loadComponent: () => import('./features/servers/servers.component').then(m => m.ServersComponent),
+    title: 'Mes serveurs — MazWorld',
+    canActivate: [authGuard],
+  },
   { path: '**', redirectTo: '' },
 ];

--- a/web/frontend/src/app/core/models/index.ts
+++ b/web/frontend/src/app/core/models/index.ts
@@ -6,3 +6,4 @@ export * from './inventory.model';
 export * from './leaderboard.model';
 export * from './stats.model';
 export * from './records.model';
+export * from './servers.model';

--- a/web/frontend/src/app/core/models/servers.model.ts
+++ b/web/frontend/src/app/core/models/servers.model.ts
@@ -1,0 +1,15 @@
+export interface DiscordServer {
+  id: string;
+  name: string;
+  icon: string | null;
+  owner: boolean;
+  member_count: number | null;
+  bot_present: boolean;
+  invite_url: string | null;
+}
+
+export interface BotStatus {
+  online: boolean;
+  username: string | null;
+  bot_id: string | null;
+}

--- a/web/frontend/src/app/core/services/index.ts
+++ b/web/frontend/src/app/core/services/index.ts
@@ -7,3 +7,4 @@ export * from './inventory.service';
 export * from './leaderboard.service';
 export * from './stats.service';
 export * from './records.service';
+export * from './servers.service';

--- a/web/frontend/src/app/core/services/servers.service.ts
+++ b/web/frontend/src/app/core/services/servers.service.ts
@@ -1,0 +1,19 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import type { DiscordServer, BotStatus } from '../models/servers.model';
+
+@Injectable({ providedIn: 'root' })
+export class ServersService {
+  private readonly http = inject(HttpClient);
+  private readonly base = environment.apiUrl;
+
+  getMyServers(): Observable<DiscordServer[]> {
+    return this.http.get<DiscordServer[]>(`${this.base}/api/servers`);
+  }
+
+  getBotStatus(): Observable<BotStatus> {
+    return this.http.get<BotStatus>(`${this.base}/api/bot/status`);
+  }
+}

--- a/web/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/web/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -4,13 +4,12 @@ import { ProfileService } from '../../core/services/profile.service';
 import { LeaderboardService } from '../../core/services/leaderboard.service';
 import { StatCardComponent } from '../../shared/components/ui/stat-card/stat-card.component';
 import { AvatarComponent } from '../../shared/components/ui/avatar/avatar.component';
-import { BadgeComponent } from '../../shared/components/ui/badge/badge.component';
 import type { UserProfile } from '../../core/models/profile.model';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [StatCardComponent, AvatarComponent, BadgeComponent],
+  imports: [StatCardComponent, AvatarComponent],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/web/frontend/src/app/features/servers/servers.component.html
+++ b/web/frontend/src/app/features/servers/servers.component.html
@@ -1,0 +1,115 @@
+<div class="servers-page">
+
+  <!-- Header -->
+  <div class="servers-header container">
+    <span class="section-label">Gestion des serveurs</span>
+    <h1>Mes serveurs <span class="text-gradient">Discord</span></h1>
+    <p class="subtitle">Serveurs Discord où vous êtes administrateur ou gérant.</p>
+  </div>
+
+  <!-- Bot status bar -->
+  @if (botStatus(); as status) {
+    <div class="bot-statusbar container">
+      <div class="bot-statusbar__dot" [class.bot-statusbar__dot--online]="status.online" [class.bot-statusbar__dot--offline]="!status.online"></div>
+      <span class="bot-statusbar__label">
+        Bot
+        @if (status.username) { <strong>{{ status.username }}</strong> }
+        — <span [class.text-online]="status.online" [class.text-offline]="!status.online">{{ status.online ? 'En ligne' : 'Hors ligne' }}</span>
+      </span>
+      @if (totalCount() > 0) {
+        <span class="bot-statusbar__count">{{ presentCount() }} / {{ totalCount() }} serveurs</span>
+      }
+    </div>
+  }
+
+  <!-- States -->
+  @if (isLoading()) {
+    <div class="servers-state container">
+      <div class="loading"></div>
+      <p>Récupération de vos serveurs Discord…</p>
+    </div>
+  } @else if (hasError()) {
+    <div class="servers-state servers-state--error container">
+      <span class="servers-state__icon">⚠️</span>
+      <p>Impossible de récupérer vos serveurs. Vérifiez que vous êtes bien connecté via Discord.</p>
+      <button class="btn-primary" (click)="load()">Réessayer</button>
+    </div>
+  } @else if (servers().length === 0) {
+    <div class="servers-state container">
+      <span class="servers-state__icon">🔍</span>
+      <p>Aucun serveur trouvé.</p>
+    </div>
+  } @else {
+
+    <!-- Servers with bot -->
+    @if (presentCount() > 0) {
+      <section class="servers-section container">
+        <div class="servers-section__label">
+          <span class="servers-section__icon">✅</span>
+          <span class="section-label">Bot présent</span>
+        </div>
+        <div class="servers-grid">
+          @for (server of servers(); track server.id) {
+            @if (server.bot_present) {
+              <div class="server-card server-card--active">
+                <div class="server-card__icon">
+                  @if (server.icon) {
+                    <img [src]="server.icon" [alt]="server.name" class="server-card__img" />
+                  } @else {
+                    <span class="server-card__initials">{{ server.name.charAt(0) }}</span>
+                  }
+                </div>
+                <div class="server-card__body">
+                  <span class="server-card__name">{{ server.name }}</span>
+                  @if (server.member_count) {
+                    <span class="server-card__members">{{ fmtCount(server.member_count) }} membres</span>
+                  }
+                </div>
+                <span class="server-card__badge server-card__badge--present">Bot actif</span>
+              </div>
+            }
+          }
+        </div>
+      </section>
+    }
+
+    <!-- Servers without bot -->
+    @if (presentCount() < totalCount()) {
+      <div class="servers-divider container"></div>
+      <section class="servers-section container">
+        <div class="servers-section__label">
+          <span class="servers-section__icon">➕</span>
+          <span class="section-label">Ajouter le bot</span>
+        </div>
+        <div class="servers-grid">
+          @for (server of servers(); track server.id) {
+            @if (!server.bot_present) {
+              <div class="server-card">
+                <div class="server-card__icon server-card__icon--dim">
+                  @if (server.icon) {
+                    <img [src]="server.icon" [alt]="server.name" class="server-card__img" />
+                  } @else {
+                    <span class="server-card__initials">{{ server.name.charAt(0) }}</span>
+                  }
+                </div>
+                <div class="server-card__body">
+                  <span class="server-card__name">{{ server.name }}</span>
+                  @if (server.member_count) {
+                    <span class="server-card__members">{{ fmtCount(server.member_count) }} membres</span>
+                  }
+                </div>
+                @if (server.invite_url) {
+                  <button class="server-card__add" (click)="openInvite(server.invite_url!)">
+                    <span aria-hidden="true">➕</span> Ajouter
+                  </button>
+                }
+              </div>
+            }
+          }
+        </div>
+      </section>
+    }
+
+  }
+
+</div>

--- a/web/frontend/src/app/features/servers/servers.component.scss
+++ b/web/frontend/src/app/features/servers/servers.component.scss
@@ -1,0 +1,219 @@
+.servers-page {
+  min-height: calc(100vh - 68px);
+  padding: var(--spacing-xl) 0 var(--spacing-2xl);
+}
+
+/* ===== HEADER ===== */
+.servers-header {
+  margin-bottom: var(--spacing-xl);
+
+  .section-label {
+    display: inline-block;
+    font-family: var(--font-heading);
+    font-size: 0.72rem;
+    letter-spacing: 0.22em;
+    color: var(--color-accent);
+    text-transform: uppercase;
+    margin-bottom: 0.25rem;
+  }
+
+  h1      { margin: 0; line-height: 1.1; }
+  .subtitle { margin: 0.5rem 0 0; font-size: 0.95rem; color: var(--color-text-dim); }
+}
+
+/* ===== BOT STATUS BAR ===== */
+.bot-statusbar {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: rgba(26, 26, 37, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--spacing-xl);
+  font-size: 0.875rem;
+  color: var(--color-text-dim);
+
+  &__dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+
+    &--online  { background: #4ade80; box-shadow: 0 0 6px rgba(74, 222, 128, 0.5); }
+    &--offline { background: #94a3b8; }
+  }
+
+  &__label { flex: 1; }
+  &__count {
+    margin-left: auto;
+    font-size: 0.78rem;
+    color: var(--color-text-dim);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius-full);
+    padding: 0.15rem 0.65rem;
+  }
+}
+
+.text-online  { color: #4ade80; font-weight: 600; }
+.text-offline { color: #94a3b8; }
+
+/* ===== STATES ===== */
+.servers-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 30vh;
+  gap: var(--spacing-md);
+  color: var(--color-text-dim);
+  text-align: center;
+
+  &__icon { font-size: 2.5rem; }
+  &--error { color: #f87171; }
+}
+
+/* ===== SECTION ===== */
+.servers-section {
+  padding: var(--spacing-lg) 0;
+}
+
+.servers-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 107, 53, 0.15) 30%, rgba(255, 107, 53, 0.15) 70%, transparent);
+  margin: 0.5rem 0;
+}
+
+.servers-section__label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+
+  .section-label {
+    display: inline-block;
+    font-family: var(--font-heading);
+    font-size: 0.72rem;
+    letter-spacing: 0.22em;
+    color: var(--color-accent);
+    text-transform: uppercase;
+  }
+}
+
+.servers-section__icon { font-size: 1.1rem; }
+
+/* ===== GRID ===== */
+.servers-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--spacing-md);
+
+  @media (max-width: 480px) { grid-template-columns: 1fr; }
+}
+
+/* ===== SERVER CARD ===== */
+.server-card {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: linear-gradient(145deg, rgba(26, 26, 37, 0.9), rgba(14, 14, 24, 0.6));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--transition-normal);
+
+  &--active {
+    border-color: rgba(74, 222, 128, 0.2);
+    background: linear-gradient(145deg, rgba(74, 222, 128, 0.05), rgba(14, 14, 24, 0.6));
+  }
+
+  &:not(&--active):hover { border-color: rgba(255, 107, 53, 0.2); }
+
+  &__icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    overflow: hidden;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+
+    &--dim { opacity: 0.6; }
+  }
+
+  &__img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &__initials {
+    font-family: var(--font-heading);
+    font-size: 1.1rem;
+    color: var(--color-text-dim);
+    text-transform: uppercase;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__name {
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__members {
+    font-size: 0.75rem;
+    color: var(--color-text-dim);
+  }
+
+  &__badge {
+    font-size: 0.7rem;
+    font-family: var(--font-heading);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.2rem 0.65rem;
+    border-radius: var(--radius-full);
+    flex-shrink: 0;
+
+    &--present {
+      color: #4ade80;
+      background: rgba(74, 222, 128, 0.1);
+      border: 1px solid rgba(74, 222, 128, 0.25);
+    }
+  }
+
+  &__add {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.35rem 0.85rem;
+    background: rgba(255, 107, 53, 0.1);
+    border: 1px solid rgba(255, 107, 53, 0.25);
+    border-radius: var(--radius-full);
+    color: var(--color-accent);
+    font-family: var(--font-heading);
+    font-size: 0.78rem;
+    cursor: pointer;
+    transition: background var(--transition-normal), border-color var(--transition-normal);
+    flex-shrink: 0;
+
+    &:hover {
+      background: rgba(255, 107, 53, 0.18);
+      border-color: rgba(255, 107, 53, 0.4);
+    }
+  }
+}

--- a/web/frontend/src/app/features/servers/servers.component.ts
+++ b/web/frontend/src/app/features/servers/servers.component.ts
@@ -1,0 +1,58 @@
+import { Component, OnInit, signal, computed, inject, ChangeDetectionStrategy } from '@angular/core';
+import { ServersService } from '../../core/services/servers.service';
+import type { DiscordServer, BotStatus } from '../../core/models/servers.model';
+
+@Component({
+  selector: 'app-servers',
+  standalone: true,
+  templateUrl: './servers.component.html',
+  styleUrl: './servers.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ServersComponent implements OnInit {
+  private readonly serversService = inject(ServersService);
+
+  readonly servers    = signal<DiscordServer[]>([]);
+  readonly botStatus  = signal<BotStatus | null>(null);
+  readonly isLoading  = signal(true);
+  readonly hasError   = signal(false);
+
+  readonly presentCount = computed(() => this.servers().filter(s => s.bot_present).length);
+  readonly totalCount   = computed(() => this.servers().length);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading.set(true);
+    this.hasError.set(false);
+
+    this.serversService.getBotStatus().subscribe({
+      next: status => this.botStatus.set(status),
+      error: () => this.botStatus.set({ online: false, username: null, bot_id: null }),
+    });
+
+    this.serversService.getMyServers().subscribe({
+      next: data => {
+        this.servers.set(data);
+        this.isLoading.set(false);
+      },
+      error: () => {
+        this.hasError.set(true);
+        this.isLoading.set(false);
+      },
+    });
+  }
+
+  fmtCount(n: number | null): string {
+    if (!n) return '0';
+    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+    if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+    return n.toLocaleString('fr-FR');
+  }
+
+  openInvite(url: string): void {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+}

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -46,6 +46,9 @@
             <a routerLink="/dashboard" class="user-menu__item" role="menuitem" (click)="closeUserMenu()">
               <span aria-hidden="true">🏠</span> Dashboard
             </a>
+            <a routerLink="/servers" class="user-menu__item" role="menuitem" (click)="closeUserMenu()">
+              <span aria-hidden="true">🖥️</span> Mes serveurs
+            </a>
             <div class="user-menu__divider" role="separator"></div>
             <button class="user-menu__item user-menu__item--danger" role="menuitem" (click)="logout()">
               <span aria-hidden="true">🚪</span> Déconnexion
@@ -82,6 +85,7 @@
         <a routerLink="/shop"      routerLinkActive="active" (click)="closeMobileMenu()">🛒 Boutique</a>
         <a routerLink="/inventory" routerLinkActive="active" (click)="closeMobileMenu()">🎒 Inventaire</a>
         <a routerLink="/records"   routerLinkActive="active" (click)="closeMobileMenu()">📈 Records</a>
+        <a routerLink="/servers"   routerLinkActive="active" (click)="closeMobileMenu()">🖥️ Mes serveurs</a>
         @if (auth.currentUser()?.roles?.includes('ROLE_ADMIN')) {
           <a routerLink="/stats" routerLinkActive="active" (click)="closeMobileMenu()">📊 Stats</a>
         }


### PR DESCRIPTION
## Résumé

- Endpoint `GET /api/servers` : retourne les serveurs Discord où l'utilisateur est owner, administrateur (`ADMINISTRATOR` 0x8) ou gestionnaire (`MANAGE_GUILD` 0x20)
- Endpoint `GET /api/bot/status` : statut du bot via l'API Discord (token bot)
- `DiscordApiClient` : `botToken` injecté via `services.yaml`, `isBotInGuild()` refactorisé (1 param), `getBotInfo()` ajouté
- `ServersComponent` : barre de statut bot, liste séparée (bot présent ✅ / à ajouter ➕), bouton d'invitation par serveur
- Route `/servers` protégée par `authGuard`, lien dans le dropdown header
- Filtre permissions Discord pour n'afficher que les serveurs administrables

Closes #83 #84 #85