### PR TITLE
feat(bot): centralized error handler + structured logger (SU #87/#88)

### DIFF
--- a/bot/src/commands/mazworld/cityinfo.ts
+++ b/bot/src/commands/mazworld/cityinfo.ts
@@ -3,7 +3,8 @@ import {
   ChatInputCommandInteraction,
   MessageFlags,
 } from "discord.js";
-import { api, ApiError } from "../../api/client";
+import { api } from "../../api/client";
+import { handleCommandError } from "../../utils/errorHandler";
 import { Command } from "../../models/Command";
 import type { TravelStatus, MapResponse } from "./data";
 import { buildCityinfoEmbed } from "./utils/embeds";
@@ -39,17 +40,7 @@ const cityinfo: Command = {
       const mapData = await api.get<MapResponse>("/api/travel/map", userId, username);
       await interaction.reply({ embeds: [buildCityinfoEmbed(mapData, avatarURL)] });
     } catch (error) {
-      if (error instanceof ApiError) {
-        await interaction.reply({ content: `❌ ${error.message}`, flags: MessageFlags.Ephemeral });
-        return;
-      }
-      console.error("Erreur dans /cityinfo:", error);
-      const errorMessage = "❌ Une erreur est survenue lors de l'affichage des informations de la ville.";
-      if (interaction.deferred || interaction.replied) {
-        await interaction.editReply({ content: errorMessage });
-      } else {
-        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
-      }
+      await handleCommandError(error, interaction);
     }
   },
 };

--- a/bot/src/commands/mazworld/coinflip.ts
+++ b/bot/src/commands/mazworld/coinflip.ts
@@ -1,12 +1,12 @@
 import {
   SlashCommandBuilder,
   ChatInputCommandInteraction,
-  MessageFlags,
 } from "discord.js";
-import { api, ApiError } from "../../api/client";
+import { api } from "../../api/client";
 import { Command } from "../../models/Command";
 import type { CoinflipResponse } from "./data";
 import { buildCoinflipLoadingEmbed, buildCoinflipResultEmbed } from "./utils/embeds";
+import { handleCommandError } from "../../utils/errorHandler";
 
 const coinflip: Command = {
   data: new SlashCommandBuilder()
@@ -49,22 +49,7 @@ const coinflip: Command = {
       await new Promise(resolve => setTimeout(resolve, 2000));
       await interaction.editReply({ embeds: [buildCoinflipResultEmbed(result, avatarURL)] });
     } catch (error) {
-      if (error instanceof ApiError) {
-        const content = `❌ ${error.message}`;
-        if (interaction.deferred || interaction.replied) {
-          await interaction.editReply({ content, embeds: [] });
-        } else {
-          await interaction.reply({ content, flags: MessageFlags.Ephemeral });
-        }
-        return;
-      }
-      console.error("Erreur dans /coinflip:", error);
-      const errorMessage = "❌ Une erreur est survenue lors du lancement de la pièce.";
-      if (interaction.deferred || interaction.replied) {
-        await interaction.editReply({ content: errorMessage, embeds: [] });
-      } else {
-        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
-      }
+      await handleCommandError(error, interaction);
     }
   },
 };

--- a/bot/src/commands/mazworld/daily.ts
+++ b/bot/src/commands/mazworld/daily.ts
@@ -3,10 +3,11 @@ import {
   ChatInputCommandInteraction,
   MessageFlags,
 } from "discord.js";
-import { api, ApiError } from "../../api/client";
+import { api } from "../../api/client";
 import { Command } from "../../models/Command";
 import type { DailyResponse } from "./data";
 import { buildDailySuccessEmbed, buildDailyAlreadyClaimedEmbed } from "./utils/embeds";
+import { handleCommandError } from "../../utils/errorHandler";
 
 const daily: Command = {
   data: new SlashCommandBuilder()
@@ -29,15 +30,7 @@ const daily: Command = {
         await interaction.reply({ embeds: [buildDailyAlreadyClaimedEmbed(result, avatarURL)], flags: MessageFlags.Ephemeral });
       }
     } catch (error) {
-      if (error instanceof ApiError && error.status === 429) {
-        await interaction.reply({ content: `⏰ ${error.message}`, flags: MessageFlags.Ephemeral });
-        return;
-      }
-      console.error("Erreur dans /daily:", error);
-      await interaction.reply({
-        content: "❌ Une erreur est survenue lors de la réclamation de votre récompense quotidienne.",
-        flags: MessageFlags.Ephemeral,
-      });
+      await handleCommandError(error, interaction);
     }
   },
 };

--- a/bot/src/commands/mazworld/inventory.ts
+++ b/bot/src/commands/mazworld/inventory.ts
@@ -2,9 +2,9 @@ import {
   SlashCommandBuilder,
   ChatInputCommandInteraction,
   StringSelectMenuInteraction,
-  MessageFlags,
 } from "discord.js";
-import { api, ApiError } from "../../api/client";
+import { api } from "../../api/client";
+import { handleCommandError } from "../../utils/errorHandler";
 import { Command } from "../../models/Command";
 import type { ProfileResponse, ShopListResponse, EquipResponse } from "./data";
 import {
@@ -113,8 +113,7 @@ const inventory: Command = {
             collector.stop("equipped");
           }
         } catch (error) {
-          const msg = error instanceof ApiError ? error.message : "Erreur lors du traitement.";
-          await i.editReply({ content: `❌ ${msg}`, embeds: [], components: [] });
+          await handleCommandError(error, i as any);
         }
       });
 
@@ -124,13 +123,7 @@ const inventory: Command = {
         }
       });
     } catch (error) {
-      console.error("Erreur dans /inventory:", error);
-      const msg = "❌ Une erreur est survenue lors de la consultation de votre inventaire.";
-      if (interaction.deferred) {
-        await interaction.editReply({ content: msg });
-      } else {
-        await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
-      }
+      await handleCommandError(error, interaction);
     }
   },
 };

--- a/bot/src/commands/mazworld/map.ts
+++ b/bot/src/commands/mazworld/map.ts
@@ -2,9 +2,9 @@ import {
   SlashCommandBuilder,
   ChatInputCommandInteraction,
   ComponentType,
-  MessageFlags,
 } from "discord.js";
-import { api, ApiError } from "../../api/client";
+import { api } from "../../api/client";
+import { handleCommandError } from "../../utils/errorHandler";
 import { Command } from "../../models/Command";
 import type { TravelStatus, MapResponse, TravelStartResponse } from "./data";
 import {
@@ -88,8 +88,7 @@ const map: Command = {
               }
               await btn.editReply({ embeds: [buildTravelSuccessEmbed(route, result, avatarURL)], components: [] });
             } catch (error) {
-              const msg = error instanceof ApiError ? error.message : "Erreur lors du départ.";
-              await btn.editReply({ content: `❌ ${msg}`, embeds: [], components: [] });
+              await handleCommandError(error, btn as any);
             }
             confirmCollector.stop();
           } else {
@@ -111,13 +110,7 @@ const map: Command = {
         }
       });
     } catch (error) {
-      console.error("Erreur dans /map:", error);
-      const errorMessage = "❌ Une erreur est survenue lors de l'affichage de la carte.";
-      if (interaction.deferred || interaction.replied) {
-        await interaction.editReply({ content: errorMessage });
-      } else {
-        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
-      }
+      await handleCommandError(error, interaction);
     }
   },
 };

--- a/bot/src/commands/mazworld/profile.ts
+++ b/bot/src/commands/mazworld/profile.ts
@@ -3,7 +3,8 @@ import {
   ChatInputCommandInteraction,
   MessageFlags,
 } from "discord.js";
-import { api, ApiError } from "../../api/client";
+import { api } from "../../api/client";
+import { handleCommandError } from "../../utils/errorHandler";
 import { generateProfileCard } from "./utils/profileCard";
 import { Command } from "../../models/Command";
 import type { ProfileResponse } from "./data";
@@ -50,15 +51,7 @@ const profile: Command = {
         files: [profileCard],
       });
     } catch (error) {
-      console.error("Erreur lors de la génération du profil:", error);
-      const msg = error instanceof ApiError
-        ? `❌ ${error.message}`
-        : "❌ Une erreur est survenue lors de la génération de votre profil.";
-      if (interaction.deferred) {
-        await interaction.editReply({ content: msg });
-      } else {
-        await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
-      }
+      await handleCommandError(error, interaction);
     }
   },
 };

--- a/bot/src/commands/mazworld/shop.ts
+++ b/bot/src/commands/mazworld/shop.ts
@@ -4,7 +4,8 @@ import {
   StringSelectMenuInteraction,
   ComponentType,
 } from "discord.js";
-import { api, ApiError } from "../../api/client";
+import { api } from "../../api/client";
+import { handleCommandError } from "../../utils/errorHandler";
 import { Command } from "../../models/Command";
 import type { ShopListResponse, PurchaseResponse } from "./data";
 import {
@@ -32,8 +33,8 @@ const shop: Command = {
     try {
       const data = await api.get<ShopListResponse>("/api/shop", userId, username);
       userCoins = data.user_coins;
-    } catch {
-      await interaction.reply({ content: "❌ Impossible de charger le magasin.", flags: 64 });
+    } catch (error) {
+      await handleCommandError(error, interaction);
       return;
     }
 
@@ -53,8 +54,8 @@ const shop: Command = {
       let shopData: ShopListResponse;
       try {
         shopData = await api.get<ShopListResponse>(`/api/shop?type=${category}`, userId, username);
-      } catch {
-        await i.editReply({ content: "❌ Impossible de charger les items.", embeds: [], components: [] });
+      } catch (error) {
+        await handleCommandError(error, i as any);
         return;
       }
 
@@ -114,8 +115,7 @@ const shop: Command = {
                 { item_id: itemId },
               );
             } catch (error) {
-              const msg = error instanceof ApiError ? error.message : "Erreur lors de l'achat.";
-              await btn.editReply({ content: `❌ ${msg}`, embeds: [], components: [] });
+              await handleCommandError(error, btn as any);
               buttonCollector.stop();
               return;
             }

--- a/bot/src/commands/mazworld/work.ts
+++ b/bot/src/commands/mazworld/work.ts
@@ -1,12 +1,12 @@
 import {
   SlashCommandBuilder,
   ChatInputCommandInteraction,
-  MessageFlags,
 } from "discord.js";
-import { api, ApiError } from "../../api/client";
+import { api } from "../../api/client";
 import { Command } from "../../models/Command";
 import type { WorkResponse } from "./data";
 import { buildWorkLoadingEmbed, buildWorkResultEmbed } from "./utils/embeds";
+import { handleCommandError } from "../../utils/errorHandler";
 
 const work: Command = {
   data: new SlashCommandBuilder()
@@ -33,24 +33,7 @@ const work: Command = {
       await new Promise(resolve => setTimeout(resolve, 2000));
       await interaction.editReply({ embeds: [buildWorkResultEmbed(result, avatarURL)] });
     } catch (error) {
-      if (error instanceof ApiError) {
-        const content = error.status === 429 || error.status === 409
-          ? `⏱️ ${error.message}`
-          : `❌ ${error.message}`;
-        if (interaction.deferred || interaction.replied) {
-          await interaction.editReply({ content, embeds: [] });
-        } else {
-          await interaction.reply({ content, flags: MessageFlags.Ephemeral });
-        }
-        return;
-      }
-      console.error("Erreur dans /work:", error);
-      const errorMessage = "❌ Une erreur est survenue pendant votre travail.";
-      if (interaction.deferred || interaction.replied) {
-        await interaction.editReply({ content: errorMessage, embeds: [] });
-      } else {
-        await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
-      }
+      await handleCommandError(error, interaction);
     }
   },
 };

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -1,10 +1,12 @@
 import path from "path";
-import { Collection, MessageFlags } from 'discord.js';
+import { Collection } from 'discord.js';
 import { readdirSync, existsSync } from "fs";
 import { TOKEN } from "./config/config";
 import { bot } from './utils/client';
 import { Command } from "./models/Command";
 import { ExtendedClient } from "./models/ExtendedClient";
+import { handleCommandError } from "./utils/errorHandler";
+import { logger } from "./utils/logger";
 
 import "./utils/discord";
 
@@ -25,7 +27,7 @@ const loadCommands = async (): Promise<Command[]> => {
       if (!file.endsWith(".js") && !file.endsWith(".ts")) continue;
       const cmd = require(path.join(folderPath, file)).default;
       if (cmd?.data?.name) commands.push(cmd);
-      else console.warn(`⚠️  Pas d'export default valide dans ${folder}/${file}`);
+      else logger.warn(`Pas d'export default valide dans ${folder}/${file}`);
     }
   }
 
@@ -33,7 +35,7 @@ const loadCommands = async (): Promise<Command[]> => {
 };
 
 const initializeBot = async () => {
-  console.log('🤖 Démarrage de MazWorld...\n');
+  logger.info('Démarrage de MazWorld...');
 
   const extendedBot = bot as ExtendedClient;
   extendedBot.commands = new Collection<string, Command>();
@@ -41,25 +43,38 @@ const initializeBot = async () => {
   const commands = await loadCommands();
   for (const command of commands) {
     extendedBot.commands.set(command.data.name, command);
-    console.log(`✅ Commande chargée : /${command.data.name}`);
+    logger.info(`Commande chargée : /${command.data.name}`);
   }
 
-  console.log(`\n📦 ${extendedBot.commands.size} commande(s) chargée(s)\n`);
+  logger.info(`${extendedBot.commands.size} commande(s) chargée(s)`);
 
   bot.on("interactionCreate", async (interaction) => {
     if (interaction.isChatInputCommand()) {
       const command = extendedBot.commands.get(interaction.commandName);
       if (!command) return;
+
+      const start = Date.now();
       try {
         await command.execute(interaction);
-      } catch (error: any) {
-        console.error(`Erreur lors de /${interaction.commandName} :`, error);
-        const errorMsg = "❌ Une erreur est survenue lors de l'exécution de cette commande.";
-        if (interaction.replied || interaction.deferred) {
-          await interaction.editReply({ content: errorMsg });
-        } else {
-          await interaction.reply({ content: errorMsg, flags: MessageFlags.Ephemeral });
-        }
+        logger.command(
+          interaction.commandName,
+          interaction.user.id,
+          interaction.user.username,
+          interaction.guildId,
+          true,
+          Date.now() - start,
+        );
+      } catch (error) {
+        logger.command(
+          interaction.commandName,
+          interaction.user.id,
+          interaction.user.username,
+          interaction.guildId,
+          false,
+          Date.now() - start,
+        );
+        logger.error(`Erreur non gérée dans /${interaction.commandName}`, error);
+        await handleCommandError(error, interaction);
       }
     } else if (interaction.isButton() || interaction.isStringSelectMenu()) {
       for (const command of extendedBot.commands.values()) {

--- a/bot/src/utils/errorHandler.ts
+++ b/bot/src/utils/errorHandler.ts
@@ -1,0 +1,35 @@
+import { MessageFlags } from 'discord.js';
+import { ApiError } from '../api/client';
+
+const COOLDOWN_STATUSES = new Set([409, 429]);
+
+interface Replyable {
+  deferred: boolean;
+  replied: boolean;
+  editReply(options: { content: string; embeds?: any[]; components?: any[] }): Promise<unknown>;
+  reply(options: { content: string; flags?: number }): Promise<unknown>;
+}
+
+function buildMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    const prefix = COOLDOWN_STATUSES.has(error.status) ? '⏱️' : '❌';
+    return `${prefix} ${error.message}`;
+  }
+  return '❌ Une erreur inattendue est survenue. Réessayez dans un instant.';
+}
+
+export async function handleCommandError(
+  error: unknown,
+  interaction: Replyable,
+): Promise<void> {
+  const content = buildMessage(error);
+  try {
+    if (interaction.deferred || interaction.replied) {
+      await interaction.editReply({ content, embeds: [], components: [] });
+    } else {
+      await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+    }
+  } catch {
+    // Interaction expirée ou déjà traitée
+  }
+}

--- a/bot/src/utils/logger.ts
+++ b/bot/src/utils/logger.ts
@@ -1,0 +1,55 @@
+type LogLevel = 'info' | 'warn' | 'error' | 'command';
+
+const EMOJI: Record<LogLevel, string> = {
+  info:    '📋',
+  warn:    '⚠️ ',
+  error:   '❌',
+  command: '⚡',
+};
+
+function ts(): string {
+  return new Date().toISOString();
+}
+
+function fmt(level: LogLevel, message: string, data?: Record<string, unknown>): string {
+  const suffix = data ? ` | ${JSON.stringify(data)}` : '';
+  return `[${ts()}] ${EMOJI[level]} ${message}${suffix}`;
+}
+
+export const logger = {
+  info(message: string, data?: Record<string, unknown>): void {
+    console.log(fmt('info', message, data));
+  },
+
+  warn(message: string, data?: Record<string, unknown>): void {
+    console.warn(fmt('warn', message, data));
+  },
+
+  error(message: string, error?: unknown, data?: Record<string, unknown>): void {
+    const errData: Record<string, unknown> = { ...data };
+    if (error instanceof Error) {
+      errData.error = error.message;
+      errData.name = error.name;
+    } else if (error !== undefined) {
+      errData.error = String(error);
+    }
+    console.error(fmt('error', message, Object.keys(errData).length ? errData : undefined));
+  },
+
+  command(
+    name: string,
+    userId: string,
+    username: string,
+    guildId: string | null,
+    success: boolean,
+    ms?: number,
+  ): void {
+    console.log(fmt('command', `/${name}`, {
+      userId,
+      username,
+      guildId,
+      success,
+      ...(ms !== undefined ? { ms } : {}),
+    }));
+  },
+};


### PR DESCRIPTION
## Résumé

- Création de `bot/src/utils/errorHandler.ts` — `handleCommandError()` centralise la gestion des erreurs Discord : cooldown (409/429 → ⏱️), erreur API (❌ message), erreur inconnue (message générique)
- Remplacement des blocs `catch` inline dans les 8 commandes mazworld par un simple `await handleCommandError(error, interaction)`
- Création de `bot/src/utils/logger.ts` — logger structuré avec `info`, `warn`, `error`, `command` (userId, guildId, succès, durée ms)
- Intégration du logger dans `index.ts` : logs de démarrage + traçage de chaque exécution de commande

## Test plan

- [ ] Déclencher une erreur de cooldown (429) → vérifier message ⏱️ éphémère
- [ ] Déclencher une erreur API autre (ex. 500) → vérifier message ❌ éphémère
- [ ] Lancer une commande → vérifier log `⚡ /nom | { userId, guildId, success: true, ms }` dans la console
- [ ] Vérifier le démarrage du bot → logs structurés avec timestamp

Closes #87
Closes #88