### PR TITLE
fix(security): comparaison en temps constant du secret bot (SU #186)

### DIFF
--- a/web/backend/src/Security/BotAuthenticator.php
+++ b/web/backend/src/Security/BotAuthenticator.php
@@ -43,7 +43,7 @@ class BotAuthenticator extends AbstractAuthenticator
         $discordUserId = $request->headers->get('X-Discord-User-Id');
         $discordUsername = $request->headers->get('X-Discord-Username', 'Unknown');
 
-        if (!$secret || $secret !== $this->botApiSecret) {
+        if (!$secret || !hash_equals($this->botApiSecret, $secret)) {
             throw new CustomUserMessageAuthenticationException('Invalid bot secret.');
         }
 


### PR DESCRIPTION
## Résumé

Remplace l'opérateur `!==` par `hash_equals()` dans `BotAuthenticator` pour éliminer la vulnérabilité aux timing attacks lors de la validation du secret `X-Bot-Secret`.

## Contexte

La comparaison naïve `$secret !== $this->botApiSecret` court-circuite dès la première différence de caractère, permettant à un attaquant de mesurer le temps de réponse pour deviner le secret octet par octet.

`hash_equals()` garantit un temps de comparaison constant indépendamment des caractères comparés.

## Fichier modifié

- `web/backend/src/Security/BotAuthenticator.php` — ligne 46

## OWASP

A07 — Identification and Authentication Failures

## Closes

Closes #186