### PR TITLE
fix(security): default-deny sur les routes /api non listées (SU #192)

### DIFF
--- a/web/backend/config/packages/security.yaml
+++ b/web/backend/config/packages/security.yaml
@@ -41,7 +41,7 @@ security:
         - { path: ^/api/records, roles: ROLE_USER }
         - { path: ^/api/servers, roles: ROLE_USER }
         - { path: ^/api/bot/status, roles: PUBLIC_ACCESS }
-        - { path: ^/api, roles: PUBLIC_ACCESS }
+        - { path: ^/api, roles: ROLE_USER }
 
 when@test:
     security:


### PR DESCRIPTION
## Résumé

Remplace le fallback `PUBLIC_ACCESS` par `ROLE_USER` en dernière règle d'`access_control` dans `security.yaml`.

Tout endpoint `/api/*` non couvert par une règle explicite retourne désormais `401` sans JWT valide, au lieu d'être publiquement accessible par défaut.

## Problème corrigé

```yaml
# Avant — tout nouveau contrôleur était public par défaut
- { path: ^/api, roles: PUBLIC_ACCESS }

# Après — tout nouveau contrôleur est protégé par défaut
- { path: ^/api, roles: ROLE_USER }
```

## Routes publiques conservées

- `/api/auth/discord/*` — firewall `security: false` (bypass total)
- `/api/auth/verify` — règle explicite `PUBLIC_ACCESS`
- `/api/bot/status` — règle explicite `PUBLIC_ACCESS`

## OWASP

A01 — Broken Access Control

## Note

Le test d'intégration associé (route non listée → 401) sera traité dans le cadre de l'issue #92 (Tests d'intégration) pour assurer une couverture cohérente de l'ensemble des SU sécurité.

Closes #192