### PR TITLE
fix(security): Suppression des messages d'erreur internes dans les réponses API (SU #180)

### DIFF
--- a/web/backend/composer.json
+++ b/web/backend/composer.json
@@ -22,6 +22,7 @@
         "symfony/flex": "^2",
         "symfony/framework-bundle": "7.0.*",
         "symfony/http-client": "7.0.*",
+        "symfony/monolog-bundle": "^3.11",
         "symfony/property-access": "7.0.*",
         "symfony/property-info": "7.0.*",
         "symfony/runtime": "7.0.*",

--- a/web/backend/composer.lock
+++ b/web/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f5596facd6f6a3df73e51fdfa050d89",
+    "content-hash": "54adc5573c9ae5b3a6b4635fe3b961fc",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2572,6 +2572,109 @@
             "time": "2025-12-20T17:47:00+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8 || ^2.0",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
             "name": "nelmio/cors-bundle",
             "version": "2.6.1",
             "source": {
@@ -4770,6 +4873,164 @@
                 }
             ],
             "time": "2024-07-26T14:56:00+00:00"
+        },
+        {
+            "name": "symfony/monolog-bridge",
+            "version": "v7.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/monolog-bridge.git",
+                "reference": "d80b7aeabc539538c6ae8962259ac422632d7796"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/d80b7aeabc539538c6ae8962259ac422632d7796",
+                "reference": "d80b7aeabc539538c6ae8962259ac422632d7796",
+                "shasum": ""
+            },
+            "require": {
+                "monolog/monolog": "^3",
+                "php": ">=8.2",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/console": "<6.4",
+                "symfony/http-foundation": "<6.4",
+                "symfony/security-core": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/mailer": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/mime": "^6.4|^7.0",
+                "symfony/security-core": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "symfony-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\Monolog\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides integration for Monolog with various Symfony components",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/monolog-bridge/tree/v7.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T14:55:39+00:00"
+        },
+        {
+            "name": "symfony/monolog-bundle",
+            "version": "v3.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/monolog-bundle.git",
+                "reference": "d87468010570b2ec766152184918ee8d267c7411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/d87468010570b2ec766152184918ee8d267c7411",
+                "reference": "d87468010570b2ec766152184918ee8d267c7411",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0",
+                "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
+                "php": ">=8.1",
+                "symfony/config": "^6.4 || ^7.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/http-kernel": "^6.4 || ^7.0",
+                "symfony/monolog-bridge": "^6.4 || ^7.0",
+                "symfony/polyfill-php84": "^1.30"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4 || ^7.0",
+                "symfony/phpunit-bridge": "^7.3.3",
+                "symfony/yaml": "^6.4 || ^7.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\MonologBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony MonologBundle",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "log",
+                "logging"
+            ],
+            "support": {
+                "issues": "https://github.com/symfony/monolog-bundle/issues",
+                "source": "https://github.com/symfony/monolog-bundle/tree/v3.11.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-02T18:23:01+00:00"
         },
         {
             "name": "symfony/password-hasher",

--- a/web/backend/config/bundles.php
+++ b/web/backend/config/bundles.php
@@ -11,4 +11,5 @@ return [
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
+    Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
 ];

--- a/web/backend/config/packages/monolog.yaml
+++ b/web/backend/config/packages/monolog.yaml
@@ -1,0 +1,55 @@
+monolog:
+    channels:
+        - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+
+when@dev:
+    monolog:
+        handlers:
+            main:
+                type: stream
+                path: "%kernel.logs_dir%/%kernel.environment%.log"
+                level: debug
+                channels: ["!event"]
+            console:
+                type: console
+                process_psr_3_messages: false
+                channels: ["!event", "!doctrine", "!console"]
+
+when@test:
+    monolog:
+        handlers:
+            main:
+                type: fingers_crossed
+                action_level: error
+                handler: nested
+                excluded_http_codes: [404, 405]
+                channels: ["!event"]
+            nested:
+                type: stream
+                path: "%kernel.logs_dir%/%kernel.environment%.log"
+                level: debug
+
+when@prod:
+    monolog:
+        handlers:
+            main:
+                type: fingers_crossed
+                action_level: error
+                handler: nested
+                excluded_http_codes: [404, 405]
+                channels: ["!deprecation"]
+                buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+            nested:
+                type: stream
+                path: php://stderr
+                level: debug
+                formatter: monolog.formatter.json
+            console:
+                type: console
+                process_psr_3_messages: false
+                channels: ["!event", "!doctrine"]
+            deprecation:
+                type: stream
+                channels: [deprecation]
+                path: php://stderr
+                formatter: monolog.formatter.json

--- a/web/backend/src/Controller/API/AbstractApiController.php
+++ b/web/backend/src/Controller/API/AbstractApiController.php
@@ -43,4 +43,14 @@ abstract class AbstractApiController extends AbstractController
     {
         return $this->errorResponse($message, Response::HTTP_NOT_FOUND);
     }
+
+    protected function serverErrorResponse(\Throwable $e): JsonResponse
+    {
+        return new JsonResponse(['error' => 'Une erreur est survenue'], Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+
+    protected function failureResponse(string $message, int $statusCode = Response::HTTP_BAD_REQUEST, array $extra = []): JsonResponse
+    {
+        return new JsonResponse(['success' => false, 'message' => $message] + $extra, $statusCode);
+    }
 }

--- a/web/backend/src/Controller/API/AbstractApiController.php
+++ b/web/backend/src/Controller/API/AbstractApiController.php
@@ -3,12 +3,22 @@
 namespace App\Controller\API;
 
 use App\Entity\User;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 abstract class AbstractApiController extends AbstractController
 {
+    protected LoggerInterface $logger;
+
+    #[Required]
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
     protected function getCurrentUser(): ?User
     {
         $user = $this->getUser();
@@ -46,6 +56,11 @@ abstract class AbstractApiController extends AbstractController
 
     protected function serverErrorResponse(\Throwable $e): JsonResponse
     {
+        $this->logger->error($e->getMessage(), [
+            'exception' => $e,
+            'user' => $this->getCurrentUser()?->getUserId(),
+        ]);
+
         return new JsonResponse(['error' => 'Une erreur est survenue'], Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 

--- a/web/backend/src/Controller/API/AuthController.php
+++ b/web/backend/src/Controller/API/AuthController.php
@@ -7,7 +7,6 @@ use App\Service\User\UserService;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/api/auth', name: 'api_auth_')]
@@ -37,7 +36,7 @@ class AuthController extends AbstractApiController
         $code = $data['code'] ?? null;
 
         if (!$code) {
-            return new JsonResponse(['error' => 'Missing authorization code'], Response::HTTP_BAD_REQUEST);
+            return $this->errorResponse('Missing authorization code');
         }
 
         try {
@@ -57,11 +56,8 @@ class AuthController extends AbstractApiController
                     'icon' => $guild->getIconUrl(),
                 ], array_slice($guilds, 0, 10)),
             ]);
-        } catch (\Exception $e) {
-            return new JsonResponse([
-                'error' => 'Authentication failed',
-                'message' => $e->getMessage(),
-            ], Response::HTTP_UNAUTHORIZED);
+        } catch (\Exception) {
+            return $this->unauthorizedResponse('Authentication failed');
         }
     }
 
@@ -71,7 +67,7 @@ class AuthController extends AbstractApiController
         $user = $this->getCurrentUser();
 
         if (!$user) {
-            return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            return $this->unauthorizedResponse();
         }
 
         try {
@@ -88,11 +84,8 @@ class AuthController extends AbstractApiController
                 'token' => $this->jwtManager->create($user),
                 'user' => $user->toArray(),
             ]);
-        } catch (\Exception $e) {
-            return new JsonResponse([
-                'error' => 'Token refresh failed',
-                'message' => $e->getMessage(),
-            ], Response::HTTP_UNAUTHORIZED);
+        } catch (\Exception) {
+            return $this->unauthorizedResponse('Token refresh failed');
         }
     }
 
@@ -114,7 +107,7 @@ class AuthController extends AbstractApiController
         $user = $this->getCurrentUser();
 
         if (!$user) {
-            return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            return $this->unauthorizedResponse();
         }
 
         return new JsonResponse(['user' => $user->toArray()]);

--- a/web/backend/src/Controller/API/CityController.php
+++ b/web/backend/src/Controller/API/CityController.php
@@ -3,13 +3,11 @@
 namespace App\Controller\API;
 
 use App\Repository\CityRepository;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/api/cities', name: 'api_cities_')]
-class CityController extends AbstractController
+class CityController extends AbstractApiController
 {
     public function __construct(
         private CityRepository $cityRepository
@@ -41,7 +39,7 @@ class CityController extends AbstractController
         $city = $this->cityRepository->findOneWithDetails($cityId);
 
         if (!$city) {
-            return $this->json(['error' => 'City not found'], Response::HTTP_NOT_FOUND);
+            return $this->notFoundResponse('City not found');
         }
 
         $jobs = array_map(function ($job) {
@@ -87,7 +85,7 @@ class CityController extends AbstractController
         $city = $this->cityRepository->find($cityId);
 
         if (!$city) {
-            return $this->json(['error' => 'City not found'], Response::HTTP_NOT_FOUND);
+            return $this->notFoundResponse('City not found');
         }
 
         $jobs = array_map(function ($job) {
@@ -111,7 +109,7 @@ class CityController extends AbstractController
         $city = $this->cityRepository->find($cityId);
 
         if (!$city) {
-            return $this->json(['error' => 'City not found'], Response::HTTP_NOT_FOUND);
+            return $this->notFoundResponse('City not found');
         }
 
         $routes = array_map(function ($route) {

--- a/web/backend/src/Controller/API/CommandsController.php
+++ b/web/backend/src/Controller/API/CommandsController.php
@@ -44,15 +44,11 @@ class CommandsController extends AbstractApiController
             if ($timeSince < self::DAILY_COOLDOWN) {
                 $remaining = self::DAILY_COOLDOWN - $timeSince;
 
-                return new JsonResponse([
-                    'success' => false,
-                    'message' => sprintf(
-                        '⏱️ Vous avez déjà réclamé votre récompense. Revenez dans %dh %dm.',
-                        floor($remaining / 3600),
-                        floor(($remaining % 3600) / 60)
-                    ),
-                    'next_daily' => $lastDaily + self::DAILY_COOLDOWN,
-                ], Response::HTTP_TOO_MANY_REQUESTS);
+                return $this->failureResponse(
+                    sprintf('⏱️ Vous avez déjà réclamé votre récompense. Revenez dans %dh %dm.', floor($remaining / 3600), floor(($remaining % 3600) / 60)),
+                    Response::HTTP_TOO_MANY_REQUESTS,
+                    ['next_daily' => $lastDaily + self::DAILY_COOLDOWN]
+                );
             }
         }
 
@@ -77,10 +73,7 @@ class CommandsController extends AbstractApiController
         }
 
         if ($user->getTravelingTo() !== null && $user->getArrivalTime() !== null && time() < $user->getArrivalTime()) {
-            return new JsonResponse([
-                'success' => false,
-                'message' => '🚂 Vous êtes en voyage ! Vous ne pouvez pas travailler pendant un déplacement.',
-            ], Response::HTTP_CONFLICT);
+            return $this->failureResponse('🚂 Vous êtes en voyage ! Vous ne pouvez pas travailler pendant un déplacement.', Response::HTTP_CONFLICT);
         }
 
         $now = time();
@@ -92,31 +85,24 @@ class CommandsController extends AbstractApiController
             if ($timeSince < self::WORK_COOLDOWN) {
                 $remaining = self::WORK_COOLDOWN - $timeSince;
 
-                return new JsonResponse([
-                    'success' => false,
-                    'message' => sprintf(
-                        '⏱️ Vous êtes fatigué ! Reposez-vous encore %dh %dm avant de retravailler.',
-                        floor($remaining / 3600),
-                        floor(($remaining % 3600) / 60)
-                    ),
-                    'next_work' => $lastWork + self::WORK_COOLDOWN,
-                ], Response::HTTP_TOO_MANY_REQUESTS);
+                return $this->failureResponse(
+                    sprintf('⏱️ Vous êtes fatigué ! Reposez-vous encore %dh %dm avant de retravailler.', floor($remaining / 3600), floor(($remaining % 3600) / 60)),
+                    Response::HTTP_TOO_MANY_REQUESTS,
+                    ['next_work' => $lastWork + self::WORK_COOLDOWN]
+                );
             }
         }
 
         $currentCity = $user->getCurrentCity();
 
         if (!$currentCity) {
-            return new JsonResponse(['success' => false, 'message' => "❌ Vous n'êtes dans aucune ville."], Response::HTTP_BAD_REQUEST);
+            return $this->failureResponse("❌ Vous n'êtes dans aucune ville.");
         }
 
         $jobs = $this->cityJobRepository->findBy(['city' => $currentCity]);
 
         if (empty($jobs)) {
-            return new JsonResponse([
-                'success' => false,
-                'message' => "❌ Aucun travail n'est disponible à {$currentCity->getEmoji()} {$currentCity->getName()}.",
-            ], Response::HTTP_NOT_FOUND);
+            return $this->failureResponse("❌ Aucun travail n'est disponible à {$currentCity->getEmoji()} {$currentCity->getName()}.", Response::HTTP_NOT_FOUND);
         }
 
         /** @var CityJob $randomJob */
@@ -151,10 +137,7 @@ class CommandsController extends AbstractApiController
         }
 
         if ($user->getTravelingTo() !== null && $user->getArrivalTime() !== null && time() < $user->getArrivalTime()) {
-            return new JsonResponse([
-                'success' => false,
-                'message' => '🚂 Vous êtes en voyage ! Vous ne pouvez pas jouer pendant un déplacement.',
-            ], Response::HTTP_CONFLICT);
+            return $this->failureResponse('🚂 Vous êtes en voyage ! Vous ne pouvez pas jouer pendant un déplacement.', Response::HTTP_CONFLICT);
         }
 
         $data = json_decode($request->getContent(), true);
@@ -162,29 +145,20 @@ class CommandsController extends AbstractApiController
         $amount = (int)($data['amount'] ?? 0);
 
         if (!in_array($choice, ['pile', 'face'])) {
-            return new JsonResponse(['success' => false, 'message' => '❌ Choix invalide. Choisissez "pile" ou "face".'], Response::HTTP_BAD_REQUEST);
+            return $this->failureResponse('❌ Choix invalide. Choisissez "pile" ou "face".');
         }
 
         if ($amount < self::COINFLIP_MIN || $amount > self::COINFLIP_MAX) {
-            return new JsonResponse([
-                'success' => false,
-                'message' => sprintf('❌ La mise doit être entre %d€ et %d€.', self::COINFLIP_MIN, self::COINFLIP_MAX),
-            ], Response::HTTP_BAD_REQUEST);
+            return $this->failureResponse(sprintf('❌ La mise doit être entre %d€ et %d€.', self::COINFLIP_MIN, self::COINFLIP_MAX));
         }
 
         $maxBet = (int)min(floor($user->getCoins() / 2), self::COINFLIP_MAX);
         if ($amount > $maxBet) {
-            return new JsonResponse([
-                'success' => false,
-                'message' => "⚠️ Mise trop élevée ! Vous pouvez parier jusqu'à {$maxBet}€ (50% de votre solde ou 500€ max).",
-            ], Response::HTTP_BAD_REQUEST);
+            return $this->failureResponse("⚠️ Mise trop élevée ! Vous pouvez parier jusqu'à {$maxBet}€ (50% de votre solde ou 500€ max).");
         }
 
         if ($user->getCoins() < $amount) {
-            return new JsonResponse([
-                'success' => false,
-                'message' => "❌ Vous n'avez pas assez d'argent. Solde actuel : {$user->getCoins()}€",
-            ], Response::HTTP_PAYMENT_REQUIRED);
+            return $this->failureResponse("❌ Vous n'avez pas assez d'argent. Solde actuel : {$user->getCoins()}€", Response::HTTP_PAYMENT_REQUIRED);
         }
 
         $result = random_int(0, 1) === 0 ? 'pile' : 'face';

--- a/web/backend/src/Controller/API/InventoryController.php
+++ b/web/backend/src/Controller/API/InventoryController.php
@@ -4,7 +4,6 @@ namespace App\Controller\API;
 
 use App\Repository\ShopItemRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/api/inventory', name: 'api_inventory_')]
@@ -21,7 +20,7 @@ class InventoryController extends AbstractApiController
             $user = $this->getCurrentUser();
 
             if (!$user) {
-                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+                return $this->unauthorizedResponse();
             }
 
             $equippedBackground = $user->getEquippedBackground();
@@ -72,7 +71,7 @@ class InventoryController extends AbstractApiController
                 'user_coins'       => $user->getCoins(),
             ]);
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 }

--- a/web/backend/src/Controller/API/JobController.php
+++ b/web/backend/src/Controller/API/JobController.php
@@ -3,12 +3,11 @@
 namespace App\Controller\API;
 
 use Doctrine\DBAL\Connection;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/api/jobs', name: 'api_jobs_')]
-class JobController extends AbstractController
+class JobController extends AbstractApiController
 {
     public function __construct(
         private Connection $connection
@@ -59,7 +58,7 @@ class JobController extends AbstractController
         ', ['jobId' => $jobId]);
 
         if (!$job) {
-            return $this->json(['error' => 'Job not found'], 404);
+            return $this->notFoundResponse('Job not found');
         }
 
         return $this->json($job);

--- a/web/backend/src/Controller/API/LeaderboardController.php
+++ b/web/backend/src/Controller/API/LeaderboardController.php
@@ -7,7 +7,6 @@ use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/api/leaderboard', name: 'api_leaderboard_')]
@@ -67,7 +66,7 @@ class LeaderboardController extends AbstractApiController
                 'user_rank' => $userRank,
             ]);
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 
@@ -76,7 +75,7 @@ class LeaderboardController extends AbstractApiController
     {
         $currentUser = $this->getCurrentUser();
         if (!$currentUser) {
-            return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            return $this->unauthorizedResponse();
         }
 
         return new JsonResponse(['rank' => $this->getUserRank($currentUser)]);

--- a/web/backend/src/Controller/API/ProfileController.php
+++ b/web/backend/src/Controller/API/ProfileController.php
@@ -25,7 +25,7 @@ class ProfileController extends AbstractApiController
             $user = $this->getCurrentUser();
 
             if (!$user) {
-                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+                return $this->unauthorizedResponse();
             }
 
             $equippedBadges = [];
@@ -52,7 +52,7 @@ class ProfileController extends AbstractApiController
                 'inventory_count' => $user->getInventory()->count(),
             ]]);
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 
@@ -62,7 +62,7 @@ class ProfileController extends AbstractApiController
         $user = $this->getCurrentUser();
 
         if (!$user) {
-            return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            return $this->unauthorizedResponse();
         }
 
         $accessToken = $user->getOauthAccessToken();
@@ -97,7 +97,7 @@ class ProfileController extends AbstractApiController
                 'has_bot' => $this->discordOAuth->isBotInGuild($guild->id),
             ], $adminGuilds))]);
         } catch (\Exception $e) {
-            return new JsonResponse(['error' => 'Failed to fetch guilds', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 
@@ -108,14 +108,14 @@ class ProfileController extends AbstractApiController
             $user = $this->getCurrentUser();
 
             if (!$user) {
-                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+                return $this->unauthorizedResponse();
             }
 
             $data = json_decode($request->getContent(), true);
             $itemId = $data['item_id'] ?? null;
 
             if (!$itemId) {
-                return new JsonResponse(['success' => false, 'message' => 'Item ID requis'], Response::HTTP_BAD_REQUEST);
+                return $this->failureResponse('Item ID requis');
             }
 
             $ownsItem = false;
@@ -127,7 +127,7 @@ class ProfileController extends AbstractApiController
             }
 
             if (!$ownsItem) {
-                return new JsonResponse(['success' => false, 'message' => 'Vous ne possédez pas ce background'], Response::HTTP_FORBIDDEN);
+                return $this->failureResponse('Vous ne possédez pas ce background', Response::HTTP_FORBIDDEN);
             }
 
             $user->setEquippedBackground($itemId);
@@ -135,7 +135,7 @@ class ProfileController extends AbstractApiController
 
             return new JsonResponse(['success' => true, 'message' => 'Background équipé avec succès']);
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 
@@ -146,7 +146,7 @@ class ProfileController extends AbstractApiController
             $user = $this->getCurrentUser();
 
             if (!$user) {
-                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+                return $this->unauthorizedResponse();
             }
 
             $data = json_decode($request->getContent(), true);
@@ -154,11 +154,11 @@ class ProfileController extends AbstractApiController
             $slot = $data['slot'] ?? null;
 
             if (!$badgeId || $slot === null) {
-                return new JsonResponse(['success' => false, 'message' => 'Badge ID et slot requis'], Response::HTTP_BAD_REQUEST);
+                return $this->failureResponse('Badge ID et slot requis');
             }
 
             if ($slot < 0 || $slot > 5) {
-                return new JsonResponse(['success' => false, 'message' => 'Slot invalide (0-5)'], Response::HTTP_BAD_REQUEST);
+                return $this->failureResponse('Slot invalide (0-5)');
             }
 
             $ownsItem = false;
@@ -170,12 +170,12 @@ class ProfileController extends AbstractApiController
             }
 
             if (!$ownsItem) {
-                return new JsonResponse(['success' => false, 'message' => 'Vous ne possédez pas ce badge'], Response::HTTP_FORBIDDEN);
+                return $this->failureResponse('Vous ne possédez pas ce badge', Response::HTTP_FORBIDDEN);
             }
 
             foreach ($user->getEquippedBadges() as $equippedBadge) {
                 if ($equippedBadge->getBadgeId() === $badgeId) {
-                    return new JsonResponse(['success' => false, 'message' => 'Ce badge est déjà équipé'], Response::HTTP_CONFLICT);
+                    return $this->failureResponse('Ce badge est déjà équipé', Response::HTTP_CONFLICT);
                 }
             }
 
@@ -196,7 +196,7 @@ class ProfileController extends AbstractApiController
 
             return new JsonResponse(['success' => true, 'message' => 'Badge équipé avec succès']);
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 
@@ -207,14 +207,14 @@ class ProfileController extends AbstractApiController
             $user = $this->getCurrentUser();
 
             if (!$user) {
-                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+                return $this->unauthorizedResponse();
             }
 
             $data = json_decode($request->getContent(), true);
             $slot = $data['slot'] ?? null;
 
             if ($slot === null) {
-                return new JsonResponse(['success' => false, 'message' => 'Slot requis'], Response::HTTP_BAD_REQUEST);
+                return $this->failureResponse('Slot requis');
             }
 
             $found = false;
@@ -227,14 +227,14 @@ class ProfileController extends AbstractApiController
             }
 
             if (!$found) {
-                return new JsonResponse(['success' => false, 'message' => 'Aucun badge dans ce slot'], Response::HTTP_NOT_FOUND);
+                return $this->failureResponse('Aucun badge dans ce slot', Response::HTTP_NOT_FOUND);
             }
 
             $this->entityManager->flush();
 
             return new JsonResponse(['success' => true, 'message' => 'Badge déséquipé avec succès']);
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 }

--- a/web/backend/src/Controller/API/RecordsController.php
+++ b/web/backend/src/Controller/API/RecordsController.php
@@ -6,7 +6,6 @@ use App\Entity\ShopItem;
 use App\Entity\UserInventory;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/api/records', name: 'api_records_')]
@@ -22,7 +21,7 @@ class RecordsController extends AbstractApiController
         $user = $this->getCurrentUser();
 
         if (!$user) {
-            return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+            return $this->unauthorizedResponse();
         }
 
         try {
@@ -117,10 +116,7 @@ class RecordsController extends AbstractApiController
                 ],
             ]);
         } catch (\Throwable $e) {
-            return new JsonResponse(
-                ['error' => 'Internal error', 'message' => $e->getMessage()],
-                Response::HTTP_INTERNAL_SERVER_ERROR
-            );
+            return $this->serverErrorResponse($e);
         }
     }
 }

--- a/web/backend/src/Controller/API/RouteController.php
+++ b/web/backend/src/Controller/API/RouteController.php
@@ -3,12 +3,11 @@
 namespace App\Controller\API;
 
 use Doctrine\DBAL\Connection;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/api/routes', name: 'api_routes_')]
-class RouteController extends AbstractController
+class RouteController extends AbstractApiController
 {
     public function __construct(
         private Connection $connection
@@ -60,7 +59,7 @@ class RouteController extends AbstractController
         ', ['routeId' => $routeId]);
 
         if (!$route) {
-            return $this->json(['error' => 'Route not found'], 404);
+            return $this->notFoundResponse('Route not found');
         }
 
         return $this->json($route);

--- a/web/backend/src/Controller/API/ServersController.php
+++ b/web/backend/src/Controller/API/ServersController.php
@@ -77,7 +77,7 @@ class ServersController extends AbstractApiController
 
             return new JsonResponse($result);
         } catch (\Throwable $e) {
-            return $this->errorResponse('Failed to fetch servers: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 

--- a/web/backend/src/Controller/API/ShopController.php
+++ b/web/backend/src/Controller/API/ShopController.php
@@ -68,7 +68,7 @@ class ShopController extends AbstractApiController
                 'user_coins' => $user?->getCoins() ?? 0,
             ]);
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 
@@ -79,29 +79,29 @@ class ShopController extends AbstractApiController
             $user = $this->getCurrentUser();
 
             if (!$user) {
-                return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+                return $this->unauthorizedResponse();
             }
 
             $data = json_decode($request->getContent(), true);
             $itemId = $data['item_id'] ?? null;
 
             if (!$itemId) {
-                return new JsonResponse(['success' => false, 'message' => 'Item ID requis'], Response::HTTP_BAD_REQUEST);
+                return $this->failureResponse('Item ID requis');
             }
 
             $item = $this->shopItemRepository->find($itemId);
 
             if (!$item) {
-                return new JsonResponse(['success' => false, 'message' => "Cet item n'existe pas"], Response::HTTP_NOT_FOUND);
+                return $this->failureResponse("Cet item n'existe pas", Response::HTTP_NOT_FOUND);
             }
 
             if (!$item->isAvailable()) {
-                return new JsonResponse(['success' => false, 'message' => "Cet item n'est plus disponible"], Response::HTTP_BAD_REQUEST);
+                return $this->failureResponse("Cet item n'est plus disponible");
             }
 
             foreach ($user->getInventory() as $inventoryItem) {
                 if ($inventoryItem->getItemId() === $itemId) {
-                    return new JsonResponse(['success' => false, 'message' => 'Vous possédez déjà cet item'], Response::HTTP_CONFLICT);
+                    return $this->failureResponse('Vous possédez déjà cet item', Response::HTTP_CONFLICT);
                 }
             }
 
@@ -137,7 +137,7 @@ class ShopController extends AbstractApiController
                 throw $e;
             }
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 
@@ -149,7 +149,7 @@ class ShopController extends AbstractApiController
             $item = $this->shopItemRepository->find($itemId);
 
             if (!$item) {
-                return new JsonResponse(['error' => 'Item not found'], Response::HTTP_NOT_FOUND);
+                return $this->notFoundResponse('Item not found');
             }
 
             $itemData = $item->toArray();
@@ -168,7 +168,7 @@ class ShopController extends AbstractApiController
 
             return new JsonResponse(['item' => $itemData]);
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 }

--- a/web/backend/src/Controller/API/StatsController.php
+++ b/web/backend/src/Controller/API/StatsController.php
@@ -4,15 +4,13 @@ namespace App\Controller\API;
 
 use App\Entity\ShopItem;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/api/stats', name: 'api_stats_')]
 #[IsGranted('ROLE_ADMIN')]
-class StatsController extends AbstractController
+class StatsController extends AbstractApiController
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager
@@ -27,7 +25,7 @@ class StatsController extends AbstractController
                 'economy' => $this->getEconomyStatsData(),
             ]);
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 
@@ -37,7 +35,7 @@ class StatsController extends AbstractController
         try {
             return new JsonResponse($this->getGlobalStatsData());
         } catch (\Throwable $e) {
-            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->serverErrorResponse($e);
         }
     }
 

--- a/web/backend/src/Controller/API/TravelController.php
+++ b/web/backend/src/Controller/API/TravelController.php
@@ -120,30 +120,27 @@ class TravelController extends AbstractApiController
         }
 
         if ($user->getTravelingTo() && $user->getArrivalTime() && time() < $user->getArrivalTime()) {
-            return new JsonResponse(['success' => false, 'message' => '🚂 Vous êtes déjà en voyage !'], Response::HTTP_CONFLICT);
+            return $this->failureResponse('🚂 Vous êtes déjà en voyage !', Response::HTTP_CONFLICT);
         }
 
         $data = json_decode($request->getContent(), true);
         $destinationId = $data['destination_id'] ?? null;
 
         if (!$destinationId) {
-            return new JsonResponse(['success' => false, 'message' => 'destination_id requis'], Response::HTTP_BAD_REQUEST);
+            return $this->failureResponse('destination_id requis');
         }
 
         $destination = $this->cityRepository->find($destinationId);
 
         if (!$destination) {
-            return new JsonResponse(['success' => false, 'message' => "Cette ville n'existe pas."], Response::HTTP_NOT_FOUND);
+            return $this->failureResponse("Cette ville n'existe pas.", Response::HTTP_NOT_FOUND);
         }
 
         $currentCity = $user->getCurrentCity();
         $route = $this->routeRepository->findOneBy(['city_from' => $currentCity, 'city_to' => $destination]);
 
         if (!$route) {
-            return new JsonResponse([
-                'success' => false,
-                'message' => "Aucune route vers {$destination->getName()} depuis {$currentCity->getName()}.",
-            ], Response::HTTP_NOT_FOUND);
+            return $this->failureResponse("Aucune route vers {$destination->getName()} depuis {$currentCity->getName()}.", Response::HTTP_NOT_FOUND);
         }
 
         $alreadyVisited = false;
@@ -157,10 +154,7 @@ class TravelController extends AbstractApiController
         $travelCost = $alreadyVisited ? 0 : $route->getCost();
 
         if ($travelCost > 0 && $user->getCoins() < $travelCost) {
-            return new JsonResponse([
-                'success' => false,
-                'message' => "❌ Vous n'avez pas assez d'argent. ({$user->getCoins()}€ / {$travelCost}€)",
-            ], Response::HTTP_PAYMENT_REQUIRED);
+            return $this->failureResponse("❌ Vous n'avez pas assez d'argent. ({$user->getCoins()}€ / {$travelCost}€)", Response::HTTP_PAYMENT_REQUIRED);
         }
 
         if ($travelCost > 0) {

--- a/web/backend/symfony.lock
+++ b/web/backend/symfony.lock
@@ -153,6 +153,18 @@
             "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
         }
     },
+    "symfony/monolog-bundle": {
+        "version": "3.11",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.7",
+            "ref": "1b9efb10c54cb51c713a9391c9300ff8bceda459"
+        },
+        "files": [
+            "./config/packages/monolog.yaml"
+        ]
+    },
     "symfony/routing": {
         "version": "7.0",
         "recipe": {


### PR DESCRIPTION
## Résumé

- Ajout de `serverErrorResponse(\Throwable $e)` et `failureResponse(string $message, int $statusCode, array $extra = [])` dans `AbstractApiController`
- Migration de `CityController`, `JobController`, `RouteController`, `StatsController` vers `AbstractApiController` (étaient encore sur `AbstractController`)
- Suppression de tous les `$e->getMessage()` exposés dans les réponses API (13 contrôleurs couverts)
- Suppression des imports `Response` devenus orphelins (`AuthController`, `InventoryController`, `RecordsController`, `LeaderboardController`)
- Installation de `symfony/monolog-bundle` — Monolog n'était pas installé, les erreurs n'étaient jamais loguées
- Injection de `LoggerInterface` dans `AbstractApiController` via `#[Required]` — `serverErrorResponse()` logue désormais l'exception avec le `user_id` avant de retourner la réponse générique au client

## OWASP

Couvre **A09:2021 – Security Logging and Monitoring Failures** :
- Les messages d'exception internes ne sont plus exposés au client (réponse générique)
- Les erreurs serveur sont loguées côté backend avec contexte utilisateur (`var/log/dev.log` / `stderr` en prod)

## Plan de test

- [ ] Couper la BDD, appeler `/api/profile/me` → réponse client : `{"error": "Une erreur est survenue"}`, log `var/log/dev.log` : message d'exception complet avec `user_id`
- [ ] Provoquer une erreur Doctrine (mauvaise requête) → vérifier que la réponse retourne `{"error": "Une erreur est survenue"}` et non le stack trace
- [ ] Tester les routes protégées sans JWT → `401 Unauthorized` via `unauthorizedResponse()`
- [ ] Tester `/api/commands/daily` deux fois → `429 Too Many Requests` avec `next_daily` dans la réponse
- [ ] Vérifier qu'aucun contrôleur n'étend directement `AbstractController`

Closes #180