### PR TITLE
feat(security): en-têtes de sécurité HTTP backend et frontend (SU #181)

### DIFF
--- a/web/backend/src/EventSubscriber/SecurityHeadersSubscriber.php
+++ b/web/backend/src/EventSubscriber/SecurityHeadersSubscriber.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class SecurityHeadersSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::RESPONSE => 'onKernelResponse'];
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+        $response->headers->set(
+            'Content-Security-Policy',
+            "default-src 'self'; img-src 'self' cdn.discordapp.com; script-src 'self'; style-src 'self' 'unsafe-inline'"
+        );
+    }
+}

--- a/web/frontend/src/index.html
+++ b/web/frontend/src/index.html
@@ -5,6 +5,8 @@
   <title>Frontend</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; img-src 'self' cdn.discordapp.com; script-src 'self'; style-src 'self' 'unsafe-inline'">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>


### PR DESCRIPTION
## Résumé

**Backend — Symfony**
- Création de `SecurityHeadersSubscriber` (EventSubscriber sur `kernel.response`)
- Injecte les headers sur toutes les réponses API (200, 401, 500…)

**Frontend — Angular**
- Ajout d'une `<meta http-equiv="Content-Security-Policy">` dans `index.html`
- Protège l'app Angular contre les injections de scripts cross-origin dès le chargement de la page

## En-têtes ajoutés

| En-tête | Valeur |
|---|---|
| `Content-Security-Policy` | `default-src 'self'; img-src 'self' cdn.discordapp.com; script-src 'self'; style-src 'self' 'unsafe-inline'` |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
| `X-Frame-Options` | `DENY` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |

## OWASP

A05 — Security Misconfiguration : *"Sending security directives to clients (Security Headers)"*

## Plan de test

- [ ] Appeler `/api/profile/me` et vérifier la présence des 5 headers dans la réponse
- [ ] Charger l'app Angular et vérifier la `<meta>` CSP dans le DOM (DevTools > Elements)
- [ ] Tenter de charger une image depuis un domaine non autorisé → bloquée par la CSP
- [ ] Vérifier qu'aucune route ne retourne de réponse sans les headers

Closes #181