### PR TITLE
feat(security): rate limiting sur les endpoints d'authentification (SU #185)

### DIFF
--- a/web/backend/composer.json
+++ b/web/backend/composer.json
@@ -24,6 +24,7 @@
         "symfony/http-client": "7.0.*",
         "symfony/property-access": "7.0.*",
         "symfony/property-info": "7.0.*",
+        "symfony/rate-limiter": "7.0.*",
         "symfony/runtime": "7.0.*",
         "symfony/security-bundle": "7.0.*",
         "symfony/serializer": "7.0.*",

--- a/web/backend/composer.lock
+++ b/web/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f5596facd6f6a3df73e51fdfa050d89",
+    "content-hash": "17068559c38592ddc483855421217b99",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -4772,6 +4772,73 @@
             "time": "2024-07-26T14:56:00+00:00"
         },
         {
+            "name": "symfony/options-resolver",
+            "version": "v7.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "19eecfc6f1b0e4b093db7f4a71eedc91843e711a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/19eecfc6f1b0e4b093db7f4a71eedc91843e711a",
+                "reference": "19eecfc6f1b0e4b093db7f4a71eedc91843e711a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T14:55:39+00:00"
+        },
+        {
             "name": "symfony/password-hasher",
             "version": "v7.0.8",
             "source": {
@@ -5496,6 +5563,76 @@
                 }
             ],
             "time": "2024-07-26T07:32:22+00:00"
+        },
+        {
+            "name": "symfony/rate-limiter",
+            "version": "v7.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/rate-limiter.git",
+                "reference": "f3f3d92414ce90c6c20a1c2e3bd5a80321390863"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/f3f3d92414ce90c6c20a1c2e3bd5a80321390863",
+                "reference": "f3f3d92414ce90c6c20a1c2e3bd5a80321390863",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/options-resolver": "^6.4|^7.0"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/lock": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\RateLimiter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Wouter de Jong",
+                    "email": "wouter@wouterj.nl"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a Token Bucket implementation to rate limit input and output in your application",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "limiter",
+                "rate-limiter"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/rate-limiter/tree/v7.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T14:55:39+00:00"
         },
         {
             "name": "symfony/routing",

--- a/web/backend/config/packages/rate_limiter.yaml
+++ b/web/backend/config/packages/rate_limiter.yaml
@@ -1,0 +1,10 @@
+framework:
+    rate_limiter:
+        auth_callback:
+            policy: 'sliding_window'
+            limit: 10
+            interval: '1 minute'
+        auth_refresh:
+            policy: 'sliding_window'
+            limit: 20
+            interval: '1 minute'

--- a/web/backend/src/Controller/API/AbstractApiController.php
+++ b/web/backend/src/Controller/API/AbstractApiController.php
@@ -6,6 +6,7 @@ use App\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
+use DateTimeInterface;
 
 abstract class AbstractApiController extends AbstractController
 {
@@ -42,5 +43,17 @@ abstract class AbstractApiController extends AbstractController
     protected function notFoundResponse(string $message = 'Resource not found'): JsonResponse
     {
         return $this->errorResponse($message, Response::HTTP_NOT_FOUND);
+    }
+
+    protected function tooManyRequestsResponse(?DateTimeInterface $retryAfter = null): JsonResponse
+    {
+        $response = $this->errorResponse('Too many requests', Response::HTTP_TOO_MANY_REQUESTS);
+
+        if ($retryAfter !== null) {
+            $seconds = max(0, $retryAfter->getTimestamp() - time());
+            $response->headers->set('Retry-After', (string) $seconds);
+        }
+
+        return $response;
     }
 }

--- a/web/backend/src/Controller/API/AuthController.php
+++ b/web/backend/src/Controller/API/AuthController.php
@@ -5,9 +5,11 @@ namespace App\Controller\API;
 use App\Service\Discord\DiscordOAuthService;
 use App\Service\User\UserService;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/api/auth', name: 'api_auth_')]
@@ -16,7 +18,11 @@ class AuthController extends AbstractApiController
     public function __construct(
         private readonly DiscordOAuthService $discordOAuth,
         private readonly UserService $userService,
-        private readonly JWTTokenManagerInterface $jwtManager
+        private readonly JWTTokenManagerInterface $jwtManager,
+        #[Autowire(service: 'limiter.auth_callback')]
+        private readonly RateLimiterFactory $callbackLimiter,
+        #[Autowire(service: 'limiter.auth_refresh')]
+        private readonly RateLimiterFactory $refreshLimiter,
     ) {}
 
     #[Route('/discord/login', name: 'discord_login', methods: ['GET'])]
@@ -33,6 +39,11 @@ class AuthController extends AbstractApiController
     #[Route('/discord/callback', name: 'discord_callback', methods: ['POST'])]
     public function discordCallback(Request $request): JsonResponse
     {
+        $limit = $this->callbackLimiter->create($request->getClientIp())->consume();
+        if (!$limit->isAccepted()) {
+            return $this->tooManyRequestsResponse($limit->getRetryAfter());
+        }
+
         $data = json_decode($request->getContent(), true);
         $code = $data['code'] ?? null;
 
@@ -66,12 +77,17 @@ class AuthController extends AbstractApiController
     }
 
     #[Route('/refresh', name: 'refresh', methods: ['POST'])]
-    public function refresh(): JsonResponse
+    public function refresh(Request $request): JsonResponse
     {
         $user = $this->getCurrentUser();
 
         if (!$user) {
             return new JsonResponse(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $limit = $this->refreshLimiter->create($user->getUserId())->consume();
+        if (!$limit->isAccepted()) {
+            return $this->tooManyRequestsResponse($limit->getRetryAfter());
         }
 
         try {


### PR DESCRIPTION
## Résumé

- Installation de `symfony/rate-limiter`
- Configuration de deux limiters dans `config/packages/rate_limiter.yaml`
- Application sur `POST /api/auth/discord/callback` (par IP, 10 req/min)
- Application sur `POST /api/auth/refresh` (par user_id, 20 req/min)
- Ajout de `tooManyRequestsResponse()` dans `AbstractApiController` avec header `Retry-After`

## Pourquoi uniquement ces deux routes

Les routes bot sont protégées par secret partagé (`X-Bot-Secret`) — le bot est l'unique client. Les routes frontend authentifiées (JWT) disposent déjà de garde-fous applicatifs (cooldowns, validation de solde). La surface d'attaque non protégée se concentre sur le flux OAuth, d'où le scope limité à callback et refresh.

## OWASP

A07 — Identification and Authentication Failures

## Plan de test

- [ ] Appeler `/api/auth/discord/callback` plus de 10 fois en moins d'une minute → `429 Too Many Requests` avec header `Retry-After`
- [ ] Appeler `/api/auth/refresh` plus de 20 fois en moins d'une minute → `429 Too Many Requests`
- [ ] Vérifier que les routes bot et les routes JWT normales ne sont pas impactées

Closes #185