### PR TITLE
fix(security): Verrouillage pessimiste sur les opérations de déduction de MazCoins (SU #182)

### DIFF
--- a/web/backend/src/Controller/API/CommandsController.php
+++ b/web/backend/src/Controller/API/CommandsController.php
@@ -180,28 +180,39 @@ class CommandsController extends AbstractApiController
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        if ($user->getCoins() < $amount) {
+        $this->entityManager->beginTransaction();
+        try {
+            $this->entityManager->lock($user, \Doctrine\DBAL\LockMode::PESSIMISTIC_WRITE);
+            $this->entityManager->refresh($user);
+
+            if ($user->getCoins() < $amount) {
+                $this->entityManager->rollback();
+                return new JsonResponse([
+                    'success' => false,
+                    'message' => "❌ Vous n'avez pas assez d'argent. Solde actuel : {$user->getCoins()}€",
+                ], Response::HTTP_PAYMENT_REQUIRED);
+            }
+
+            $result = random_int(0, 1) === 0 ? 'pile' : 'face';
+            $won = $result === $choice;
+
+            $user->setCoins($won ? $user->getCoins() + $amount : $user->getCoins() - $amount);
+            $this->entityManager->flush();
+            $this->entityManager->commit();
+
             return new JsonResponse([
-                'success' => false,
-                'message' => "❌ Vous n'avez pas assez d'argent. Solde actuel : {$user->getCoins()}€",
-            ], Response::HTTP_PAYMENT_REQUIRED);
+                'success' => true,
+                'won' => $won,
+                'result' => $result,
+                'amount' => $amount,
+                'message' => $won
+                    ? "🎉 La pièce est tombée sur {$result} ! Vous gagnez {$amount}€ !"
+                    : "😢 La pièce est tombée sur {$result}. Vous perdez {$amount}€.",
+                'coins' => $user->getCoins(),
+            ]);
+        } catch (\Throwable $e) {
+            $this->entityManager->rollback();
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
-
-        $result = random_int(0, 1) === 0 ? 'pile' : 'face';
-        $won = $result === $choice;
-
-        $user->setCoins($won ? $user->getCoins() + $amount : $user->getCoins() - $amount);
-        $this->entityManager->flush();
-
-        return new JsonResponse([
-            'success' => true,
-            'won' => $won,
-            'result' => $result,
-            'amount' => $amount,
-            'message' => $won
-                ? "🎉 La pièce est tombée sur {$result} ! Vous gagnez {$amount}€ !"
-                : "😢 La pièce est tombée sur {$result}. Vous perdez {$amount}€.",
-            'coins' => $user->getCoins(),
-        ]);
     }
 }

--- a/web/backend/src/Controller/API/ShopController.php
+++ b/web/backend/src/Controller/API/ShopController.php
@@ -99,22 +99,27 @@ class ShopController extends AbstractApiController
                 return new JsonResponse(['success' => false, 'message' => "Cet item n'est plus disponible"], Response::HTTP_BAD_REQUEST);
             }
 
-            foreach ($user->getInventory() as $inventoryItem) {
-                if ($inventoryItem->getItemId() === $itemId) {
-                    return new JsonResponse(['success' => false, 'message' => 'Vous possédez déjà cet item'], Response::HTTP_CONFLICT);
-                }
-            }
-
-            if ($user->getCoins() < $item->getPrice()) {
-                return new JsonResponse([
-                    'success' => false,
-                    'message' => sprintf("Vous n'avez pas assez d'argent. (%d€ / %d€)", $user->getCoins(), $item->getPrice()),
-                ], Response::HTTP_PAYMENT_REQUIRED);
-            }
-
             $this->entityManager->beginTransaction();
 
             try {
+                $this->entityManager->lock($user, \Doctrine\DBAL\LockMode::PESSIMISTIC_WRITE);
+                $this->entityManager->refresh($user);
+
+                foreach ($user->getInventory() as $inventoryItem) {
+                    if ($inventoryItem->getItemId() === $itemId) {
+                        $this->entityManager->rollback();
+                        return new JsonResponse(['success' => false, 'message' => 'Vous possédez déjà cet item'], Response::HTTP_CONFLICT);
+                    }
+                }
+
+                if ($user->getCoins() < $item->getPrice()) {
+                    $this->entityManager->rollback();
+                    return new JsonResponse([
+                        'success' => false,
+                        'message' => sprintf("Vous n'avez pas assez d'argent. (%d€ / %d€)", $user->getCoins(), $item->getPrice()),
+                    ], Response::HTTP_PAYMENT_REQUIRED);
+                }
+
                 $user->setCoins($user->getCoins() - $item->getPrice());
 
                 $inventoryEntry = new UserInventory();

--- a/web/backend/src/Controller/API/TravelController.php
+++ b/web/backend/src/Controller/API/TravelController.php
@@ -156,29 +156,45 @@ class TravelController extends AbstractApiController
 
         $travelCost = $alreadyVisited ? 0 : $route->getCost();
 
-        if ($travelCost > 0 && $user->getCoins() < $travelCost) {
+        $this->entityManager->beginTransaction();
+        try {
+            $this->entityManager->lock($user, \Doctrine\DBAL\LockMode::PESSIMISTIC_WRITE);
+            $this->entityManager->refresh($user);
+
+            if ($user->getTravelingTo() && $user->getArrivalTime() && time() < $user->getArrivalTime()) {
+                $this->entityManager->rollback();
+                return new JsonResponse(['success' => false, 'message' => '🚂 Vous êtes déjà en voyage !'], Response::HTTP_CONFLICT);
+            }
+
+            if ($travelCost > 0 && $user->getCoins() < $travelCost) {
+                $this->entityManager->rollback();
+                return new JsonResponse([
+                    'success' => false,
+                    'message' => "❌ Vous n'avez pas assez d'argent. ({$user->getCoins()}€ / {$travelCost}€)",
+                ], Response::HTTP_PAYMENT_REQUIRED);
+            }
+
+            if ($travelCost > 0) {
+                $user->setCoins($user->getCoins() - $travelCost);
+            }
+
+            $arrivalTime = time() + $route->getDuration();
+            $user->setTravelingTo($destination);
+            $user->setArrivalTime($arrivalTime);
+            $this->entityManager->flush();
+            $this->entityManager->commit();
+
             return new JsonResponse([
-                'success' => false,
-                'message' => "❌ Vous n'avez pas assez d'argent. ({$user->getCoins()}€ / {$travelCost}€)",
-            ], Response::HTTP_PAYMENT_REQUIRED);
+                'success' => true,
+                'message' => "Voyage commencé !",
+                'arrival_time' => $arrivalTime,
+                'travel_cost' => $travelCost,
+                'coins' => $user->getCoins(),
+            ]);
+        } catch (\Throwable $e) {
+            $this->entityManager->rollback();
+            return new JsonResponse(['error' => 'Internal error', 'message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
-
-        if ($travelCost > 0) {
-            $user->setCoins($user->getCoins() - $travelCost);
-        }
-
-        $arrivalTime = time() + $route->getDuration();
-        $user->setTravelingTo($destination);
-        $user->setArrivalTime($arrivalTime);
-        $this->entityManager->flush();
-
-        return new JsonResponse([
-            'success' => true,
-            'message' => "Voyage commencé !",
-            'arrival_time' => $arrivalTime,
-            'travel_cost' => $travelCost,
-            'coins' => $user->getCoins(),
-        ]);
     }
 
     private function completeTravel(\App\Entity\User $user): void


### PR DESCRIPTION
## Résumé

Trois opérations de déduction de MazCoins étaient vulnérables aux race conditions (TOCTOU — Time of Check, Time of Use) :

- `ShopController::purchaseItem()` — achat d'item
- `TravelController::start()` — démarrage d'un voyage payant
- `CommandsController::coinflip()` — mise en jeu

**Scénario exploitable sans ce fix :**
Deux requêtes simultanées lisent le même solde stale (50€), passent toutes les deux le check (50 >= 40), et la dernière écriture gagne → l'item est acheté mais la déduction n'est appliquée qu'une seule fois.

## Fix

Ajout d'un `SELECT ... FOR UPDATE` (Doctrine `LockMode::PESSIMISTIC_WRITE`) à l'intérieur de chaque transaction, suivi d'un `refresh()` pour forcer la relecture des valeurs fraîches depuis la base avant tout check et toute mutation.

## OWASP

Couvre **A04:2021 – Insecure Design** : les flux critiques de déduction sont maintenant atomiques et résistants aux accès concurrents.

## Plan de test

- [ ] Envoyer deux requêtes concurrentes sur `POST /api/shop/purchase` avec le même item — vérifier qu'une seule réussit
- [ ] Envoyer deux requêtes concurrentes sur `POST /api/travel/start` avec la même destination — vérifier qu'une seule démarre
- [ ] Envoyer deux requêtes concurrentes sur `POST /api/commands/coinflip` — vérifier que le solde est cohérent après les deux résolutions

Closes #182