### PR TITLE
feat(security): En-têtes de sécurité HTTP backend et frontend (Feature #176)

### DIFF
--- a/web/backend/src/EventSubscriber/SecurityHeadersSubscriber.php
+++ b/web/backend/src/EventSubscriber/SecurityHeadersSubscriber.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class SecurityHeadersSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::RESPONSE => 'onKernelResponse'];
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+        $response->headers->set(
+            'Content-Security-Policy',
+            "default-src 'self'; img-src 'self' cdn.discordapp.com; script-src 'self'; style-src 'self' 'unsafe-inline'"
+        );
+    }
+}

--- a/web/frontend/src/index.html
+++ b/web/frontend/src/index.html
@@ -5,6 +5,8 @@
   <title>Frontend</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; img-src 'self' cdn.discordapp.com; script-src 'self'; style-src 'self' 'unsafe-inline'">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>


### PR DESCRIPTION
## Résumé

Implémentation des en-têtes de sécurité HTTP pour durcir la surface d'attaque côté navigateur et API.

Inclut **SU #181** (PR #197).

## OWASP

Couvre **A05:2021 – Security Misconfiguration** : les en-têtes HTTP par défaut exposent des informations sur la stack technique et autorisent des comportements non sécurisés (clickjacking, MIME sniffing, mixed content).

## Plan de test

- [ ] Vérifier la présence des en-têtes sur les réponses API (Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy)
- [ ] Vérifier que les en-têtes sont présents sur le frontend Angular
- [ ] Tester l'absence de `X-Powered-By` et `Server` dans les réponses

Closes #176