### PR TITLE
feat(security): configuration Dependabot npm et Composer (SU #104)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/web/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependabot"
+      - "dependencies"
+    assignees:
+      - "Mazlai"
+
+  - package-ecosystem: "npm"
+    directory: "/web/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependabot"
+      - "dependencies"
+    assignees:
+      - "Mazlai"
+
+  - package-ecosystem: "npm"
+    directory: "/bot"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependabot"
+      - "dependencies"
+    assignees:
+      - "Mazlai"


### PR DESCRIPTION
## Résumé

- Ajout de `.github/dependabot.yml` configurant les version updates pour les 3 ecosystèmes :
  - Composer (`/web/backend`)
  - npm frontend (`/web/frontend`)
  - npm bot (`/bot`)
- Scan hebdomadaire chaque lundi
- PRs automatiques avec label `dependabot` + `dependencies`, assignées à @Mazlai

Couvre OWASP A05 & A06 — Security Misconfiguration / Vulnerable and Outdated Components.

> Les Dependabot alerts et security updates sont à activer via Settings > Advanced Security du repo.

## Plan de test

- [ ] Après merge, vérifier l'onglet **Security > Dependabot alerts** sur GitHub
- [ ] Vérifier l'onglet **Insights > Dependency graph > Dependabot** pour confirmer la détection des 3 ecosystèmes
- [ ] Les PRs Dependabot apparaissent avec le label `dependabot`