### PR TITLE
feat(observabilite): journalisation sécurité et Dependabot (Feature #103)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/web/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependabot"
+      - "dependencies"
+    assignees:
+      - "Mazlai"
+
+  - package-ecosystem: "npm"
+    directory: "/web/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependabot"
+      - "dependencies"
+    assignees:
+      - "Mazlai"
+
+  - package-ecosystem: "npm"
+    directory: "/bot"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependabot"
+      - "dependencies"
+    assignees:
+      - "Mazlai"

--- a/web/backend/config/packages/monolog.yaml
+++ b/web/backend/config/packages/monolog.yaml
@@ -1,6 +1,7 @@
 monolog:
     channels:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+        - security
 
 when@dev:
     monolog:
@@ -10,6 +11,11 @@ when@dev:
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: debug
                 channels: ["!event"]
+            security:
+                type: stream
+                path: "%kernel.logs_dir%/security.log"
+                level: info
+                channels: [security]
             console:
                 type: console
                 process_psr_3_messages: false
@@ -37,12 +43,18 @@ when@prod:
                 action_level: error
                 handler: nested
                 excluded_http_codes: [404, 405]
-                channels: ["!deprecation"]
+                channels: ["!deprecation", "!security"]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
             nested:
                 type: stream
                 path: php://stderr
                 level: debug
+                formatter: monolog.formatter.json
+            security:
+                type: stream
+                path: php://stderr
+                level: info
+                channels: [security]
                 formatter: monolog.formatter.json
             console:
                 type: console

--- a/web/backend/src/Controller/API/AbstractApiController.php
+++ b/web/backend/src/Controller/API/AbstractApiController.php
@@ -5,6 +5,7 @@ namespace App\Controller\API;
 use App\Entity\User;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -12,11 +13,30 @@ use Symfony\Contracts\Service\Attribute\Required;
 abstract class AbstractApiController extends AbstractController
 {
     protected LoggerInterface $logger;
+    protected LoggerInterface $securityLogger;
 
     #[Required]
     public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
+    }
+
+    #[Required]
+    public function setSecurityLogger(
+        #[Autowire(service: 'monolog.logger.security')]
+        LoggerInterface $securityLogger
+    ): void {
+        $this->securityLogger = $securityLogger;
+    }
+
+    protected function logCoinTransaction(User $user, string $type, int $delta, int $balanceAfter): void
+    {
+        $this->securityLogger->info('Coin transaction', [
+            'user_id' => $user->getUserId(),
+            'type' => $type,
+            'delta' => $delta,
+            'balance_after' => $balanceAfter,
+        ]);
     }
 
     protected function getCurrentUser(): ?User

--- a/web/backend/src/Controller/API/CommandsController.php
+++ b/web/backend/src/Controller/API/CommandsController.php
@@ -55,6 +55,7 @@ class CommandsController extends AbstractApiController
         $user->setCoins($user->getCoins() + self::DAILY_REWARD);
         $user->setLastDaily($now);
         $this->entityManager->flush();
+        $this->logCoinTransaction($user, 'daily', self::DAILY_REWARD, $user->getCoins());
 
         return new JsonResponse([
             'success' => true,
@@ -114,6 +115,7 @@ class CommandsController extends AbstractApiController
         $user->setCoins($user->getCoins() + $reward);
         $user->setLastWork($now);
         $this->entityManager->flush();
+        $this->logCoinTransaction($user, 'work', $reward, $user->getCoins());
 
         return new JsonResponse([
             'success' => true,
@@ -170,9 +172,11 @@ class CommandsController extends AbstractApiController
             $result = random_int(0, 1) === 0 ? 'pile' : 'face';
             $won = $result === $choice;
 
-            $user->setCoins($won ? $user->getCoins() + $amount : $user->getCoins() - $amount);
+            $delta = $won ? $amount : -$amount;
+            $user->setCoins($user->getCoins() + $delta);
             $this->entityManager->flush();
             $this->entityManager->commit();
+            $this->logCoinTransaction($user, 'coinflip', $delta, $user->getCoins());
 
             return new JsonResponse([
                 'success' => true,

--- a/web/backend/src/Controller/API/ShopController.php
+++ b/web/backend/src/Controller/API/ShopController.php
@@ -117,7 +117,8 @@ class ShopController extends AbstractApiController
                     return $this->failureResponse(sprintf("Vous n'avez pas assez d'argent. (%d€ / %d€)", $user->getCoins(), $item->getPrice()), Response::HTTP_PAYMENT_REQUIRED);
                 }
 
-                $user->setCoins($user->getCoins() - $item->getPrice());
+                $price = $item->getPrice();
+                $user->setCoins($user->getCoins() - $price);
 
                 $inventoryEntry = new UserInventory();
                 $inventoryEntry->setUser($user);
@@ -127,6 +128,7 @@ class ShopController extends AbstractApiController
                 $this->entityManager->persist($inventoryEntry);
                 $this->entityManager->flush();
                 $this->entityManager->commit();
+                $this->logCoinTransaction($user, 'shop_purchase', -$price, $user->getCoins());
 
                 return new JsonResponse([
                     'success' => true,

--- a/web/backend/src/Controller/API/TravelController.php
+++ b/web/backend/src/Controller/API/TravelController.php
@@ -178,6 +178,10 @@ class TravelController extends AbstractApiController
             $this->entityManager->flush();
             $this->entityManager->commit();
 
+            if ($travelCost > 0) {
+                $this->logCoinTransaction($user, 'travel', -$travelCost, $user->getCoins());
+            }
+
             return new JsonResponse([
                 'success' => true,
                 'message' => "Voyage commencé !",

--- a/web/backend/src/EventSubscriber/JwtSecurityLogSubscriber.php
+++ b/web/backend/src/EventSubscriber/JwtSecurityLogSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTExpiredEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class JwtSecurityLogSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        #[Autowire(service: 'monolog.logger.security')]
+        private readonly LoggerInterface $securityLogger,
+    ) {}
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::JWT_INVALID => 'onJWTInvalid',
+            Events::JWT_EXPIRED => 'onJWTExpired',
+        ];
+    }
+
+    public function onJWTInvalid(JWTInvalidEvent $event): void
+    {
+        $request = $event->getRequest();
+        $this->securityLogger->warning('Invalid JWT token', [
+            'ip' => $request->getClientIp(),
+            'path' => $request->getPathInfo(),
+        ]);
+    }
+
+    public function onJWTExpired(JWTExpiredEvent $event): void
+    {
+        $request = $event->getRequest();
+        $this->securityLogger->info('Expired JWT token', [
+            'ip' => $request->getClientIp(),
+            'path' => $request->getPathInfo(),
+        ]);
+    }
+}

--- a/web/backend/src/Security/BotAuthenticator.php
+++ b/web/backend/src/Security/BotAuthenticator.php
@@ -8,6 +8,7 @@ use App\Entity\UserInventory;
 use App\Entity\VisitedCity;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,6 +31,8 @@ class BotAuthenticator extends AbstractAuthenticator
         private readonly EntityManagerInterface $entityManager,
         #[Autowire(env: 'BOT_API_SECRET')]
         private readonly string $botApiSecret,
+        #[Autowire(service: 'monolog.logger.security')]
+        private readonly LoggerInterface $securityLogger,
     ) {}
 
     public function supports(Request $request): ?bool
@@ -71,6 +74,11 @@ class BotAuthenticator extends AbstractAuthenticator
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
+        $this->securityLogger->warning('Bot authentication failure', [
+            'ip' => $request->getClientIp(),
+            'reason' => $exception->getMessageKey(),
+        ]);
+
         return new JsonResponse([
             'success' => false,
             'message' => $exception->getMessage(),


### PR DESCRIPTION
## Résumé

- **SU #187** — Canal Monolog `security` dédié, log des échecs d'auth bot, JWT invalides/expirés, audit trail des transactions MazCoins
- **SU #104** — Configuration Dependabot (Composer + npm) avec scan hebdomadaire, labels et assignation automatique

Couvre OWASP A05, A06, A09.

## Plan de test

- [ ] `var/log/security.log` alimenté après daily/work/coinflip/shop
- [ ] Echec auth bot → entrée `Bot authentication failure` dans security.log
- [ ] JWT invalide → entrée `Invalid JWT token`
- [ ] Après merge dans `main` : Dependabot actif dans Insights > Dependency graph