### PR TITLE
feat(security): sécurisation des tokens auth en production (SU #151)

### DIFF
--- a/web/backend/config/packages/lexik_jwt_authentication.yaml
+++ b/web/backend/config/packages/lexik_jwt_authentication.yaml
@@ -3,4 +3,4 @@ lexik_jwt_authentication:
     public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
     pass_phrase: '%env(JWT_PASSPHRASE)%'
     user_id_claim: user_id
-    token_ttl: 3600
+    token_ttl: 900

--- a/web/backend/config/packages/nelmio_cors.yaml
+++ b/web/backend/config/packages/nelmio_cors.yaml
@@ -5,6 +5,7 @@ nelmio_cors:
         allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
         allow_headers: ['Content-Type', 'Authorization']
         expose_headers: ['Link']
+        allow_credentials: true
         max_age: 3600
     paths:
         '^/': null

--- a/web/backend/config/packages/security.yaml
+++ b/web/backend/config/packages/security.yaml
@@ -12,7 +12,7 @@ security:
             security: false
 
         auth:
-            pattern: ^/api/auth/discord
+            pattern: ^/api/auth/(discord|refresh)
             stateless: true
             security: false
 
@@ -31,7 +31,7 @@ security:
         - { path: ^/api/auth/discord, roles: PUBLIC_ACCESS }
         - { path: ^/api/auth/verify, roles: PUBLIC_ACCESS }
         - { path: ^/api/auth/me, roles: ROLE_USER }
-        - { path: ^/api/auth/refresh, roles: ROLE_USER }
+        - { path: ^/api/auth/refresh, roles: PUBLIC_ACCESS }
         - { path: ^/api/auth/logout, roles: ROLE_USER }
         - { path: ^/api/profile, roles: ROLE_USER }
         - { path: ^/api/travel, roles: ROLE_USER }

--- a/web/backend/src/Controller/API/AuthController.php
+++ b/web/backend/src/Controller/API/AuthController.php
@@ -2,11 +2,13 @@
 
 namespace App\Controller\API;
 
+use App\Repository\UserRepository;
 use App\Service\Crypto\TokenEncryptorService;
 use App\Service\Discord\DiscordOAuthService;
 use App\Service\User\UserService;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -17,6 +19,9 @@ use Psr\Cache\CacheItemPoolInterface;
 #[Route('/api/auth', name: 'api_auth_')]
 class AuthController extends AbstractApiController
 {
+    private const REFRESH_COOKIE = 'mw_refresh';
+    private const REFRESH_TTL = 604800; // 7 days
+
     public function __construct(
         private readonly DiscordOAuthService $discordOAuth,
         private readonly UserService $userService,
@@ -27,6 +32,7 @@ class AuthController extends AbstractApiController
         private readonly RateLimiterFactory $refreshLimiter,
         private readonly CacheItemPoolInterface $cache,
         private readonly TokenEncryptorService $tokenEncryptor,
+        private readonly UserRepository $userRepository,
     ) {}
 
     #[Route('/discord/login', name: 'discord_login', methods: ['GET'])]
@@ -75,7 +81,7 @@ class AuthController extends AbstractApiController
 
             $guilds = $this->discordOAuth->getDiscordUserGuilds($tokens->accessToken);
 
-            return new JsonResponse([
+            $response = new JsonResponse([
                 'token' => $jwt,
                 'user' => $this->userService->serializeUser($user),
                 'guilds' => array_map(fn($guild) => [
@@ -84,21 +90,40 @@ class AuthController extends AbstractApiController
                     'icon' => $guild->getIconUrl(),
                 ], array_slice($guilds, 0, 10)),
             ]);
+
+            $response->headers->setCookie($this->createRefreshCookie($user->getUserId()));
+
+            return $response;
         } catch (\Exception) {
             return $this->unauthorizedResponse('Authentication failed');
         }
     }
 
     #[Route('/refresh', name: 'refresh', methods: ['POST'])]
-    public function refresh(): JsonResponse
+    public function refresh(Request $request): JsonResponse
     {
-        $user = $this->getCurrentUser();
+        $rawToken = $request->cookies->get(self::REFRESH_COOKIE);
 
-        if (!$user) {
-            return $this->unauthorizedResponse();
+        if (!$rawToken) {
+            return $this->unauthorizedResponse('No refresh token');
         }
 
-        $limit = $this->refreshLimiter->create($user->getUserId())->consume();
+        $cacheKey = 'refresh_token_' . hash('sha256', $rawToken);
+        $item = $this->cache->getItem($cacheKey);
+
+        if (!$item->isHit()) {
+            return $this->unauthorizedResponse('Invalid or expired refresh token');
+        }
+
+        $userId = $item->get();
+        $user = $this->userRepository->find($userId);
+
+        if (!$user) {
+            $this->cache->deleteItem($cacheKey);
+            return $this->unauthorizedResponse('User not found');
+        }
+
+        $limit = $this->refreshLimiter->create($userId)->consume();
         if (!$limit->isAccepted()) {
             return $this->tooManyRequestsResponse($limit->getRetryAfter());
         }
@@ -107,23 +132,27 @@ class AuthController extends AbstractApiController
             if ($user->isAccessTokenExpired() && $user->getOauthRefreshToken()) {
                 $newTokens = $this->discordOAuth->refreshTokens($this->tokenEncryptor->decrypt($user->getOauthRefreshToken()));
                 $this->userService->updateUserTokens($user, $newTokens);
-
                 $discordUser = $this->discordOAuth->getDiscordUser($newTokens->accessToken);
                 $this->userService->updateUserFromDiscord($user, $discordUser);
                 $this->userService->save($user);
             }
 
-            return new JsonResponse([
+            // Rotate refresh token
+            $this->cache->deleteItem($cacheKey);
+            $response = new JsonResponse([
                 'token' => $this->jwtManager->create($user),
                 'user' => $this->userService->serializeUser($user),
             ]);
+            $response->headers->setCookie($this->createRefreshCookie($userId));
+
+            return $response;
         } catch (\Exception) {
             return $this->unauthorizedResponse('Token refresh failed');
         }
     }
 
     #[Route('/logout', name: 'logout', methods: ['POST'])]
-    public function logout(): JsonResponse
+    public function logout(Request $request): JsonResponse
     {
         $user = $this->getCurrentUser();
 
@@ -133,11 +162,36 @@ class AuthController extends AbstractApiController
             }
 
             $item = $this->cache->getItem('jwt_blacklist_' . $user->getUserId());
-            $item->set(time())->expiresAfter(3600);
+            $item->set(time())->expiresAfter(900);
             $this->cache->save($item);
         }
 
-        return new JsonResponse(['message' => 'Logged out successfully']);
+        $rawToken = $request->cookies->get(self::REFRESH_COOKIE);
+        if ($rawToken) {
+            $this->cache->deleteItem('refresh_token_' . hash('sha256', $rawToken));
+        }
+
+        $response = new JsonResponse(['message' => 'Logged out successfully']);
+        $response->headers->clearCookie(self::REFRESH_COOKIE, '/api/auth');
+
+        return $response;
+    }
+
+    private function createRefreshCookie(string $userId): Cookie
+    {
+        $rawToken = bin2hex(random_bytes(32));
+
+        $item = $this->cache->getItem('refresh_token_' . hash('sha256', $rawToken));
+        $item->set($userId)->expiresAfter(self::REFRESH_TTL);
+        $this->cache->save($item);
+
+        return Cookie::create(self::REFRESH_COOKIE)
+            ->withValue($rawToken)
+            ->withExpires(time() + self::REFRESH_TTL)
+            ->withPath('/api/auth')
+            ->withSecure(true)
+            ->withHttpOnly(true)
+            ->withSameSite('strict');
     }
 
     #[Route('/me', name: 'me', methods: ['GET'])]

--- a/web/frontend/src/app/core/interceptors/jwt.interceptor.ts
+++ b/web/frontend/src/app/core/interceptors/jwt.interceptor.ts
@@ -12,9 +12,10 @@ export const jwtInterceptor: HttpInterceptorFn = (req, next) => {
   if (PUBLIC_URLS.some(url => req.url.includes(url))) return next(req);
 
   const token = inject(AuthStorageService).getToken();
-  const authReq = token
-    ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
-    : req;
+  const authReq = req.clone({
+    withCredentials: true,
+    ...(token ? { setHeaders: { Authorization: `Bearer ${token}` } } : {}),
+  });
 
   return next(authReq).pipe(
     catchError((err: HttpErrorResponse) => throwError(() => err)),

--- a/web/frontend/src/app/core/services/auth-storage.service.ts
+++ b/web/frontend/src/app/core/services/auth-storage.service.ts
@@ -1,8 +1,7 @@
-import { Injectable, inject, PLATFORM_ID } from '@angular/core';
+import { Injectable, inject, PLATFORM_ID, signal } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import type { User } from '../models/user.model';
 
-const TOKEN_KEY = 'mw_token';
 const USER_KEY = 'mw_user';
 const STATE_KEY = 'mw_oauth_state';
 const PROCESSED_CODE_KEY = 'mw_processed_code';
@@ -11,6 +10,7 @@ const REDIRECT_URL_KEY = 'mw_redirect_url';
 @Injectable({ providedIn: 'root' })
 export class AuthStorageService {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly _token = signal<string | null>(null);
 
   private get<T = string>(key: string): T | null {
     if (!this.isBrowser) return null;
@@ -28,9 +28,9 @@ export class AuthStorageService {
     if (this.isBrowser) sessionStorage.removeItem(key);
   }
 
-  getToken(): string | null { return this.get(TOKEN_KEY); }
-  saveToken(token: string): void { this.set(TOKEN_KEY, token); }
-  clearToken(): void { this.remove(TOKEN_KEY); }
+  getToken(): string | null { return this._token(); }
+  saveToken(token: string): void { this._token.set(token); }
+  clearToken(): void { this._token.set(null); }
 
   getUser(): User | null { return this.get<User>(USER_KEY); }
   saveUser(user: User): void { this.set(USER_KEY, user); }
@@ -49,7 +49,8 @@ export class AuthStorageService {
   clearRedirectUrl(): void { this.remove(REDIRECT_URL_KEY); }
 
   clearAll(): void {
-    [TOKEN_KEY, USER_KEY, STATE_KEY, PROCESSED_CODE_KEY, REDIRECT_URL_KEY]
+    this._token.set(null);
+    [USER_KEY, STATE_KEY, PROCESSED_CODE_KEY, REDIRECT_URL_KEY]
       .forEach(k => this.remove(k));
   }
 }

--- a/web/frontend/src/app/core/services/auth.service.ts
+++ b/web/frontend/src/app/core/services/auth.service.ts
@@ -35,29 +35,17 @@ export class AuthService {
   }
 
   private initializeAuth(): void {
-    const token = this.storage.getToken();
-    const storedUser = this.storage.getUser();
-
-    if (token && storedUser) {
-      this._currentUser.set(storedUser);
-      this._isLoading.set(false);
-
-      this.verifyToken().subscribe({
-        next: res => {
-          if (res.valid && res.user) {
-            this.setUser(res.user);
-          } else if (res.valid === false) {
-            this.clearAuth();
-          }
-        },
-        error: err => {
-          if (err.status === 401) this.clearAuth();
-        },
-      });
-    } else {
-      this.clearAuth();
-      this._isLoading.set(false);
-    }
+    this.http.post<AuthResponse>(`${environment.apiUrl}/api/auth/refresh`, {}, { withCredentials: true }).subscribe({
+      next: res => {
+        this.storage.saveToken(res.token);
+        this.setUser(res.user);
+        this._isLoading.set(false);
+      },
+      error: () => {
+        this.clearAuth();
+        this._isLoading.set(false);
+      },
+    });
   }
 
   loginWithDiscord(): Observable<LoginUrlResponse> {
@@ -95,9 +83,12 @@ export class AuthService {
     );
   }
 
-  refreshToken(): Observable<{ token: string }> {
-    return this.http.post<{ token: string }>(`${environment.apiUrl}/api/auth/refresh`, {}).pipe(
-      tap(res => this.storage.saveToken(res.token)),
+  refreshToken(): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(`${environment.apiUrl}/api/auth/refresh`, {}, { withCredentials: true }).pipe(
+      tap(res => {
+        this.storage.saveToken(res.token);
+        this.setUser(res.user);
+      }),
       catchError(err => {
         this.clearAuth();
         return throwError(() => err);
@@ -110,7 +101,7 @@ export class AuthService {
   }
 
   logout(): void {
-    this.http.post(`${environment.apiUrl}/api/auth/logout`, {}).pipe(
+    this.http.post(`${environment.apiUrl}/api/auth/logout`, {}, { withCredentials: true }).pipe(
       catchError(() => of(null)),
     ).subscribe(() => {
       this.clearAuth();


### PR DESCRIPTION
## Résumé

Pattern **access token en mémoire + refresh token httpOnly cookie** :

- JWT court (15 min) retourné dans la réponse JSON, stocké uniquement dans un signal Angular (jamais en storage)
- Refresh token (7 jours) posé en cookie `httpOnly; Secure; SameSite=Strict; Path=/api/auth`
- Rotation du refresh token à chaque utilisation (prévient le rejeu)
- `/api/auth/refresh` passe en `PUBLIC_ACCESS` — le cookie suffit, aucun JWT requis
- `CORS allow_credentials: true` pour les requêtes cross-origin avec cookie
- `initializeAuth()` : appel silencieux à `/api/auth/refresh` au démarrage → session restaurée après F5 sans repasser par Discord

## Plan de test

- [ ] Connexion Discord → DevTools Cookies → `mw_refresh` présent avec **HttpOnly ✓**
- [ ] `document.cookie` dans la console → `mw_refresh` absent (httpOnly)
- [ ] `sessionStorage` → `mw_token` absent (token en mémoire uniquement)
- [ ] F5 → utilisateur toujours connecté (refresh silencieux via cookie)
- [ ] Déconnexion → cookie `mw_refresh` supprimé, F5 → utilisateur déconnecté