### PR TITLE
feat(accessibility): textes alternatifs et labels accessibles WCAG 2.1 AA (SU #191)

### DIFF
--- a/web/backend/.env.example
+++ b/web/backend/.env.example
@@ -33,3 +33,8 @@ APP_ENCRYPTION_KEY=your_base64_encoded_32byte_key
 ###> nelmio/cors-bundle ###
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
+
+###> symfony/lock ###
+# flock (cross-platform, sys_get_temp_dir) | flock:///tmp/locks (chemin explicite) | semaphore (Linux/Mac) | doctrine://default
+LOCK_DSN=flock
+###< symfony/lock ###

--- a/web/frontend/src/app/features/commands/commands.component.html
+++ b/web/frontend/src/app/features/commands/commands.component.html
@@ -9,7 +9,7 @@
 
   <!-- Tip banner -->
   <div class="commands-tip container">
-    <span class="commands-tip__icon">💡</span>
+    <span class="commands-tip__icon" aria-hidden="true">💡</span>
     <span>Tapez <strong>/</strong> dans Discord pour accéder aux commandes. Elles sont disponibles sur tout serveur où le bot est présent.</span>
   </div>
 
@@ -18,7 +18,7 @@
     <section class="cmd-category container">
 
       <div class="cmd-category__header">
-        <span class="cmd-category__icon">{{ cat.emoji }}</span>
+        <span class="cmd-category__icon" aria-hidden="true">{{ cat.emoji }}</span>
         <span class="cmd-category__title">{{ cat.label }}</span>
         <span class="cmd-category__count">{{ commandsFor(cat.id).length }} commande{{ commandsFor(cat.id).length > 1 ? 's' : '' }}</span>
       </div>
@@ -28,7 +28,7 @@
           <div class="cmd-card">
 
             <div class="cmd-card__top">
-              <span class="cmd-card__emoji">{{ cmd.emoji }}</span>
+              <span class="cmd-card__emoji" aria-hidden="true">{{ cmd.emoji }}</span>
               <span class="cmd-card__name">/{{ cmd.name }}</span>
             </div>
 

--- a/web/frontend/src/app/features/dashboard/dashboard.component.html
+++ b/web/frontend/src/app/features/dashboard/dashboard.component.html
@@ -25,7 +25,7 @@
     </div>
   } @else {
     <div class="dashboard-loading">
-      <span>⚠️</span>
+      <span aria-hidden="true">⚠️</span>
       <p>Impossible de charger les données.</p>
     </div>
   }

--- a/web/frontend/src/app/features/home/home.component.html
+++ b/web/frontend/src/app/features/home/home.component.html
@@ -54,7 +54,7 @@
         @for (f of features; track f.icon; let i = $index) {
           <div class="feature-card">
             <span class="feature-card__num">{{ (i + 1).toString().padStart(2, '0') }}</span>
-            <span class="feature-card__icon">{{ f.icon }}</span>
+            <span class="feature-card__icon" aria-hidden="true">{{ f.icon }}</span>
             <h3>{{ f.title }}</h3>
             <p>{{ f.desc }}</p>
           </div>
@@ -76,7 +76,7 @@
       <div class="cities-grid">
         @for (city of cities; track city.id) {
           <div class="city-card city-card--{{ city.id }}">
-            <span class="city-card__emoji">{{ city.emoji }}</span>
+            <span class="city-card__emoji" aria-hidden="true">{{ city.emoji }}</span>
             <span class="city-card__name">{{ city.name }}</span>
             <span class="city-card__theme">{{ city.theme }}</span>
           </div>
@@ -107,7 +107,7 @@
           <div class="flow-step__top">
             <div class="flow-step__circle">
               <span class="flow-step__num">{{ i + 1 }}</span>
-              {{ step.emoji }}
+              <span aria-hidden="true">{{ step.emoji }}</span>
             </div>
             @if (!last) { <div class="flow-connector"></div> }
           </div>

--- a/web/frontend/src/app/features/inventory/inventory.component.html
+++ b/web/frontend/src/app/features/inventory/inventory.component.html
@@ -8,7 +8,7 @@
       <p class="subtitle">Gérez vos backgrounds et badges équipés</p>
     </div>
     <div class="inventory-header__balance">
-      <span>💰</span>
+      <span aria-hidden="true">💰</span>
       <span class="balance-value">{{ userCoins() }}</span>
       <span class="balance-unit">MC</span>
     </div>
@@ -33,7 +33,7 @@
   <!-- Error -->
   @else if (hasError()) {
     <div class="inventory-state inventory-state--error">
-      <span>⚠️</span>
+      <span aria-hidden="true">⚠️</span>
       <p>Impossible de charger l'inventaire.</p>
       <button class="btn btn-primary btn--sm" (click)="load()">Réessayer</button>
     </div>
@@ -41,7 +41,7 @@
 
   @else if (items().length === 0) {
     <div class="inventory-state container">
-      <span style="font-size:3rem">🎒</span>
+      <span style="font-size:3rem" aria-hidden="true">🎒</span>
       <p>Votre inventaire est vide.</p>
       <a class="btn-primary" href="/shop">Visiter la boutique</a>
     </div>
@@ -62,7 +62,7 @@
     @if (activeTab() === 'background') {
       @if (backgrounds().length === 0) {
         <div class="inventory-state container">
-          <span style="font-size:2.5rem">🖼️</span>
+          <span style="font-size:2.5rem" aria-hidden="true">🖼️</span>
           <p>Aucun background dans l'inventaire.</p>
         </div>
       } @else {
@@ -71,7 +71,7 @@
             <div class="item-card" [class.item-card--equipped]="item.equipped">
 
               <div class="item-card__header item-card__header--bg">
-                <span class="item-emoji">{{ getEmoji(item) }}</span>
+                <span class="item-emoji" aria-hidden="true">{{ getEmoji(item) }}</span>
                 @if (item.equipped) {
                   <span class="item-tag item-tag--equipped">⭐ Équipé</span>
                 }
@@ -108,9 +108,9 @@
           @for (slot of slots; track slot) {
             <div class="badge-slot-card" [class.badge-slot-card--filled]="getBadgeInSlot(slot)">
               @if (getBadgeInSlot(slot); as badge) {
-                <span class="slot-emoji">{{ getEmoji(badge) }}</span>
+                <span class="slot-emoji" aria-hidden="true">{{ getEmoji(badge) }}</span>
                 <span class="slot-name">{{ badge.name }}</span>
-                <button class="slot-unequip" (click)="unequipBadge(slot)" title="Déséquiper">✕</button>
+                <button class="slot-unequip" (click)="unequipBadge(slot)" aria-label="Déséquiper">✕</button>
               } @else {
                 <span class="slot-empty">{{ slot + 1 }}</span>
                 <span class="slot-label">Vide</span>
@@ -123,7 +123,7 @@
       <!-- Liste badges possédés -->
       @if (badges().length === 0) {
         <div class="inventory-state container">
-          <span style="font-size:2.5rem">🏅</span>
+          <span style="font-size:2.5rem" aria-hidden="true">🏅</span>
           <p>Aucun badge dans l'inventaire.</p>
         </div>
       } @else {
@@ -133,7 +133,7 @@
             <div class="item-card" [class.item-card--equipped]="item.equipped">
 
               <div class="item-card__header item-card__header--badge">
-                <span class="item-emoji">{{ getEmoji(item) }}</span>
+                <span class="item-emoji" aria-hidden="true">{{ getEmoji(item) }}</span>
                 @if (item.equipped) {
                   <span class="item-tag item-tag--equipped">⭐ Slot {{ (item.slot ?? 0) + 1 }}</span>
                 }

--- a/web/frontend/src/app/features/leaderboard/leaderboard.component.html
+++ b/web/frontend/src/app/features/leaderboard/leaderboard.component.html
@@ -26,7 +26,7 @@
   <!-- Error -->
   @else if (hasError()) {
     <div class="leaderboard-state leaderboard-state--error container">
-      <span>⚠️</span>
+      <span aria-hidden="true">⚠️</span>
       <p>Impossible de charger le classement.</p>
       <button class="btn btn-primary btn--sm" (click)="load()">Réessayer</button>
     </div>
@@ -35,7 +35,7 @@
   <!-- Empty -->
   @else if (entries().length === 0) {
     <div class="leaderboard-state container">
-      <span style="font-size:3rem">📊</span>
+      <span style="font-size:3rem" aria-hidden="true">📊</span>
       <p>Aucun joueur dans le classement pour le moment.</p>
     </div>
   }
@@ -46,7 +46,7 @@
       <div class="table-head">
         <span class="col-rank">Rang</span>
         <span class="col-player">Joueur</span>
-        <span class="col-coins">🪙 MazCoins</span>
+        <span class="col-coins"><span aria-hidden="true">🪙</span> MazCoins</span>
       </div>
 
       @for (entry of entries(); track entry.discord_id) {
@@ -65,11 +65,11 @@
 
     <!-- Pagination -->
     @if (totalPages() > 1) {
-      <div class="pagination container">
+      <nav class="pagination container" aria-label="Pagination">
         <button class="page-btn" [disabled]="!hasPrev()" (click)="prevPage()">← Précédent</button>
-        <span class="page-info">Page {{ currentPage() }} / {{ totalPages() }}</span>
+        <span class="page-info" aria-live="polite">Page {{ currentPage() }} / {{ totalPages() }}</span>
         <button class="page-btn" [disabled]="!hasNext()" (click)="nextPage()">Suivant →</button>
-      </div>
+      </nav>
     }
   }
 

--- a/web/frontend/src/app/features/map/map.component.html
+++ b/web/frontend/src/app/features/map/map.component.html
@@ -20,7 +20,7 @@
   <!-- Error -->
   @else if (hasError()) {
     <div class="map-state map-state--error">
-      <span>⚠️</span>
+      <span aria-hidden="true">⚠️</span>
       <p>Impossible de charger la carte.</p>
       <button class="btn btn-primary" (click)="load()">Réessayer</button>
     </div>
@@ -31,13 +31,13 @@
     @if (isTraveling()) {
       <div class="travel-banner container">
         <div class="travel-banner__inner">
-          <span class="travel-banner__icon">🚂</span>
+          <span class="travel-banner__icon" aria-hidden="true">🚂</span>
           <div class="travel-banner__text">
             <span>En route vers {{ travelingToEmoji() }} <strong>{{ travelingToName() }}</strong></span>
             <span class="travel-banner__countdown">Arrivée dans {{ formatCountdown(remainingSeconds()) }}</span>
           </div>
           <div class="travel-banner__coins">
-            <span>💰</span>
+            <span aria-hidden="true">💰</span>
             <span>{{ coins() }} MC</span>
           </div>
         </div>
@@ -100,7 +100,7 @@
               <div class="city-pulse"></div>
 
               <div class="city-icon">
-                <span class="city-emoji">{{ city.emoji }}</span>
+                <span class="city-emoji" aria-hidden="true">{{ city.emoji }}</span>
               </div>
 
               @if (isCurrentCity(city.city_id)) {
@@ -124,10 +124,10 @@
     <aside class="details-panel" [class.open]="selectedCity()">
       @if (selectedCity(); as city) {
         <div class="panel-content">
-          <button class="close-btn" (click)="closePanel()">✕</button>
+          <button class="close-btn" (click)="closePanel()" aria-label="Fermer le panneau">✕</button>
 
           <div class="panel-header">
-            <span class="panel-emoji">{{ city.emoji }}</span>
+            <span class="panel-emoji" aria-hidden="true">{{ city.emoji }}</span>
             <div>
               <h2>{{ city.name }}</h2>
               <span class="panel-theme">{{ city.theme }}</span>
@@ -146,7 +146,7 @@
               <div class="jobs-list">
                 @for (job of getCurrentCityJobs(); track job.job_id) {
                   <div class="job-item">
-                    <span class="job-emoji">{{ job.job_emoji }}</span>
+                    <span class="job-emoji" aria-hidden="true">{{ job.job_emoji }}</span>
                     <span class="job-name">{{ job.job_name }}</span>
                   </div>
                 }

--- a/web/frontend/src/app/features/records/records.component.html
+++ b/web/frontend/src/app/features/records/records.component.html
@@ -14,7 +14,7 @@
     </div>
   } @else if (hasError()) {
     <div class="records-state records-state--error container">
-      <span class="records-state__icon">⚠️</span>
+      <span class="records-state__icon" aria-hidden="true">⚠️</span>
       <p>Impossible de charger vos records.</p>
       <button class="btn-primary" (click)="load()">Réessayer</button>
     </div>
@@ -24,7 +24,7 @@
     <section class="records-section container">
       <div class="rec-block">
         <div class="rec-block__label">
-          <span class="rec-icon">🪙</span>
+          <span class="rec-icon" aria-hidden="true">🪙</span>
           <span class="section-label">MazCoins</span>
         </div>
 
@@ -57,7 +57,7 @@
     <section class="records-section container">
       <div class="rec-block">
         <div class="rec-block__label">
-          <span class="rec-icon">🗺️</span>
+          <span class="rec-icon" aria-hidden="true">🗺️</span>
           <span class="section-label">Exploration</span>
         </div>
 
@@ -78,7 +78,7 @@
           @for (city of r.exploration.cities; track city.city_id) {
             <div class="city-rec" [class.city-rec--visited]="city.visited" [class.city-rec--locked]="!city.visited">
               <div class="city-rec__inner">
-                <span class="city-rec__emoji">{{ city.visited ? (city.emoji ?? '🏙️') : '🔒' }}</span>
+                <span class="city-rec__emoji" aria-hidden="true">{{ city.visited ? (city.emoji ?? '🏙️') : '🔒' }}</span>
                 <span class="city-rec__name">{{ city.visited ? city.name : '???' }}</span>
                 @if (city.visited && city.first_visit) {
                   <span class="city-rec__date">{{ city.first_visit | date:'d MMM yy' }}</span>
@@ -101,25 +101,25 @@
     <section class="records-section container">
       <div class="rec-block">
         <div class="rec-block__label">
-          <span class="rec-icon">🛒</span>
+          <span class="rec-icon" aria-hidden="true">🛒</span>
           <span class="section-label">Collection</span>
         </div>
 
         <div class="collection-stats">
           <div class="collection-stat">
             <span class="collection-stat__value">{{ r.collection.inventory_count }}</span>
-            <span class="collection-stat__icon">📦</span>
+            <span class="collection-stat__icon" aria-hidden="true">📦</span>
             <span class="collection-stat__label">Items possédés</span>
           </div>
           <div class="collection-stat collection-stat--gold">
             <span class="collection-stat__value">{{ r.collection.badges_count }}</span>
-            <span class="collection-stat__icon">🏅</span>
+            <span class="collection-stat__icon" aria-hidden="true">🏅</span>
             <span class="collection-stat__label">Badges équipés</span>
           </div>
           @if (r.collection.recent_item) {
             <div class="collection-stat collection-stat--accent">
               <span class="collection-stat__value collection-stat__value--sm">{{ r.collection.recent_item }}</span>
-              <span class="collection-stat__icon">✨</span>
+              <span class="collection-stat__icon" aria-hidden="true">✨</span>
               <span class="collection-stat__label">Dernier achat</span>
             </div>
           }
@@ -137,7 +137,7 @@
     <section class="records-section container">
       <div class="rec-block">
         <div class="rec-block__label">
-          <span class="rec-icon">📅</span>
+          <span class="rec-icon" aria-hidden="true">📅</span>
           <span class="section-label">Activité</span>
         </div>
 

--- a/web/frontend/src/app/features/servers/servers.component.html
+++ b/web/frontend/src/app/features/servers/servers.component.html
@@ -10,7 +10,7 @@
   <!-- Bot status bar -->
   @if (botStatus(); as status) {
     <div class="bot-statusbar container">
-      <div class="bot-statusbar__dot" [class.bot-statusbar__dot--online]="status.online" [class.bot-statusbar__dot--offline]="!status.online"></div>
+      <div class="bot-statusbar__dot" [class.bot-statusbar__dot--online]="status.online" [class.bot-statusbar__dot--offline]="!status.online" aria-hidden="true"></div>
       <span class="bot-statusbar__label">
         Bot
         @if (status.username) { <strong>{{ status.username }}</strong> }
@@ -30,13 +30,13 @@
     </div>
   } @else if (hasError()) {
     <div class="servers-state servers-state--error container">
-      <span class="servers-state__icon">⚠️</span>
+      <span class="servers-state__icon" aria-hidden="true">⚠️</span>
       <p>Impossible de récupérer vos serveurs. Vérifiez que vous êtes bien connecté via Discord.</p>
       <button class="btn-primary" (click)="load()">Réessayer</button>
     </div>
   } @else if (servers().length === 0) {
     <div class="servers-state container">
-      <span class="servers-state__icon">🔍</span>
+      <span class="servers-state__icon" aria-hidden="true">🔍</span>
       <p>Aucun serveur trouvé.</p>
     </div>
   } @else {
@@ -45,7 +45,7 @@
     @if (presentCount() > 0) {
       <section class="servers-section container">
         <div class="servers-section__label">
-          <span class="servers-section__icon">✅</span>
+          <span class="servers-section__icon" aria-hidden="true">✅</span>
           <span class="section-label">Bot présent</span>
         </div>
         <div class="servers-grid">
@@ -78,7 +78,7 @@
       <div class="servers-divider container"></div>
       <section class="servers-section container">
         <div class="servers-section__label">
-          <span class="servers-section__icon">➕</span>
+          <span class="servers-section__icon" aria-hidden="true">➕</span>
           <span class="section-label">Ajouter le bot</span>
         </div>
         <div class="servers-grid">

--- a/web/frontend/src/app/features/shop/shop.component.html
+++ b/web/frontend/src/app/features/shop/shop.component.html
@@ -8,7 +8,7 @@
       <p class="subtitle">Personnalisez votre profil avec des backgrounds et badges uniques</p>
     </div>
     <div class="shop-header__balance">
-      <span>💰</span>
+      <span aria-hidden="true">💰</span>
       <span class="balance-value">{{ userCoins() }}</span>
       <span class="balance-unit">MC</span>
     </div>
@@ -33,7 +33,7 @@
   <!-- Error -->
   @else if (hasError()) {
     <div class="shop-state shop-state--error">
-      <span>⚠️</span>
+      <span aria-hidden="true">⚠️</span>
       <p>Impossible de charger la boutique.</p>
       <button class="btn btn-primary btn--sm" (click)="load()">Réessayer</button>
     </div>
@@ -43,22 +43,22 @@
     <!-- Stats -->
     <div class="shop-stats container">
       <div class="stat-chip">
-        <span>🛍️</span>
+        <span aria-hidden="true">🛍️</span>
         <strong>{{ totalCount() }}</strong>
         <span>Articles</span>
       </div>
       <div class="stat-chip">
-        <span>🖼️</span>
+        <span aria-hidden="true">🖼️</span>
         <strong>{{ bgCount() }}</strong>
         <span>Backgrounds</span>
       </div>
       <div class="stat-chip">
-        <span>🏅</span>
+        <span aria-hidden="true">🏅</span>
         <strong>{{ badgeCount() }}</strong>
         <span>Badges</span>
       </div>
       <div class="stat-chip stat-chip--owned">
-        <span>📦</span>
+        <span aria-hidden="true">📦</span>
         <strong>{{ ownedCount() }}</strong>
         <span>Possédés</span>
       </div>
@@ -77,7 +77,7 @@
     <!-- Grille articles -->
     @if (filteredItems().length === 0) {
       <div class="shop-state container">
-        <span style="font-size:3rem">🔍</span>
+        <span style="font-size:3rem" aria-hidden="true">🔍</span>
         <p>Aucun article dans cette catégorie.</p>
       </div>
     } @else {
@@ -89,7 +89,7 @@
 
             <!-- En-tête visuel -->
             <div class="item-card__header" [class.item-card__header--bg]="item.item_type === 'background'" [class.item-card__header--badge]="item.item_type === 'badge'">
-              <span class="item-emoji">{{ getEmoji(item) }}</span>
+              <span class="item-emoji" aria-hidden="true">{{ getEmoji(item) }}</span>
               @if (item.equipped) {
                 <span class="item-tag item-tag--equipped">⭐ Équipé</span>
               } @else if (item.owned) {
@@ -117,9 +117,10 @@
                 <button
                   class="btn-buy"
                   [disabled]="!canBuy(item) || purchasing() === item.item_id"
+                  [attr.aria-label]="purchasing() === item.item_id ? 'Achat en cours…' : null"
                   (click)="purchase(item)">
                   @if (purchasing() === item.item_id) {
-                    <span class="loading-dot"></span>
+                    <span class="loading-dot" aria-hidden="true"></span>
                   } @else if (!item.available) {
                     Indisponible
                   } @else if (userCoins() < item.price) {
@@ -154,16 +155,16 @@
 
       <!-- Pagination -->
       @if (totalPages() > 1) {
-        <div class="pagination container">
-          <button class="pagination-btn" [disabled]="!canGoPrev()" (click)="prevPage()">◀</button>
+        <nav class="pagination container" aria-label="Pagination">
+          <button class="pagination-btn" [disabled]="!canGoPrev()" (click)="prevPage()" aria-label="Page précédente">◀</button>
           <div class="pagination-pages">
             @for (p of pagesArray(); track p) {
-              <button class="pagination-page" [class.pagination-page--active]="page() === p" (click)="goToPage(p)">{{ p }}</button>
+              <button class="pagination-page" [class.pagination-page--active]="page() === p" [attr.aria-current]="page() === p ? 'page' : null" [attr.aria-label]="'Page ' + p" (click)="goToPage(p)">{{ p }}</button>
             }
           </div>
-          <button class="pagination-btn" [disabled]="!canGoNext()" (click)="nextPage()">▶</button>
-          <span class="pagination-info">{{ page() }}/{{ totalPages() }}</span>
-        </div>
+          <button class="pagination-btn" [disabled]="!canGoNext()" (click)="nextPage()" aria-label="Page suivante">▶</button>
+          <span class="pagination-info" aria-live="polite">{{ page() }}/{{ totalPages() }}</span>
+        </nav>
       }
     }
   }

--- a/web/frontend/src/app/features/stats/stats.component.html
+++ b/web/frontend/src/app/features/stats/stats.component.html
@@ -18,7 +18,7 @@
   <!-- Error -->
   @else if (hasError()) {
     <div class="stats-state stats-state--error container">
-      <span>⚠️</span>
+      <span aria-hidden="true">⚠️</span>
       <p>Impossible de charger les statistiques.</p>
       <button class="btn btn-primary btn--sm" (click)="load()">Réessayer</button>
     </div>
@@ -28,7 +28,7 @@
     <!-- Statistiques globales -->
     @if (globalStats(); as g) {
       <section class="stats-section container">
-        <h2 class="section-title">🌍 Statistiques globales</h2>
+        <h2 class="section-title"><span aria-hidden="true">🌍</span> Statistiques globales</h2>
         <div class="stats-grid">
           <app-stat-card icon="👥" label="Joueurs" [value]="fmt(g.total_users)" />
           <app-stat-card icon="🏙️" label="Villes" [value]="fmt(g.total_cities)" />
@@ -42,7 +42,7 @@
     <!-- Économie -->
     @if (economyStats(); as e) {
       <section class="stats-section container">
-        <h2 class="section-title">💰 Économie</h2>
+        <h2 class="section-title"><span aria-hidden="true">💰</span> Économie</h2>
         <div class="stats-grid stats-grid--4">
           <app-stat-card icon="📈" label="Moyenne par joueur" [value]="fmt(e.average_coins_per_user) + ' 🪙'" />
           <app-stat-card icon="👑" label="Record de richesse" [value]="fmt(e.richest_user_coins) + ' 🪙'" variant="gold" />

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -70,7 +70,8 @@
         class="mobile-toggle"
         [class.open]="isMobileMenuOpen()"
         (click)="toggleMobileMenu()"
-        aria-label="Ouvrir le menu"
+        [attr.aria-label]="isMobileMenuOpen() ? 'Fermer le menu' : 'Ouvrir le menu'"
+        [attr.aria-expanded]="isMobileMenuOpen()"
       >
         <span></span><span></span><span></span>
       </button>

--- a/web/frontend/src/app/shared/components/ui/stat-card/stat-card.component.ts
+++ b/web/frontend/src/app/shared/components/ui/stat-card/stat-card.component.ts
@@ -4,11 +4,11 @@ import { Component, ChangeDetectionStrategy, input } from '@angular/core';
   selector: 'app-stat-card',
   standalone: true,
   template: `
-    <div class="stat-card" [class]="'stat-card--' + variant()">
+    <div class="stat-card" [class]="'stat-card--' + variant()" role="group" [attr.aria-label]="value() + ' ' + label()">
       @if (icon()) {
         <span class="stat-card__icon" aria-hidden="true">{{ icon() }}</span>
       }
-      <div class="stat-card__body">
+      <div class="stat-card__body" aria-hidden="true">
         <span class="stat-card__value">{{ value() }}</span>
         <span class="stat-card__label">{{ label() }}</span>
       </div>

--- a/web/frontend/src/index.html
+++ b/web/frontend/src/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<html lang="en">
+<html lang="fr">
 <head>
   <meta charset="utf-8">
-  <title>Frontend</title>
+  <title>MazWorld</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; img-src 'self' cdn.discordapp.com; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com">
+        content="default-src 'self'; connect-src 'self' https://fonts.googleapis.com; img-src 'self' cdn.discordapp.com; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>

--- a/web/frontend/src/main.ts
+++ b/web/frontend/src/main.ts
@@ -11,17 +11,22 @@ bootstrapApplication(App, appConfig)
       const { default: axe } = await import('axe-core');
       const router = appRef.injector.get(Router);
 
-      const runAxe = () => setTimeout(() => {
-        axe.run().then(({ violations }) => {
-          if (!violations.length) return;
-          console.group(`%c♿ axe — ${violations.length} violation(s)`, 'color:#f87171;font-weight:bold');
-          violations.forEach(v => {
-            console.warn(`[${v.impact?.toUpperCase()}] ${v.description}`);
-            v.nodes.forEach(n => console.warn('  ↳', n.html));
+      let axeTimer: ReturnType<typeof setTimeout> | null = null;
+      const runAxe = () => {
+        if (axeTimer) clearTimeout(axeTimer);
+        axeTimer = setTimeout(() => {
+          axeTimer = null;
+          axe.run().then(({ violations }) => {
+            if (!violations.length) return;
+            console.group(`%c♿ axe — ${violations.length} violation(s)`, 'color:#f87171;font-weight:bold');
+            violations.forEach(v => {
+              console.warn(`[${v.impact?.toUpperCase()}] ${v.description}`);
+              v.nodes.forEach(n => console.warn('  ↳', n.html));
+            });
+            console.groupEnd();
           });
-          console.groupEnd();
-        });
-      }, 500);
+        }, 500);
+      };
 
       router.events.pipe(filter(e => e instanceof NavigationEnd)).subscribe(runAxe);
       runAxe();


### PR DESCRIPTION
## Résumé

- **WCAG 3.1.1** — `lang=\"fr\"` sur `<html>`, `<title>MazWorld</title>`
- **WCAG 1.1.1** — `stat-card` : `role=\"group\"` + `aria-label` composé valeur+libellé pour les lecteurs d'écran
- **WCAG 4.1.2** — `aria-label` sur tous les boutons icon-only (hamburger, fermer panneau, déséquiper, achat en cours) ; `aria-expanded` sur le hamburger
- **Pagination** — `<nav aria-label=\"Pagination\">`, `aria-current=\"page\"`, `aria-live=\"polite\"` dans shop et leaderboard
- **Emojis décoratifs** — `aria-hidden=\"true\"` sur tous les emojis non-porteurs d'information dans les 13 templates (features + header + stat-card)
- **CSP** — `connect-src 'self' https://fonts.googleapis.com` dans le meta CSP de `index.html` (nécessaire pour axe-core en dev)
- **axe-core** — debounce dans `main.ts` pour éviter l'erreur "Axe is already running"
- **LOCK_DSN** — documentation `flock` dans `.env.example` (Symfony Lock component)

## Fichiers modifiés

| Fichier | Changements |
|---|---|
| `index.html` | `lang`, `title`, CSP `connect-src` |
| `main.ts` | debounce axe-core |
| `stat-card.component.ts` | `role="group"`, `aria-label` |
| `header.component.html` | hamburger `aria-label`/`aria-expanded`, emojis dropdown |
| `map.component.html` | close-btn `aria-label`, emojis décoratifs |
| `shop.component.html` | btn-buy loading `aria-label`, pagination `<nav>`, emojis |
| `inventory.component.html` | slot-unequip `aria-label`, emojis états vides |
| `leaderboard.component.html` | pagination `<nav>`, emojis |
| `records`, `home`, `servers`, `commands`, `stats`, `dashboard` | emojis décoratifs `aria-hidden` |
| `.env.example` | `LOCK_DSN=flock` |

## Plan de test

- [ ] Lancer `ng serve` et vérifier la console : 0 violation axe-core `critical` ou `serious`
- [ ] Tester avec un lecteur d'écran (NVDA/VoiceOver) : les emojis décoratifs ne sont pas lus, les boutons icon-only ont un nom
- [ ] Vérifier que le bouton hamburger annonce "Ouvrir/Fermer le menu" et l'état `aria-expanded`
- [ ] Vérifier que la pagination annonce la page active (`aria-current="page"`) et les changements de page (`aria-live`)
- [ ] Vérifier que `stat-card` est annoncé comme groupe avec valeur+libellé (ex : "1 234 Joueurs")
- [ ] Confirmer que `LOCK_DSN=flock` est défini dans `.env` local (backend)