### PR TITLE
feat(accessibility): attributs ARIA sur composants dynamiques (SU #189)

### DIFF
--- a/web/frontend/src/app/features/leaderboard/leaderboard.component.html
+++ b/web/frontend/src/app/features/leaderboard/leaderboard.component.html
@@ -17,7 +17,7 @@
 
   <!-- Loading -->
   @if (isLoading()) {
-    <div class="leaderboard-state container">
+    <div class="leaderboard-state container" role="status">
       <div class="loading"></div>
       <p>Chargement du classement…</p>
     </div>
@@ -42,26 +42,29 @@
 
   @else {
     <!-- Table -->
-    <div class="leaderboard-table container">
-      <div class="table-head">
-        <span class="col-rank">Rang</span>
-        <span class="col-player">Joueur</span>
-        <span class="col-coins"><span aria-hidden="true">🪙</span> MazCoins</span>
-      </div>
-
-      @for (entry of entries(); track entry.discord_id) {
-        <div class="table-row" [class]="getRankClass(entry.rank)">
-          <span class="col-rank">
-            <span class="rank-badge">{{ getRankEmoji(entry.rank) }}</span>
-          </span>
-          <span class="col-player">
-            <img [src]="getAvatarUrl(entry)" [alt]="entry.username" class="player-avatar" width="40" height="40">
-            <span class="player-name">{{ entry.username }}</span>
-          </span>
-          <span class="col-coins">{{ entry.coins.toLocaleString() }}</span>
-        </div>
-      }
-    </div>
+    <table class="leaderboard-table container">
+      <thead>
+        <tr class="table-head">
+          <th scope="col" class="col-rank">Rang</th>
+          <th scope="col" class="col-player">Joueur</th>
+          <th scope="col" class="col-coins"><span aria-hidden="true">🪙</span> MazCoins</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (entry of entries(); track entry.discord_id) {
+          <tr class="table-row" [class]="getRankClass(entry.rank)">
+            <td class="col-rank">
+              <span class="rank-badge">{{ getRankEmoji(entry.rank) }}</span>
+            </td>
+            <td class="col-player">
+              <img [src]="getAvatarUrl(entry)" [alt]="entry.username" class="player-avatar" width="40" height="40">
+              <span class="player-name">{{ entry.username }}</span>
+            </td>
+            <td class="col-coins">{{ entry.coins.toLocaleString() }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
 
     <!-- Pagination -->
     @if (totalPages() > 1) {

--- a/web/frontend/src/app/features/leaderboard/leaderboard.component.scss
+++ b/web/frontend/src/app/features/leaderboard/leaderboard.component.scss
@@ -74,11 +74,15 @@
 
 /* ===== TABLE ===== */
 .leaderboard-table {
+  display: block;
+  width: 100%;
   background: linear-gradient(135deg, rgba(26, 26, 37, 0.7), rgba(20, 20, 30, 0.5));
   border: 1px solid rgba(255, 107, 53, 0.1);
   border-radius: var(--radius-lg);
   overflow: hidden;
   margin-bottom: var(--spacing-lg);
+
+  thead, tbody { display: block; }
 }
 
 .table-head {

--- a/web/frontend/src/app/features/map/map.component.html
+++ b/web/frontend/src/app/features/map/map.component.html
@@ -11,7 +11,7 @@
 
   <!-- Loading -->
   @if (isLoading()) {
-    <div class="map-state">
+    <div class="map-state" role="status">
       <div class="loading"></div>
       <p>Chargement de la carte…</p>
     </div>

--- a/web/frontend/src/app/features/shop/shop.component.html
+++ b/web/frontend/src/app/features/shop/shop.component.html
@@ -16,15 +16,15 @@
 
   <!-- Notification -->
   @if (notification(); as notif) {
-    <div class="notification container" [class.notification--success]="notif.type === 'success'" [class.notification--error]="notif.type === 'error'">
-      <span>{{ notif.type === 'success' ? '✅' : '❌' }}</span>
+    <div class="notification container" role="alert" aria-live="assertive" [class.notification--success]="notif.type === 'success'" [class.notification--error]="notif.type === 'error'">
+      <span aria-hidden="true">{{ notif.type === 'success' ? '✅' : '❌' }}</span>
       <span>{{ notif.message }}</span>
     </div>
   }
 
   <!-- Loading -->
   @if (isLoading()) {
-    <div class="shop-state">
+    <div class="shop-state" role="status">
       <div class="loading"></div>
       <p>Chargement de la boutique…</p>
     </div>

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -33,13 +33,13 @@
 
         <!-- User dropdown -->
         <div class="user-menu">
-          <button class="user-menu__trigger" (click)="toggleUserMenu()">
+          <button class="user-menu__trigger" (click)="toggleUserMenu()" aria-haspopup="menu" [attr.aria-expanded]="isUserMenuOpen()">
             <app-avatar [src]="auth.userAvatar()" [alt]="auth.displayName() ?? 'Avatar'" size="sm" />
             <span class="user-menu__name">{{ auth.displayName() }}</span>
             <span class="user-menu__chevron" [class.open]="isUserMenuOpen()" aria-hidden="true">▼</span>
           </button>
 
-          <div class="user-menu__dropdown" [class.open]="isUserMenuOpen()" role="menu">
+          <div class="user-menu__dropdown" [class.open]="isUserMenuOpen()" role="menu" [attr.aria-hidden]="!isUserMenuOpen() || null">
             <a routerLink="/profile"   class="user-menu__item" role="menuitem" (click)="closeUserMenu()">
               <span aria-hidden="true">👤</span> Mon profil
             </a>

--- a/web/frontend/src/app/shared/components/ui/empty-state/empty-state.component.ts
+++ b/web/frontend/src/app/shared/components/ui/empty-state/empty-state.component.ts
@@ -4,7 +4,7 @@ import { Component, ChangeDetectionStrategy, input } from '@angular/core';
   selector: 'app-empty-state',
   standalone: true,
   template: `
-    <div class="empty-state">
+    <div class="empty-state" aria-live="polite">
       @if (icon()) {
         <span class="empty-state__icon" aria-hidden="true">{{ icon() }}</span>
       }


### PR DESCRIPTION
## Résumé

- **Header** : `aria-haspopup=menu` + `[attr.aria-expanded]` sur le bouton trigger du dropdown utilisateur ; `[attr.aria-hidden]` conditionnel sur le menu (caché aux AT quand fermé)
- **Shop** : `role=alert` + `aria-live=assertive` sur la notification d achat ; `role=status` sur l état de chargement
- **Map** : `role=status` sur l état de chargement
- **EmptyState** : `aria-live=polite` sur le conteneur pour annoncer l apparition du contenu
- **Leaderboard** : conversion de la structure `div`/`span` en `<table>` sémantique avec `<thead>`, `<tbody>`, `<th scope=col>` et `<td>` ; `role=status` sur l état de chargement ; ajout de `display: block` dans le SCSS pour préserver le layout CSS grid

## Critères WCAG couverts

- 4.1.2 A — Nom, rôle, valeur (header dropdown)
- 4.1.3 AA — Messages de statut (shop notification, états de chargement)
- 1.3.1 A — Information et relations (leaderboard table sémantique)

## Test plan

- [ ] Ouvrir/fermer le dropdown utilisateur : vérifier `aria-expanded` passe à `true`/`false` dans le DOM
- [ ] Acheter un article : la notification doit être annoncée immédiatement par les AT (`role=alert`)
- [ ] Naviguer vers le leaderboard : vérifier que les AT lisent les en-têtes de colonnes
- [ ] Vérifier que le visuel du leaderboard est identique avant/après (layout CSS grid préservé)
- [ ] Lancer axe-core en dev : aucune violation nouvelle sur les pages concernées