### PR TITLE
feat(accessibility): navigation clavier et gestion du focus (SU #190)

### DIFF
--- a/docs/accessibility-audit.md
+++ b/docs/accessibility-audit.md
@@ -58,6 +58,15 @@ Par ailleurs, le RGAA ajoute 56 critères propres à la méthodologie française
 | `empty-state` | 4.1.3 AA | Améliorer | Contenu dynamique non annoncé | `aria-live="polite"` |
 | Leaderboard — tableau | 1.3.1 A | Améliorer | Structure div/span sans sémantique tabulaire | `<table>` avec `<th scope="col">` |
 
+### À vérifier (hors périmètre des SUs actuels)
+
+| Critère | Description | Statut |
+|---|---|---|
+| 1.4.3 AA | Contraste texte ≥ 4.5:1 (normal) / 3:1 (grand) | Non audité formellement — à vérifier avec un outil dédié (ex : Chrome DevTools > Accessibilité) |
+| 1.4.11 AA | Contraste composants UI (boutons, indicateur de focus) ≥ 3:1 | Non audité formellement |
+| 1.4.4 AA | Zoom 200 % sans perte de contenu | À tester manuellement |
+| 2.4.7 A | Indicateur de focus visible | `outline: none` remplacé par `box-shadow` — conformité à confirmer visuellement |
+
 ---
 
 ## Points conformes

--- a/web/frontend/src/app/app.ts
+++ b/web/frontend/src/app/app.ts
@@ -7,8 +7,11 @@ import { HeaderComponent } from './shared/components/header/header.component';
   standalone: true,
   imports: [RouterOutlet, HeaderComponent],
   template: `
+    <a class="skip-link" href="#main-content">Aller au contenu principal</a>
     <app-header />
-    <router-outlet />
+    <main id="main-content">
+      <router-outlet />
+    </main>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/web/frontend/src/app/features/map/map.component.html
+++ b/web/frontend/src/app/features/map/map.component.html
@@ -88,6 +88,9 @@
           @for (city of cities(); track city.city_id) {
             <div
               class="city"
+              role="button"
+              tabindex="0"
+              [attr.aria-label]="city.name"
               [class.city--current]="isCurrentCity(city.city_id)"
               [class.city--destination]="isDestination(city.city_id)"
               [class.city--reachable]="getRouteToCity(city.city_id) !== null && !isCurrentCity(city.city_id)"
@@ -95,7 +98,9 @@
               [class.city--near-bottom]="getCityPosition(city).y > 75"
               [style.left.%]="getCityPosition(city).x"
               [style.top.%]="getCityPosition(city).y"
-              (click)="selectCity(city)">
+              (click)="selectCity(city, $event)"
+              (keydown.enter)="selectCity(city, $event)"
+              (keydown.space)="$event.preventDefault(); selectCity(city, $event)">
 
               <div class="city-pulse"></div>
 
@@ -121,7 +126,7 @@
     </section>
 
     <!-- Panneau de détails -->
-    <aside class="details-panel" [class.open]="selectedCity()">
+    <aside class="details-panel" #detailsPanel [class.open]="selectedCity()" (keydown.escape)="closePanel()">
       @if (selectedCity(); as city) {
         <div class="panel-content">
           <button class="close-btn" (click)="closePanel()" aria-label="Fermer le panneau">✕</button>

--- a/web/frontend/src/app/features/map/map.component.ts
+++ b/web/frontend/src/app/features/map/map.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, signal, computed, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, OnDestroy, signal, computed, inject, ChangeDetectionStrategy, viewChild, ElementRef } from '@angular/core';
 import { forkJoin, interval, Subscription } from 'rxjs';
 import { TravelService } from '../../core/services/travel.service';
 import type { City, RouteData, TravelRoute, TravelMapData, TravelStatus, VisualRoute } from '../../core/models/travel.model';
@@ -27,6 +27,9 @@ export class MapComponent implements OnInit, OnDestroy {
   readonly allRoutes = signal<RouteData[]>([]);
   private travelMapData: TravelMapData | null = null;
   private travelStatus: TravelStatus | null = null;
+
+  private readonly panelRef = viewChild<ElementRef<HTMLElement>>('detailsPanel');
+  private lastFocusedCity: HTMLElement | null = null;
 
   readonly visualRoutes = computed<VisualRoute[]>(() => {
     return this.allRoutes()
@@ -136,12 +139,18 @@ export class MapComponent implements OnInit, OnDestroy {
     return colors[theme ?? ''] ?? 'rgba(255, 107, 53, 0.4)';
   }
 
-  selectCity(city: City): void {
+  selectCity(city: City, event?: Event): void {
+    this.lastFocusedCity = (event?.target as HTMLElement) ?? null;
     this.selectedCity.set(city);
+    setTimeout(() => {
+      const closeBtn = this.panelRef()?.nativeElement.querySelector<HTMLElement>('.close-btn');
+      closeBtn?.focus();
+    });
   }
 
   closePanel(): void {
     this.selectedCity.set(null);
+    setTimeout(() => this.lastFocusedCity?.focus());
   }
 
   startTravel(cityId: string): void {

--- a/web/frontend/src/app/shared/components/header/header.component.html
+++ b/web/frontend/src/app/shared/components/header/header.component.html
@@ -33,13 +33,13 @@
 
         <!-- User dropdown -->
         <div class="user-menu">
-          <button class="user-menu__trigger" (click)="toggleUserMenu()">
+          <button class="user-menu__trigger" #userMenuTrigger (click)="toggleUserMenu()" (keydown)="onUserMenuKeydown($event)">
             <app-avatar [src]="auth.userAvatar()" [alt]="auth.displayName() ?? 'Avatar'" size="sm" />
             <span class="user-menu__name">{{ auth.displayName() }}</span>
             <span class="user-menu__chevron" [class.open]="isUserMenuOpen()" aria-hidden="true">▼</span>
           </button>
 
-          <div class="user-menu__dropdown" [class.open]="isUserMenuOpen()" role="menu">
+          <div class="user-menu__dropdown" #userMenuDropdown [class.open]="isUserMenuOpen()" role="menu" (keydown)="onMenuKeydown($event)">
             <a routerLink="/profile"   class="user-menu__item" role="menuitem" (click)="closeUserMenu()">
               <span aria-hidden="true">👤</span> Mon profil
             </a>

--- a/web/frontend/src/app/shared/components/header/header.component.ts
+++ b/web/frontend/src/app/shared/components/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, inject, ChangeDetectionStrategy, signal, viewChild, ElementRef } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthService } from '../../../core/services/auth.service';
 import { SpinnerComponent } from '../ui/spinner/spinner.component';
@@ -18,6 +18,9 @@ export class HeaderComponent {
   readonly isMobileMenuOpen = signal(false);
   readonly isUserMenuOpen = signal(false);
 
+  private readonly triggerRef = viewChild<ElementRef<HTMLElement>>('userMenuTrigger');
+  private readonly dropdownRef = viewChild<ElementRef<HTMLElement>>('userMenuDropdown');
+
   login(): void { this.auth.loginWithDiscord().subscribe(); }
   logout(): void { this.closeUserMenu(); this.auth.logout(); }
 
@@ -26,4 +29,44 @@ export class HeaderComponent {
 
   toggleUserMenu(): void { this.isUserMenuOpen.update(v => !v); }
   closeUserMenu(): void { this.isUserMenuOpen.set(false); }
+
+  onUserMenuKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.closeUserMenu();
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.isUserMenuOpen.set(true);
+      setTimeout(() => this.getMenuItems()[0]?.focus());
+    }
+  }
+
+  onMenuKeydown(event: KeyboardEvent): void {
+    const items = this.getMenuItems();
+    const current = items.indexOf(document.activeElement as HTMLElement);
+
+    switch (event.key) {
+      case 'Escape':
+        event.preventDefault();
+        this.closeUserMenu();
+        this.triggerRef()?.nativeElement.focus();
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        items[(current + 1) % items.length]?.focus();
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        items[(current - 1 + items.length) % items.length]?.focus();
+        break;
+      case 'Tab':
+        this.closeUserMenu();
+        break;
+    }
+  }
+
+  private getMenuItems(): HTMLElement[] {
+    const menu = this.dropdownRef()?.nativeElement;
+    if (!menu) return [];
+    return Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+  }
 }

--- a/web/frontend/src/styles.scss
+++ b/web/frontend/src/styles.scss
@@ -72,6 +72,24 @@ body {
   overflow-x: hidden;
 }
 
+/* ===== SKIP LINK ===== */
+.skip-link {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 10000;
+  transform: translateY(calc(-100% - 1rem));
+  padding: 0.5rem 1.25rem;
+  background: var(--color-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  text-decoration: none;
+
+  &:focus { transform: translateY(0); }
+}
+
 /* ===== SCROLLBAR ===== */
 ::-webkit-scrollbar {
   width: 12px;


### PR DESCRIPTION
## Résumé

- **Skip link** : lien "Aller au contenu principal" visible au focus (Tab), `position: fixed` au-dessus du header, cible `<main id="main-content">`
- **Map — marqueurs villes** : `role="button"` + `tabindex="0"` + `keydown.enter/space` + `aria-label`
- **Map — panneau** : focus sur le bouton Fermer à l'ouverture ; retour sur la ville à la fermeture ; Echap ferme
- **Header dropdown** : ArrowDown ouvre et focus le premier item ; ArrowUp/Down naviguent ; Echap ferme et retourne le focus au trigger ; Tab ferme
- **Audit** : section "À vérifier" ajoutée pour les critères de contraste non encore audités (1.4.3, 1.4.11, 1.4.4, 2.4.7)

## Critères WCAG couverts

- 2.4.1 A — Ignorer des blocs (skip link)
- 2.1.1 A — Clavier (marqueurs carte, dropdown header)
- 2.4.3 A — Parcours du focus (panneau carte)
- 2.4.7 A — Visibilité du focus

## Test plan

- [ ] F6 puis Tab : le skip link orange apparaît en haut à gauche → Entrée saute au contenu principal
- [ ] Carte : Tab vers un marqueur → Entrée ouvre le panneau → focus sur Fermer → Echap ferme → focus retourné sur la ville
- [ ] Header : Tab vers le bouton avatar → ArrowDown ouvre le menu et focus le premier item → ArrowUp/Down naviguent → Echap ferme et retourne le focus sur le trigger
