### PR TITLE
fix(accessibility): correction ratios de contraste WCAG 1.4.3 (SU #215)

### DIFF
--- a/web/frontend/src/app/features/inventory/inventory.component.scss
+++ b/web/frontend/src/app/features/inventory/inventory.component.scss
@@ -339,7 +339,7 @@
 
 .item-status {
   font-size: 0.8rem;
-  color: var(--color-text-darker);
+  color: var(--color-text-dim);
 
   &--equipped {
     color: var(--color-accent);

--- a/web/frontend/src/app/features/shop/shop.component.scss
+++ b/web/frontend/src/app/features/shop/shop.component.scss
@@ -316,14 +316,14 @@
 .item-price {
   font-size: 0.9rem;
   font-weight: 600;
-  color: var(--color-text-darker);
+  color: var(--color-text-dim);
 
   &--affordable { color: var(--color-gold); }
 }
 
 .item-status {
   font-size: 0.8rem;
-  color: var(--color-text-darker);
+  color: var(--color-text-dim);
 
   &--equipped {
     color: var(--color-accent);
@@ -480,6 +480,6 @@
 
 .pagination-info {
   font-size: 0.8rem;
-  color: var(--color-text-darker);
+  color: var(--color-text-dim);
   margin-left: 0.25rem;
 }

--- a/web/frontend/src/styles.scss
+++ b/web/frontend/src/styles.scss
@@ -391,7 +391,7 @@ input, textarea, select {
   }
 
   &::placeholder {
-    color: var(--color-text-darker);
+    color: var(--color-text-dim);
   }
 }
 


### PR DESCRIPTION
## Contexte

Correction des ratios de contraste insuffisants identifiés lors de l'audit WCAG 2.1 AA (critère 1.4.3 — contraste texte minimum 4.5:1 pour du texte normal).

`--color-text-darker: #6a6a7a` produisait des ratios de 3.25:1 à 3.72:1 selon le fond, en dessous du minimum requis.

## Corrections

`--color-text-darker` → `--color-text-dim` (#a0a0b0, ratio ~7.7:1) sur 5 éléments informatifs :

| Fichier | Sélecteur | Avant | Après |
|---|---|---|---|
| `styles.scss` | `::placeholder` | 3.72:1 ❌ | 7.7:1 ✅ |
| `shop.component.scss` | `.item-price` | 3.72:1 ❌ | 7.7:1 ✅ |
| `shop.component.scss` | `.item-status` | 3.25:1 ❌ | 6.7:1 ✅ |
| `shop.component.scss` | `.pagination-info` | 3.25:1 ❌ | 6.7:1 ✅ |
| `inventory.component.scss` | `.item-status` | 3.25:1 ❌ | 6.7:1 ✅ |

Le `button:disabled` conserve `--color-text-darker` — les composants inactifs sont explicitement exemptés par WCAG 1.4.3.

## Test plan

- [ ] Shop : vérifier visuellement que les prix, statuts et pagination sont lisibles (légèrement plus clairs qu'avant)
- [ ] Inventory : vérifier le statut des items équipés/non équipés
- [ ] Inputs : vérifier le placeholder des champs de formulaire
- [ ] Chrome DevTools > Accessibilité : confirmer ratio ≥ 4.5:1 sur ces éléments
