### PR TITLE
feat(cd): workflow de release automatisée (Feature #99)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 1 : Création du tag Git et de la GitHub Release
+  # ─────────────────────────────────────────────────────────────────────────────
+  create-tag-and-release:
+    name: Create Tag & GitHub Release
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Read version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./web/frontend/package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version detected: $VERSION"
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        run: |
+          git tag -a "v${{ steps.version.outputs.version }}" \
+            -m "Release v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "Release v${{ steps.version.outputs.version }}" \
+            --generate-notes \
+            --latest


### PR DESCRIPTION
## Résumé

Workflow déclenché au merge d'une PR `release/*` → `main` :

1. Lit la version dans `web/frontend/package.json`
2. Crée et pousse le tag Git `vX.Y.Z`
3. Crée la GitHub Release avec notes auto-générées

## Plan de test

- [ ] Bumper la version dans `web/frontend/package.json`
- [ ] Créer une branche `release/X.Y.Z`, ouvrir une PR vers `main`, la merger
- [ ] Vérifier que le tag `vX.Y.Z` et la release apparaissent dans GitHub