### PR TITLE
feat(ci): couverture de code PHPUnit en artifact CI (SU #228)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           php-version: '8.2'
           tools: composer
-          coverage: none
+          coverage: pcov
 
       - name: Install dependencies
         working-directory: web/backend
@@ -107,9 +107,16 @@ jobs:
         working-directory: web/backend
         run: touch .env
 
-      - name: Run unit tests
+      - name: Run unit tests with coverage
         working-directory: web/backend
-        run: php bin/phpunit --group unit
+        run: php bin/phpunit --group unit --coverage-html coverage-reports/ci
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: web/backend/coverage-reports/ci
+          retention-days: 30
 
   backend-tests-integration:
     name: Backend Tests — Intégration (PHPUnit + MySQL)


### PR DESCRIPTION
## Résumé

- Remplacement de `coverage: none` par `coverage: pcov` dans le job `backend-tests-unit`
- Ajout de `--coverage-html coverage-reports/ci` à la commande PHPUnit
- Upload du rapport HTML via `actions/upload-artifact` (rétention 30 jours)

## Accès au rapport

Après chaque run CI : onglet **Summary** du workflow → section **Artifacts** → `coverage-report`.

## Lien

- SU de #95 — Pipeline CI/CD
- Closes #228