### PR TITLE
feat(ci): rapport de couverture TU+TI fusionné via phpcov (SU #228)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,14 +109,14 @@ jobs:
 
       - name: Run unit tests with coverage
         working-directory: web/backend
-        run: php bin/phpunit --group unit --coverage-html coverage-reports/ci
+        run: php bin/phpunit --group unit --coverage-php coverage-unit.cov
 
-      - name: Upload coverage report
+      - name: Upload coverage data (unit)
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
-          path: web/backend/coverage-reports/ci
-          retention-days: 30
+          name: coverage-unit
+          path: web/backend/coverage-unit.cov
+          retention-days: 1
 
   backend-tests-integration:
     name: Backend Tests — Intégration (PHPUnit + MySQL)
@@ -153,7 +153,7 @@ jobs:
           php-version: '8.2'
           tools: composer
           extensions: pdo_mysql
-          coverage: none
+          coverage: pcov
 
       - name: Install dependencies
         working-directory: web/backend
@@ -173,6 +173,57 @@ jobs:
           php bin/console doctrine:schema:create --env=test --no-interaction
           php bin/console doctrine:fixtures:load --env=test --no-interaction
 
-      - name: Run integration tests
+      - name: Run integration tests with coverage
         working-directory: web/backend
-        run: php bin/phpunit --group integration
+        run: php bin/phpunit --group integration --coverage-php coverage-integration.cov
+
+      - name: Upload coverage data (integration)
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-integration
+          path: web/backend/coverage-integration.cov
+          retention-days: 1
+
+  # ==================== COVERAGE REPORT ====================
+
+  coverage-report:
+    name: Coverage Report (TU + TI fusionnés)
+    runs-on: ubuntu-latest
+    needs: [backend-tests-unit, backend-tests-integration]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+          coverage: pcov
+
+      - name: Install dependencies
+        working-directory: web/backend
+        run: composer install --no-interaction --prefer-dist --no-scripts
+
+      - name: Download unit coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-unit
+          path: web/backend/coverage-cov
+
+      - name: Download integration coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-integration
+          path: web/backend/coverage-cov
+
+      - name: Merge and generate HTML report
+        working-directory: web/backend
+        run: php vendor/bin/phpcov merge --html coverage-reports/ci coverage-cov/
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: web/backend/coverage-reports/ci
+          retention-days: 30

--- a/web/backend/composer.json
+++ b/web/backend/composer.json
@@ -89,6 +89,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.6",
         "friendsofphp/php-cs-fixer": "^3.66",
+        "phpunit/phpcov": "^10.0",
         "phpunit/phpunit": "^11.5",
         "symfony/browser-kit": "7.0.*",
         "symfony/css-selector": "7.0.*",

--- a/web/backend/symfony.lock
+++ b/web/backend/symfony.lock
@@ -61,6 +61,18 @@
             "./migrations/.gitignore"
         ]
     },
+    "friendsofphp/php-cs-fixer": {
+        "version": "3.66",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.39",
+            "ref": "97aaf9026490db73b86c23d49e5774bc89d2b232"
+        },
+        "files": [
+            "./.php-cs-fixer.dist.php"
+        ]
+    },
     "lexik/jwt-authentication-bundle": {
         "version": "3.2",
         "recipe": {


### PR DESCRIPTION
## Résumé

Suite de la PR #229 — approche fusionnée TU + TI via `phpcov merge`.

- `backend-tests-unit` : génère `coverage-unit.cov` (format sérialisé PHPUnit)
- `backend-tests-integration` : génère `coverage-integration.cov`
- Nouveau job `coverage-report` (`needs` les deux) : fusionne via `phpcov merge`, upload HTML 30 jours

## Dépendance ajoutée

`phpunit/phpcov ^10.0` (dev)

## Closes

- #228