### PR TITLE
feat(ci): couverture PCOV fusionnée TU+TI, artifact HTML 30j (Feature #228)

### DIFF
--- a/.github/workflows/branch-strategy.yml
+++ b/.github/workflows/branch-strategy.yml
@@ -1,0 +1,67 @@
+name: Branch Strategy Validation
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - develop
+      - main
+      - 'release/**'
+      - 'feature/**'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-branch-strategy:
+    name: Validate Branch Strategy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch naming rules
+        run: |
+          SOURCE="${{ github.head_ref }}"
+          TARGET="${{ github.base_ref }}"
+
+          echo "Source branch : $SOURCE"
+          echo "Target branch : $TARGET"
+
+          # feature/SU/* -> feature/* (pas feature/SU/*)
+          if [[ "$TARGET" == feature/* && "$TARGET" != feature/SU/* ]]; then
+            if [[ ! "$SOURCE" == feature/SU/* ]]; then
+              echo "ERROR: Only branches starting with 'feature/SU/' can be merged into 'feature/*'."
+              echo "       Current source branch: $SOURCE"
+              exit 1
+            fi
+            echo "OK: feature/SU/* -> feature/*"
+
+          # feature/* -> develop  (ou main -> develop pour sync)
+          elif [[ "$TARGET" == "develop" ]]; then
+            if [[ ! "$SOURCE" == feature/* && "$SOURCE" != "main" ]]; then
+              echo "ERROR: Only branches starting with 'feature/' or 'main' can be merged into 'develop'."
+              echo "       Current source branch: $SOURCE"
+              exit 1
+            fi
+            if [[ "$SOURCE" == feature/* ]]; then
+              echo "OK: feature/* -> develop"
+            elif [[ "$SOURCE" == "main" ]]; then
+              echo "OK: main -> develop (sync)"
+            fi
+
+          # release/* -> main
+          elif [[ "$TARGET" == "main" ]]; then
+            if [[ ! "$SOURCE" == release/* ]]; then
+              echo "ERROR: Only branches starting with 'release/' can be merged into 'main'."
+              echo "       Current source branch: $SOURCE"
+              exit 1
+            fi
+            echo "OK: release/* -> main"
+
+          # develop ou hotfix/* -> release/*
+          elif [[ "$TARGET" == release/* ]]; then
+            if [[ "$SOURCE" != "develop" && ! "$SOURCE" == hotfix/* ]]; then
+              echo "ERROR: Only 'develop' or branches starting with 'hotfix/' can be merged into 'release/*'."
+              echo "       Current source branch: $SOURCE"
+              exit 1
+            fi
+            echo "OK: develop/hotfix/* -> release/*"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,10 @@ jobs:
         working-directory: web/backend
         run: composer install --no-interaction --prefer-dist --no-scripts
 
+      - name: Create .env placeholder
+        working-directory: web/backend
+        run: touch .env
+
       - name: Run unit tests
         working-directory: web/backend
         run: php bin/phpunit --group unit
@@ -142,6 +146,10 @@ jobs:
       - name: Install dependencies
         working-directory: web/backend
         run: composer install --no-interaction --prefer-dist --no-scripts
+
+      - name: Create .env placeholder
+        working-directory: web/backend
+        run: touch .env
 
       - name: Generate JWT keypair
         working-directory: web/backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           php-version: '8.2'
           tools: composer
-          coverage: none
+          coverage: pcov
 
       - name: Install dependencies
         working-directory: web/backend
@@ -107,9 +107,16 @@ jobs:
         working-directory: web/backend
         run: touch .env
 
-      - name: Run unit tests
+      - name: Run unit tests with coverage
         working-directory: web/backend
-        run: php bin/phpunit --group unit
+        run: php bin/phpunit --group unit --coverage-html coverage-reports/ci
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: web/backend/coverage-reports/ci
+          retention-days: 30
 
   backend-tests-integration:
     name: Backend Tests — Intégration (PHPUnit + MySQL)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,11 @@ jobs:
       APP_ENV: test
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE }}
+      DISCORD_CLIENT_ID: ${{ secrets.DISCORD_CLIENT_ID }}
+      DISCORD_CLIENT_SECRET: ${{ secrets.DISCORD_CLIENT_SECRET }}
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+      BOT_API_SECRET: ${{ secrets.BOT_API_SECRET }}
+      APP_ENCRYPTION_KEY: ${{ secrets.APP_ENCRYPTION_KEY }}
     services:
       mysql:
         image: mysql:8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
   backend-lint:
     name: Backend Linting (PHP CS Fixer)
     runs-on: ubuntu-latest
+    env:
+      APP_ENV: test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -51,7 +53,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: web/backend
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader --no-scripts
 
       - name: Run PHP CS Fixer
         working-directory: web/backend
@@ -84,6 +86,8 @@ jobs:
   backend-tests-unit:
     name: Backend Tests — Unitaires (PHPUnit)
     runs-on: ubuntu-latest
+    env:
+      APP_ENV: test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -97,7 +101,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: web/backend
-        run: composer install --no-interaction --prefer-dist
+        run: composer install --no-interaction --prefer-dist --no-scripts
 
       - name: Run unit tests
         working-directory: web/backend
@@ -106,6 +110,10 @@ jobs:
   backend-tests-integration:
     name: Backend Tests — Intégration (PHPUnit + MySQL)
     runs-on: ubuntu-latest
+    env:
+      APP_ENV: test
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE }}
     services:
       mysql:
         image: mysql:8.0
@@ -133,26 +141,18 @@ jobs:
 
       - name: Install dependencies
         working-directory: web/backend
-        run: composer install --no-interaction --prefer-dist
+        run: composer install --no-interaction --prefer-dist --no-scripts
 
       - name: Generate JWT keypair
         working-directory: web/backend
-        env:
-          JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE }}
         run: php bin/console lexik:jwt:generate-keypair --skip-if-exists
 
       - name: Create test schema and load fixtures
         working-directory: web/backend
-        env:
-          DATABASE_URL: mysql://root@127.0.0.1:3307/mazworld
-          JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE }}
         run: |
           php bin/console doctrine:schema:create --env=test --no-interaction
           php bin/console doctrine:fixtures:load --env=test --no-interaction
 
       - name: Run integration tests
         working-directory: web/backend
-        env:
-          DATABASE_URL: mysql://root@127.0.0.1:3307/mazworld
-          JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE }}
         run: php bin/phpunit --group integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,158 @@
+name: CI - Tests & Linting
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - develop
+      - main
+      - 'release/**'
+
+permissions:
+  contents: read
+
+jobs:
+  # ==================== LINTING JOBS ====================
+
+  frontend-lint:
+    name: Frontend Linting (ESLint Angular)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web/frontend
+        run: npm ci
+
+      - name: Run ESLint
+        working-directory: web/frontend
+        run: npm run lint
+
+  backend-lint:
+    name: Backend Linting (PHP CS Fixer)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Install dependencies
+        working-directory: web/backend
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Run PHP CS Fixer
+        working-directory: web/backend
+        run: composer lint
+
+  # ==================== TESTS JOBS ====================
+
+  frontend-tests:
+    name: Frontend Tests (Vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web/frontend
+        run: npm ci
+
+      - name: Run tests
+        working-directory: web/frontend
+        run: npx ng test --no-watch
+
+  backend-tests-unit:
+    name: Backend Tests — Unitaires (PHPUnit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+          coverage: none
+
+      - name: Install dependencies
+        working-directory: web/backend
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run unit tests
+        working-directory: web/backend
+        run: php bin/phpunit --group unit
+
+  backend-tests-integration:
+    name: Backend Tests — Intégration (PHPUnit + MySQL)
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: mazworld_test
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+          extensions: pdo_mysql
+          coverage: none
+
+      - name: Install dependencies
+        working-directory: web/backend
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Generate JWT keypair
+        working-directory: web/backend
+        env:
+          JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE }}
+        run: php bin/console lexik:jwt:generate-keypair --skip-if-exists
+
+      - name: Create test schema and load fixtures
+        working-directory: web/backend
+        env:
+          DATABASE_URL: mysql://root@127.0.0.1:3307/mazworld
+          JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE }}
+        run: |
+          php bin/console doctrine:schema:create --env=test --no-interaction
+          php bin/console doctrine:fixtures:load --env=test --no-interaction
+
+      - name: Run integration tests
+        working-directory: web/backend
+        env:
+          DATABASE_URL: mysql://root@127.0.0.1:3307/mazworld
+          JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE }}
+        run: php bin/phpunit --group integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,14 +109,14 @@ jobs:
 
       - name: Run unit tests with coverage
         working-directory: web/backend
-        run: php bin/phpunit --group unit --coverage-html coverage-reports/ci
+        run: php bin/phpunit --group unit --coverage-php coverage-unit.cov
 
-      - name: Upload coverage report
+      - name: Upload coverage data (unit)
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
-          path: web/backend/coverage-reports/ci
-          retention-days: 30
+          name: coverage-unit
+          path: web/backend/coverage-unit.cov
+          retention-days: 1
 
   backend-tests-integration:
     name: Backend Tests — Intégration (PHPUnit + MySQL)
@@ -153,7 +153,7 @@ jobs:
           php-version: '8.2'
           tools: composer
           extensions: pdo_mysql
-          coverage: none
+          coverage: pcov
 
       - name: Install dependencies
         working-directory: web/backend
@@ -173,6 +173,57 @@ jobs:
           php bin/console doctrine:schema:create --env=test --no-interaction
           php bin/console doctrine:fixtures:load --env=test --no-interaction
 
-      - name: Run integration tests
+      - name: Run integration tests with coverage
         working-directory: web/backend
-        run: php bin/phpunit --group integration
+        run: php bin/phpunit --group integration --coverage-php coverage-integration.cov
+
+      - name: Upload coverage data (integration)
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-integration
+          path: web/backend/coverage-integration.cov
+          retention-days: 1
+
+  # ==================== COVERAGE REPORT ====================
+
+  coverage-report:
+    name: Coverage Report (TU + TI fusionnés)
+    runs-on: ubuntu-latest
+    needs: [backend-tests-unit, backend-tests-integration]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+          coverage: pcov
+
+      - name: Install dependencies
+        working-directory: web/backend
+        run: composer install --no-interaction --prefer-dist --no-scripts
+
+      - name: Download unit coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-unit
+          path: web/backend/coverage-cov
+
+      - name: Download integration coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-integration
+          path: web/backend/coverage-cov
+
+      - name: Merge and generate HTML report
+        working-directory: web/backend
+        run: php vendor/bin/phpcov merge --html coverage-reports/ci coverage-cov/
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: web/backend/coverage-reports/ci
+          retention-days: 30

--- a/web/backend/.env.test
+++ b/web/backend/.env.test
@@ -3,3 +3,7 @@ KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
+DEFAULT_URI=http://localhost
+DISCORD_REDIRECT_URI=http://localhost:4200/auth/callback
+CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
+LOCK_DSN=flock

--- a/web/backend/.env.test
+++ b/web/backend/.env.test
@@ -1,3 +1,5 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
+JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
+JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem

--- a/web/backend/composer.json
+++ b/web/backend/composer.json
@@ -89,6 +89,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.6",
         "friendsofphp/php-cs-fixer": "^3.66",
+        "phpunit/phpcov": "^10.0",
         "phpunit/phpunit": "^11.5",
         "symfony/browser-kit": "7.0.*",
         "symfony/css-selector": "7.0.*",

--- a/web/backend/composer.lock
+++ b/web/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c994afd157aef9ba6e41a4f70183210",
+    "content-hash": "b6f77427be1bcdd2e749c0139e2444e0",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -9106,6 +9106,68 @@
                 }
             ],
             "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpcov",
+            "version": "10.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpcov.git",
+                "reference": "a6029f35b6aa4934f3acfe520e60aa7a0285e845"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpcov/zipball/a6029f35b6aa4934f3acfe520e60aa7a0285e845",
+                "reference": "a6029f35b6aa4934f3acfe520e60aa7a0285e845",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.8",
+                "phpunit/php-file-iterator": "^5.1",
+                "phpunit/phpunit": "^11.5.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/version": "^5.0.2"
+            },
+            "bin": [
+                "phpcov"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "CLI frontend for php-code-coverage",
+            "homepage": "https://github.com/sebastianbergmann/phpcov",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpcov/issues",
+                "source": "https://github.com/sebastianbergmann/phpcov/tree/10.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-20T09:43:28+00:00"
         },
         {
             "name": "phpunit/phpunit",

--- a/web/backend/symfony.lock
+++ b/web/backend/symfony.lock
@@ -61,6 +61,18 @@
             "./migrations/.gitignore"
         ]
     },
+    "friendsofphp/php-cs-fixer": {
+        "version": "3.66",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.39",
+            "ref": "97aaf9026490db73b86c23d49e5774bc89d2b232"
+        },
+        "files": [
+            "./.php-cs-fixer.dist.php"
+        ]
+    },
     "lexik/jwt-authentication-bundle": {
         "version": "3.2",
         "recipe": {


### PR DESCRIPTION
## Résumé

Suite de la PR #227 (Feature #95/#98) : ajout de la couverture de code sur les jobs CI backend.

- Couverture PCOV sur `backend-tests-unit` et `backend-tests-integration`
- Fusion des rapports TU+TI via `phpcov merge --html`
- Artifact `coverage-report` conservé 30 jours
- `composer.lock` mis à jour (ajout `phpunit/phpcov`)

## Commits inclus

- e1e76bc feat(ci): couverture de code PHPUnit via PCOV, rapport HTML en artifact 30j (Feature #228)
- 659a7f4 feat(ci): rapport de couverture TU+TI fusionné via phpcov, artifact HTML 30j (Feature #228)
- 5f98e6c fix(ci): commit composer.lock avec phpunit/phpcov (Feature #228)