### PR TITLE
docs(rncp): protocole de déploiement VPS et mise à jour C2.1.1 (Feature #101)

### DIFF
--- a/docs/C2.1.1-environnement-deploiement.md
+++ b/docs/C2.1.1-environnement-deploiement.md
@@ -1,0 +1,194 @@
+# Environnement de déploiement et de développement — MazWorld
+
+Ce document centralise le protocole de déploiement continu ainsi que les critères de qualité et de performance mis en œuvre sur le projet MazWorld (compétence RNCP **C2.1.1**). Il couvre l'environnement de développement local, la gestion de sources, l'intégration continue (CI), le déploiement continu (CD) et les outils de suivi qualité/performance.
+
+---
+
+## 1. Environnement de développement
+
+### Éditeur et outils locaux
+
+Le développement se fait sous **VS Code**, avec les extensions dédiées à chaque stack :
+- **Angular Language Service** (`angular.ng-template`), recommandée via `web/frontend/.vscode/extensions.json` — autocomplétion et diagnostics dans les templates Angular.
+- **PHP Intelephense**, pour l'autocomplétion, la navigation et la détection d'erreurs sur le code Symfony (dont la reconnaissance des mocks PHPUnit via les annotations `@var Interface&MockObject`, documentée dans `docs/TESTING.md`).
+
+### Langages, interpréteurs et compilation
+
+| Composant | Rôle | Détail |
+|---|---|---|
+| **PHP 8.2** | Interpréteur backend | Exécuté via **PHP-FPM** (image `php:8.2-fpm-alpine`). Pas de compilation classique : bytecode mis en cache par **OPcache** en production pour limiter la recompilation à chaque requête. |
+| **esbuild** (`@angular/build:application`) | Compilateur frontend | Transpile TypeScript → JavaScript et bundle l'application Angular. Remplace l'ancien builder Webpack (`@angular-devkit/build-angular`), plus rapide en développement (`ng serve`) comme en production (`ng build`). |
+| **tsc** | Compilateur du bot Discord | Compile le TypeScript du bot (`bot/src`) vers `bot/dist` (`npm run build`). |
+
+### Environnement de développement conteneurisé
+
+Le développement local repose désormais entièrement sur **Docker Compose** (`docker compose up`), avec le même outillage et la même topologie de services qu'en production — seule la configuration diffère (voir §4). Ce choix élimine les divergences d'environnement entre postes de développement et supprime le besoin d'installer PHP, Node ou MySQL nativement sur la machine.
+
+```bash
+docker compose up -d
+```
+
+fusionne automatiquement `docker-compose.yml` (topologie commune) et `docker-compose.override.yaml` (surcouche de développement), et démarre :
+- **`nginx`** (reverse proxy, `http://localhost:8080`) ;
+- **`backend`** (PHP-FPM, code monté en direct depuis `web/backend/` — modification du code appliquée immédiatement, sans rebuild d'image) ;
+- **`frontend`** (`ng serve --host 0.0.0.0`, rechargement à chaud) ;
+- **`mysql`** (MySQL 8, exposé sur `localhost:3307`) ;
+- **`bot`** (`nodemon` + `ts-node`, rechargement à chaud sur modification de `bot/src`).
+
+Au démarrage, le conteneur `backend` exécute automatiquement (`web/backend/docker/entrypoint.sh`) : génération des clés JWT si absentes, attente de la disponibilité de MySQL, migrations Doctrine, puis — en développement uniquement, et une seule fois grâce à un fichier marqueur — chargement des fixtures de démonstration (villes, boutique).
+
+### Gestion des dépendances
+
+- **Composer** pour le backend PHP (`web/backend/composer.json` / `composer.lock`).
+- **npm** pour le frontend Angular (`web/frontend/package.json` / `package-lock.json`) et pour le bot Discord (`bot/package.json` / `package-lock.json`).
+
+---
+
+## 2. Gestion de sources et stratégie de branches
+
+Le code source est versionné avec **Git**, hébergé sur **GitHub** (`Mazlai/MazWorld`). Le projet suit un modèle inspiré de Gitflow, à quatre niveaux :
+
+```
+feature/SU/xx  →  feature/xx  →  develop  →  release/x.y.z  →  main
+  (sous-tâche)      (fonctionnalité)   (intégration continue)  (stabilisation)   (production)
+```
+
+La Dockerisation illustre concrètement ce découpage : la Feature **#96 « Déploiement continu (CD) »** (branche `feature/96-cd`) a été livrée par deux sous-tâches (SU) indépendantes mais couplées — **#107 « Dockerisation de la stack »** et **#108 « Configuration Docker Compose »**, développées ensemble sur `feature/SU/108-configuration-docker-compose` (PR #233, testée de bout en bout avant merge) — puis intégrée à `develop` via PR #232.
+
+Cette stratégie est **validée automatiquement** par le workflow `.github/workflows/branch-strategy.yml` (job `validate-branch-strategy`) : à chaque ouverture/mise à jour de pull request, un script vérifie que la branche source et la branche cible respectent la convention (ex. une PR `feature/SU/*` ne peut cibler qu'une branche `feature/*`, une PR `release/*` ne peut cibler que `main`). Toute violation fait échouer le job avec un message explicite.
+
+La gouvernance du dépôt est renforcée par deux **rulesets GitHub** :
+
+| Ruleset | Règles |
+|---|---|
+| `protect-main` | Suppression bloquée, force-push bloqué, pull request obligatoire pour merger |
+| `protect-develop` | Suppression bloquée |
+
+---
+
+## 3. Intégration continue (CI)
+
+Le pipeline CI (`.github/workflows/ci.yml`, nom *CI - Tests & Linting*) se déclenche à l'ouverture, la réouverture ou la mise à jour d'une pull request ciblant `develop`, `main`, `release/**` ou **`feature/**`** (étendu à ce dernier cas lors de la Dockerisation, pour que les PR des sous-tâches — ex. `feature/SU/108-...` → `feature/96-cd` — bénéficient elles aussi de la CI). Il exécute sept jobs :
+
+| Ordre | Job | Rôle | Outils |
+|---|---|---|---|
+| 1 | `frontend-lint` | Analyse statique du code Angular | ESLint (`npm run lint`) |
+| 2 | `backend-lint` | Analyse de style du code PHP | PHP-CS-Fixer en mode `--dry-run` (`composer lint`) |
+| 3 | `frontend-tests` | Tests unitaires Angular | Vitest (`npx ng test --no-watch`) |
+| 4 | `backend-tests-unit` | Tests unitaires PHP (sans base de données) | PHPUnit `--group unit`, couverture PCOV → artifact `coverage-unit.cov` |
+| 5 | `backend-tests-integration` | Tests d'intégration PHP (HTTP + SQL réel) | PHPUnit `--group integration`, service `mysql:8.0` éphémère, couverture PCOV → artifact `coverage-integration.cov` |
+| 6 | `coverage-report` | Fusion de la couverture TU + TI | `phpcov merge --html` → rapport HTML, artifact conservé 30 jours |
+| 7 | `docker-build` | Sanity-check des images Docker | `docker/build-push-action`, build des 3 images (backend, frontend, bot) sans publication, avec cache GitHub Actions |
+
+Le driver de couverture retenu est **PCOV** plutôt que Xdebug, choisi spécifiquement pour sa rapidité et donc un retour CI plus court. Les secrets nécessaires aux tests d'intégration (`DATABASE_URL`, `JWT_PASSPHRASE`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_BOT_TOKEN`, `BOT_API_SECRET`, `APP_ENCRYPTION_KEY`) sont injectés via **GitHub Secrets** (`${{ secrets.* }}`), jamais en clair dans le YAML.
+
+> **Preuve de valeur ajoutée** : le job `docker-build` a immédiatement révélé un bug préexistant, invisible jusque-là — `ng build` en configuration de production échouait silencieusement (deux feuilles de style dépassaient le budget d'erreur fixé dans `angular.json`), car aucun job CI ne construisait réellement l'application en mode production avant son introduction. Corrigé le jour même (cf. §5).
+
+> **Limite assumée** : les rulesets `protect-main`/`protect-develop` ne déclarent actuellement aucun *required status check* — la CI s'exécute et rapporte un statut sur chaque PR, mais ne bloque pas techniquement le merge en cas d'échec. Rendre les jobs `ci.yml` obligatoires dans les rulesets est identifié comme axe d'amélioration immédiat.
+
+---
+
+## 4. Déploiement continu (CD)
+
+### Publication de version
+
+Le workflow `.github/workflows/release.yml` (job `create-tag-and-release`) automatise le versionnement : il se déclenche à la fermeture d'une pull request vers `main`, et ne s'exécute que si la PR a été **mergée** et que sa branche source commence par `release/`. Il lit alors la version dans `web/frontend/package.json`, crée et pousse un tag Git `vX.Y.Z`, puis publie une **GitHub Release** avec notes générées automatiquement (`gh release create --generate-notes --latest`).
+
+### Architecture conteneurisée
+
+Toute la stack applicative est dockerisée (Dockerfiles multi-stage, un par service), orchestrée par Docker Compose avec **la même topologie en développement et en production** — seule la configuration change, via un fichier de surcouche dédié à chaque contexte :
+
+| Fichier | Rôle | Chargement |
+|---|---|---|
+| `docker-compose.yml` | Topologie commune (services, volumes, dépendances) | Toujours |
+| `docker-compose.override.yaml` | Développement : bind-mounts (hot-reload), `ng serve`, `nodemon`, port MySQL exposé | Automatique (`docker compose up`) |
+| `docker-compose.prod.yaml` | Production : certificats TLS, secrets par service, `restart: unless-stopped` | Explicite (`-f docker-compose.prod.yaml`) |
+
+| Service | Rôle | Image de base | Actif en prod | Actif en dev |
+|---|---|---|---|---|
+| `nginx` | Reverse proxy, TLS, sert le build Angular | `nginx:1.27-alpine` | ✅ | ✅ (proxifie vers `frontend` au lieu de fichiers statiques) |
+| `backend` | API Symfony (PHP-FPM) | `php:8.2-fpm-alpine` | ✅ | ✅ (code monté en direct) |
+| `mysql` | Base de données | `mysql:8.0` | ✅ | ✅ |
+| `bot` | Bot Discord | `node:22-bookworm-slim` | ✅ | ✅ (`nodemon`) |
+| `frontend-build` | Build Angular de production (one-shot) | `node:22-alpine` | ✅ (`--profile prod`) | ❌ |
+| `frontend` | Serveur de développement Angular | `node:22` | ❌ | ✅ |
+
+Chaque `Dockerfile` est **multi-stage** pour produire des images de production minimales : le backend sépare l'installation Composer (`stage vendor`) de l'exécution PHP-FPM, le frontend sépare le build Node du service statique nginx, le bot sépare la compilation TypeScript (`node:22-bookworm`, avec les bibliothèques nécessaires à `canvas`) de l'exécution (`node:22-bookworm-slim`, allégée).
+
+### Séquence de déploiement
+
+```bash
+# 1. Récupération de la version taguée
+git fetch --tags && git checkout vX.Y.Z
+
+# 2. Build de la version statique du frontend (one-shot)
+docker compose -f docker-compose.yml -f docker-compose.prod.yaml --profile prod run --rm frontend-build
+
+# 3. Démarrage / mise à jour de la stack
+docker compose -f docker-compose.yml -f docker-compose.prod.yaml up -d
+```
+
+Au démarrage du conteneur `backend`, `entrypoint.sh` génère les clés JWT si absentes (persistées dans un volume nommé `jwt_keys`, donc conservées d'un déploiement à l'autre), exécute les migrations Doctrine, puis réchauffe le cache Symfony — aucune intervention manuelle supplémentaire n'est nécessaire.
+
+**Rollback** : `git checkout <tag précédent>` puis ré-exécution de la même séquence ; restauration d'une sauvegarde MySQL (volume nommé `mysql_data`) en cas de migration de schéma non rétro-compatible.
+
+### Secrets — principe de moindre privilège
+
+Chaque service ne reçoit que ses propres identifiants, via un fichier `env_file` dédié :
+
+| Fichier | Service | Contenu |
+|---|---|---|
+| `.env.prod` (racine) | `mysql` | Identifiants MySQL uniquement |
+| `web/backend/.env.prod` | `backend` | Secrets applicatifs (JWT, chiffrement, OAuth Discord, base de données) |
+| `bot/.env.prod` | `bot` | Token Discord, secret d'API partagé |
+
+Ce découpage n'était pas la conception initiale : une première version utilisait un unique fichier `.env.prod` partagé par les trois services, ce qui exposait chaque conteneur à des secrets qui ne le concernaient pas — le conteneur du bot, par exemple, aurait reçu le mot de passe root MySQL et la clé de chiffrement du backend, sans jamais s'en servir. Repéré et corrigé avant le merge de la PR : si un conteneur applicatif est compromis (le bot dépend de bibliothèques tierces, dont certaines signalées vulnérables par `npm audit`), l'attaquant n'accède qu'aux secrets réellement nécessaires à ce service, pas à l'ensemble du système.
+
+Aucun de ces fichiers `.env.prod` n'est commité (gitignorés à tous les niveaux) ; chacun est créé sur le serveur à partir du `.env.example` correspondant.
+
+### Choix d'hébergement : VPS OVHcloud
+
+Le projet est destiné à être hébergé sur un **VPS OVHcloud**, choix motivé par deux critères adaptés aux exigences du projet :
+- **Souveraineté des données** : hébergement en France/UE, sous droit européen, cohérent avec les traitements de données personnelles Discord (OAuth, emails chiffrés — cf. `TokenEncryptorService`).
+- **Sobriété énergétique** : OVHcloud opère ses datacenters avec un refroidissement par eau plutôt que par climatisation active, réduisant l'empreinte énergétique de l'hébergement — un critère de performance étendu à la dimension écoresponsable du projet.
+
+Le durcissement prévu à la mise en service : utilisateur non-root dédié, connexion SSH par clé uniquement, pare-feu (`ufw`) limité aux ports 22/80/443, certificat TLS via Certbot exécuté sur l'hôte (hors conteneurs, renouvellement par cron), monté en lecture seule dans `nginx`.
+
+> **Limite assumée et justifiée** : le déclenchement du déploiement sur le VPS n'est pas automatisé depuis `release.yml` (pas de step SSH). Ce choix est délibéré, pas seulement budgétaire : sans serveur réel à cibler, un tel step ne pourrait pas être testé, et de l'automatisation non vérifiée est un risque plus qu'un bénéfice — elle échouerait silencieusement le jour de son activation. La séquence de déploiement ci-dessus a en revanche été **démontrée de bout en bout en local**, avec les commandes Docker Compose strictement identiques à celles qui s'exécuteront sur le VPS : nginx sert le frontend et route l'API (HTTP 200), MySQL répond, 142 tests unitaires passent dans le conteneur backend, et le bot se connecte réellement à Discord. L'ajout du step SSH dans `release.yml` (avec les commandes ci-dessus) est l'axe d'amélioration immédiat une fois le VPS provisionné et ses secrets (`VPS_HOST`, `VPS_SSH_KEY`) ajoutés aux secrets GitHub du dépôt.
+
+---
+
+## 5. Critères de qualité
+
+| Outil | Périmètre | Déclenchement |
+|---|---|---|
+| **PHP-CS-Fixer** (`web/backend/.php-cs-fixer.php`) | Style du code PHP : `@Symfony` + `@PSR12`, imports triés et nettoyés, syntaxe de tableau courte, virgules finales sur les tableaux multilignes | `composer lint` (CI, mode `--dry-run`) / `composer lint:fix` (local) |
+| **ESLint** (`web/frontend/eslint.config.js`) | Style et bonnes pratiques Angular/TypeScript : suffixe des classes de composants, interdiction du `any` explicite (warning), imports inutilisés (erreur), `eqeqeq`, liaisons de template (`banana-in-box`) | `npm run lint` (CI) |
+| **PHPUnit 11** + **Vitest** | Couverture fonctionnelle : 295 tests / 715 assertions côté backend (74,32 % lignes, 81,34 % méthodes), 231 tests côté frontend (73,43 % lignes) | Voir `docs/TESTING.md` — compétence C2.2.2 |
+| **`docker-build`** (CI) | Les 3 images Docker doivent réellement builder — a révélé un bug de build de production invisible jusque-là (budget CSS dépassé sur deux composants, seuil ajusté de 8 à 12 kB dans `angular.json`) | Chaque pull request |
+
+> **Limite assumée** : aucun outil d'analyse statique de types (PHPStan/Psalm) n'est intégré à ce jour — seul le style est vérifié, pas la cohérence de typage. L'intégration de `phpstan/phpstan` (niveau ≥ 5) dans un job `backend-static-analysis` dédié est identifiée comme prochaine étape naturelle du pipeline qualité.
+
+---
+
+## 6. Critères de performance
+
+- **Frontend** : budgets de bundle définis dans `web/frontend/angular.json` — avertissement à 500 kB / erreur à 1 MB pour le bundle initial, 8 kB / 12 kB par feuille de style de composant. Ces seuils empêchent la régression silencieuse de la taille de l'application livrée au navigateur.
+- **Images Docker allégées** : builds multi-stage systématiques — seul le résultat compilé (autoload PHP optimisé, bundle Angular, JavaScript transpilé) est copié dans l'image finale, jamais les outils de build ni les dépendances de développement (`npm prune --omit=dev` pour le bot, `composer install --no-dev` pour le backend).
+- **Backend (boucle de rétroaction CI)** : le choix de **PCOV** plutôt que Xdebug comme driver de couverture réduit significativement le temps d'exécution de la CI, un critère de performance appliqué au processus de développement lui-même.
+- **Backend (exécution)** : activation d'**OPcache** en production, réduisant le coût de recompilation du bytecode PHP à chaque requête.
+- **Infrastructure** : le choix d'un VPS OVHcloud (cf. §4) répond aussi à un objectif de performance énergétique — infrastructure mutualisée et refroidie efficacement plutôt que sur-dimensionnée.
+
+> **Limite assumée** : aucun outil de profiling applicatif (Blackfire, Symfony Web Profiler) n'est activé, y compris en développement. Ce choix est cohérent avec le périmètre actuel du projet (pas encore de charge réelle à profiler) mais constitue un axe d'amélioration si le projet passe en production avec des utilisateurs actifs.
+
+---
+
+## Contexte RNCP — Compétence C2.1.1
+
+| Critère d'évaluation | Réponse apportée |
+|---|---|
+| Protocole de déploiement continu explicité | §3 (CI) et §4 (CD, architecture conteneurisée, séquence de déploiement) |
+| Environnement de développement détaillé | §1 |
+| Composants identifiés (compilateur, serveur d'application, gestion de sources) | §1 (PHP/esbuild/tsc), §4 (nginx/PHP-FPM conteneurisés), §2 (Git/GitHub) |
+| Séquences de déploiement définies | §4 (runbook Docker Compose, démontré localement) et tableau §3 (jobs CI) |
+| Critères de qualité et de performance répondant aux exigences du projet | §5 et §6 |

--- a/docs/C2.1.1-environnement-deploiement.md
+++ b/docs/C2.1.1-environnement-deploiement.md
@@ -35,7 +35,9 @@ fusionne automatiquement `docker-compose.yml` (topologie commune) et `docker-com
 - **`mysql`** (MySQL 8, exposé sur `localhost:3307`) ;
 - **`bot`** (`nodemon` + `ts-node`, rechargement à chaud sur modification de `bot/src`).
 
-Au démarrage, le conteneur `backend` exécute automatiquement (`web/backend/docker/entrypoint.sh`) : génération des clés JWT si absentes, attente de la disponibilité de MySQL, migrations Doctrine, puis — en développement uniquement, et une seule fois grâce à un fichier marqueur — chargement des fixtures de démonstration (villes, boutique).
+Au démarrage, le conteneur `backend` exécute automatiquement (`web/backend/docker/entrypoint.sh`) : génération des clés JWT si absentes, attente de la disponibilité de MySQL, migrations Doctrine, puis — en développement uniquement, et une seule fois grâce à un fichier marqueur — chargement des fixtures de démonstration (villes, métiers, boutique).
+
+> **Ce script est unique** : la même image (`web/backend/Dockerfile`, stage `php_base`) définit un seul `entrypoint.sh`, hérité aussi bien par le stage `dev` que par le stage `prod` — son comportement ne change pas, seul le contenu réel de `config/jwt/` diffère selon ce qui y est monté (dossier de l'hôte en dev, volume nommé `jwt_keys` en prod, cf. §4). Cette distinction a eu une conséquence concrète : une première version de `docker-compose.yml` déclarait le volume `jwt_keys` au niveau de la base partagée dev/prod plutôt que dans la seule surcouche de production — Docker Compose fusionnant les volumes par chemin de montage plutôt que de remplacer la liste entre fichiers, ce volume restait actif en développement et masquait silencieusement les clés réelles de l'hôte. Repéré et corrigé via un hotfix dédié (`hotfix/jwt-keys-volume-dev`), en suivant le protocole `hotfix → release → main` de la stratégie de branches (§2).
 
 ### Gestion des dépendances
 
@@ -54,6 +56,8 @@ feature/SU/xx  →  feature/xx  →  develop  →  release/x.y.z  →  main
 ```
 
 La Dockerisation illustre concrètement ce découpage : la Feature **#96 « Déploiement continu (CD) »** (branche `feature/96-cd`) a été livrée par deux sous-tâches (SU) indépendantes mais couplées — **#107 « Dockerisation de la stack »** et **#108 « Configuration Docker Compose »**, développées ensemble sur `feature/SU/108-configuration-docker-compose` (PR #233, testée de bout en bout avant merge) — puis intégrée à `develop` via PR #232.
+
+Le modèle prévoit aussi un chemin de correctif direct, sans repasser par le cycle `feature/SU/*` complet : `hotfix/*` (ou `develop`) → `release/x.y.z` → `main`, validé par la même règle `branch-strategy.yml`. Ce chemin a été concrètement emprunté pour corriger un bug de configuration Docker découvert après coup (cf. §1, encadré sur `entrypoint.sh`) : branche `hotfix/jwt-keys-volume-dev` créée depuis `release/0.1.0`, PR vers `release/0.1.0` (mergée), puis PR `release/0.1.0` → `main` — déclenchant `release.yml` et publiant la première version taguée du projet, `v0.1.0`.
 
 Cette stratégie est **validée automatiquement** par le workflow `.github/workflows/branch-strategy.yml` (job `validate-branch-strategy`) : à chaque ouverture/mise à jour de pull request, un script vérifie que la branche source et la branche cible respectent la convention (ex. une PR `feature/SU/*` ne peut cibler qu'une branche `feature/*`, une PR `release/*` ne peut cibler que `main`). Toute violation fait échouer le job avec un message explicite.
 


### PR DESCRIPTION
Closes #101

## Résumé

Met à jour `docs/C2.1.1-environnement-deploiement.md` (compétence RNCP C2.1.1) pour refléter l'architecture Docker réellement construite (PR #233) plutôt que le protocole manuel initialement théorisé :

- Environnement de dev entièrement conteneurisé (`docker compose up`)
- Architecture des conteneurs en prod (tableau des services, images de base)
- Séquence de déploiement réelle (`--profile prod run --rm frontend-build && ... up -d`)
- Secrets par service (principe de moindre privilège) et pourquoi ce choix a remplacé la conception initiale à fichier unique
- Choix d'hébergement VPS OVHcloud (souveraineté des données, sobriété énergétique) et durcissement prévu
- Limite assumée sur l'absence de step SSH automatisé dans `release.yml` : non testable sans VPS réel, protocole démontré localement à la place (mêmes commandes Docker Compose)
- CI : job `docker-build` (7ᵉ job), déclenchement étendu à `feature/**`, bug de build de production révélé et corrigé (budget CSS)

Aucun changement de code applicatif — uniquement de la documentation.