### PR TITLE
fix(docker): déplacer le volume jwt_keys de la base vers prod uniquement

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -11,6 +11,8 @@ services:
 
   backend:
     env_file: web/backend/.env.prod
+    volumes:
+      - jwt_keys:/var/www/config/jwt
     restart: unless-stopped
 
   mysql:
@@ -20,3 +22,6 @@ services:
   bot:
     env_file: bot/.env.prod
     restart: unless-stopped
+
+volumes:
+  jwt_keys:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
     build:
       context: ./web/backend
       target: prod
-    volumes:
-      - jwt_keys:/var/www/config/jwt
     depends_on:
       mysql:
         condition: service_healthy
@@ -42,5 +40,4 @@ services:
 
 volumes:
   frontend_dist:
-  jwt_keys:
   mysql_data:


### PR DESCRIPTION
## Résumé

`docker-compose.yml` déclarait `jwt_keys:/var/www/config/jwt` sur le service `backend`. Docker Compose fusionne les listes `volumes` par chemin cible plutôt que de les remplacer intégralement entre fichiers : cette déclaration restait donc active en dev même après avoir retiré la ligne équivalente de `docker-compose.override.yaml`, et masquait les vraies clés JWT apportées par le bind-mount (`./web/backend:/var/www`) sous le sous-chemin `config/jwt/`.

Conséquence en dev : régénération silencieuse d'une nouvelle paire de clés à chaque recréation du volume nommé, au lieu de réutiliser celles déjà présentes sur le disque local : fonctionnel (l'auth continuait de marcher), mais incohérent avec ce qui est réellement sur `web/backend/config/jwt/`.

## Correctif

Le volume `jwt_keys` n'a de sens qu'en **production** (aucun bind-mount là-bas, donc rien d'autre ne persisterait les clés entre redéploiements). Déplacé de `docker-compose.yml` (base, partagée dev+prod) vers `docker-compose.prod.yaml` (chargé uniquement en prod via `-f`).

## Vérification

- [x] `docker compose config` (dev) : le service `backend` n'a plus que le bind-mount, `jwt_keys` absent
- [x] `docker compose -f docker-compose.yml -f docker-compose.prod.yaml config` (prod, avec fichiers `.env.prod` temporaires) : `jwt_keys` bien présent sur `backend`