### PR TITLE
fix(docker): fiabiliser le démarrage à froid (CRLF + healthcheck MySQL)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+
+*.sh text eol=lf
+Dockerfile text eol=lf
+*.conf text eol=lf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+      start_period: 60s
 
   bot:
     build:


### PR DESCRIPTION
## Résumé

Deux bugs découverts en testant un rebuild complet depuis zéro (Docker Desktop entièrement vidé) sur `main` après la publication de v0.1.0.

### 1. CRLF sur `entrypoint.sh`

Le fichier se retrouvait avec des fins de ligne CRLF dans la copie de travail locale (Windows), cassant le shebang (`#!/bin/sh\r`) et empêchant le backend de démarrer :
```
exec /usr/local/bin/entrypoint.sh: no such file or directory
```
Message trompeur — le fichier existe, c'est l'interpréteur (mal encodé) que Linux ne trouve pas. nginx plantait en cascade juste après (résolution DNS de `backend` échouée, son conteneur ayant déjà crashé).

Le contenu déjà commité était en réalité correct (LF) — confirmé via `git add --renormalize .` qui n'a rien changé. Le problème venait uniquement du checkout local. Ajout de `.gitattributes` pour forcer LF sur `*.sh`, `Dockerfile` et `*.conf` à tout checkout, quelle que soit la config Git de la machine — protège les futurs contributeurs Windows du même piège, sans dépendre de leur configuration personnelle.

### 2. Healthcheck MySQL trop court

`retries: 10` × `interval: 5s` = 50s, insuffisant pour une initialisation à froid sur un volume neuf (~65s observées en pratique). Ajout de `start_period: 60s` : les échecs pendant cette fenêtre ne comptent plus dans le budget de tentatives, sans affecter la détection de pannes une fois le démarrage terminé.

## Vérification

- [x] `file` confirme l'absence de CRLF sur tous les scripts/Dockerfiles/confs après re-checkout
- [x] Rebuild complet + `docker compose up -d` depuis `main` (Docker Desktop vidé) — sera revérifié après merge de cette PR