### PR TITLE
fix(docker): fixtures rechargées après reset DB (marqueur obsolète)

### DIFF
--- a/web/backend/docker/entrypoint.sh
+++ b/web/backend/docker/entrypoint.sh
@@ -18,9 +18,11 @@ done
 
 php bin/console doctrine:migrations:migrate --no-interaction
 
-if [ "$APP_ENV" = "dev" ] && [ ! -f var/.fixtures_loaded ]; then
-    php bin/console doctrine:fixtures:load --no-interaction
-    touch var/.fixtures_loaded
+if [ "$APP_ENV" = "dev" ]; then
+    CITY_COUNT=$(php bin/console dbal:run-sql "SELECT COUNT(*) as c FROM cities" 2>/dev/null | grep -oE '[0-9]+' | tail -1)
+    if [ "${CITY_COUNT:-0}" = "0" ]; then
+        php bin/console doctrine:fixtures:load --no-interaction
+    fi
 fi
 
 if [ "$APP_ENV" = "prod" ]; then


### PR DESCRIPTION
## Résumé

Bug découvert en testant le flux de connexion Discord de bout en bout sur `release/0.1.1` : première connexion → 401 « Authentication failed », avec en réalité (confirmé via un ajout temporaire de debug) `RuntimeException: Aucune ville par défaut trouvée` dans `UserService::createNewUser`.

Cause : le marqueur `var/.fixtures_loaded` vit dans le dossier bind-monté (`web/backend/`), donc **survit** à un `docker compose down -v` qui vide la base MySQL. L'entrypoint pensait les fixtures déjà chargées alors que la table `cities` était vide (confirmé : `SELECT COUNT(*) FROM cities` → 0, marqueur daté du 15 juillet).

## Correctif

Remplace le marqueur fichier par une vérification directe du contenu de la table `cities` — fixtures rechargées seulement si elle est vide. Toujours synchronisé avec l'état réel de la base, plus de désynchronisation possible.

## Vérification

- [x] Rebuild + restart avec base vide → fixtures chargées (6 villes), flux de connexion Discord fonctionnel de bout en bout
- [x] Restart sans purge de la base → fixtures **non** rechargées (idempotence confirmée, count toujours à 6)