### PR TITLE
fix(docker): créer un .env vide dans l'entrypoint (requis par Symfony Dotenv)

### DIFF
--- a/web/backend/docker/entrypoint.sh
+++ b/web/backend/docker/entrypoint.sh
@@ -3,6 +3,8 @@ set -e
 
 cd /var/www
 
+touch .env
+
 if [ ! -f vendor/autoload.php ]; then
     composer install --prefer-dist --no-interaction
 fi


### PR DESCRIPTION
## Résumé

Découvert en exécutant réellement la config prod en local (`docker compose -f docker-compose.yml -f docker-compose.prod.yaml up -d`, jamais fait jusqu'ici — seule la syntaxe avait été validée via `config`).

`Symfony\Component\Dotenv\Dotenv::bootEnv()` lève une exception fatale si `/var/www/.env` n'existe pas, même quand toute la configuration réelle vient de vraies variables d'environnement (qui ont de toute façon priorité sur le contenu d'un `.env`). En dev, le bind-mount fournissait un vrai `.env` par accident, masquant le problème. En prod, `.env` est explicitement exclu de l'image (`.dockerignore`, pour ne jamais y graver de secrets) — rien ne le fournissait, donc le backend plantait au démarrage à chaque tentative.

## Correctif

`touch .env` en tout début d'`entrypoint.sh`. Sûr dans les deux contextes : si le fichier existe déjà (dev, via bind-mount), `touch` ne fait que mettre à jour sa date, jamais son contenu.

## Vérification

- [x] Stack prod complète relancée en local (nginx HTTPS 200, API HTTPS 200, MySQL healthy, bot connecté à Discord) après ce correctif — plus de crash au démarrage