### PR TITLE
fix(frontend): header conserve sa hauteur de base quand le menu mobile est fermé

### DIFF
--- a/web/frontend/src/app/shared/components/header/header.component.scss
+++ b/web/frontend/src/app/shared/components/header/header.component.scss
@@ -241,6 +241,10 @@
 /* ===== MOBILE MENU ===== */
 .mobile-menu {
   display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
   background: rgba(8, 8, 12, 0.98);
   backdrop-filter: blur(20px);
   border-top: 1px solid rgba(255, 107, 53, 0.1);


### PR DESCRIPTION
## Problème

Sur mobile/tablette (< 1024px), le header gardait la même hauteur que le menu soit ouvert ou fermé, faisant perdre de l'espace à l'écran en permanence.

## Cause

`.mobile-menu` restait dans le flux normal du document (pas de `position: absolute`). La règle responsive lui donnait `display: block` dès qu'on passait sous 1024px, indépendamment de l'état ouvert/fermé — seuls `opacity`/`visibility`/`transform` étaient animés pour simuler la transition, mais ces propriétés ne retirent pas l'élément du flux : sa hauteur (nav + footer) restait donc toujours réservée dans le `<header>`.

## Correctif

Alignement sur le pattern déjà utilisé par `.user-menu__dropdown` : `position: absolute; top: 100%; left: 0; right: 0;` sur `.mobile-menu`, pour le sortir du flux normal. Le header revient à sa hauteur de base (~68px) quand le menu est fermé ; le menu s'affiche désormais en overlay par-dessus le contenu quand ouvert.

## Test plan

- [x] Vérifié en local (stack Docker dev, `localhost:8080`) : hauteur du header stable en dessous de 1024px, que le menu soit ouvert ou fermé
- [x] Menu mobile toujours fonctionnel (ouverture/fermeture, navigation, liens actifs)