### PR TITLE
test(bot): ajout d'une suite de tests unitaires (Vitest)

### DIFF
--- a/bot/.gitignore
+++ b/bot/.gitignore
@@ -39,6 +39,9 @@ backup/
 /build
 /*.tsbuildinfo
 
+# Test coverage
+/coverage
+
 # Database (SQLite)
 /data/*.db
 /data/*.db-shm

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -18,10 +18,72 @@
       },
       "devDependencies": {
         "@types/node": "^25.0.6",
+        "@vitest/coverage-v8": "^4.1.10",
         "nodemon": "^3.1.11",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -172,7 +234,6 @@
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -184,7 +245,6 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -195,7 +255,6 @@
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -671,13 +730,13 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -687,6 +746,280 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
@@ -973,6 +1306,13 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -1002,14 +1342,39 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.9.4",
@@ -1027,6 +1392,150 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
@@ -1085,6 +1594,39 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
@@ -1213,6 +1755,16 @@
         "node": "^18.12.0 || >= 20.9.0"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1243,6 +1795,13 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1397,6 +1956,13 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -1439,6 +2005,16 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1446,6 +2022,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1525,6 +2111,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -1633,6 +2226,336 @@
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -1671,6 +2594,44 @@
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
       "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
       "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -1763,6 +2724,25 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -1826,6 +2806,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1834,6 +2828,20 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
@@ -1846,6 +2854,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prebuild-install": {
@@ -1960,6 +2997,40 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1997,6 +3068,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -2056,6 +3134,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sql-escaper": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
@@ -2070,6 +3158,20 @@
         "type": "github",
         "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2128,6 +3230,81 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -2288,6 +3465,217 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/bot/package.json
+++ b/bot/package.json
@@ -10,7 +10,8 @@
     "rest": "tsx src/utils/rest.ts",
     "rest-guild": "tsx src/utils/rest-guild.ts",
     "start": "node dist/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "repository": {
     "type": "git",
@@ -31,9 +32,11 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.6",
+    "@vitest/coverage-v8": "^4.1.10",
     "nodemon": "^3.1.11",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/bot/src/commands/mazworld/utils/components.spec.ts
+++ b/bot/src/commands/mazworld/utils/components.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildMapButtons,
+  buildPurchaseConfirmRow,
+  buildInventoryButtons,
+  buildBackgroundSelectMenu,
+  buildSlotSelectMenu,
+  buildUnequipSelectMenu,
+} from './components';
+import type { MapRoute, ShopItem } from '../data';
+
+function route(overrides: Partial<MapRoute> = {}): MapRoute {
+  return {
+    city_to: 'riverside', destination_name: 'Riverside', destination_emoji: '🏞️',
+    cost: 100, duration: 600, visited: false, effective_cost: 100, ...overrides,
+  };
+}
+
+function item(overrides: Partial<ShopItem> = {}): ShopItem {
+  return { item_id: 'bg_blue', item_type: 'background', name: 'Blue', price: 100, owned: false, equipped: false, ...overrides };
+}
+
+describe('components', () => {
+  describe('buildMapButtons', () => {
+    it('returns no row when there is no route', () => {
+      expect(buildMapButtons([])).toHaveLength(0);
+    });
+
+    it('caps buttons to the first 5 routes', () => {
+      const routes = Array.from({ length: 8 }, (_, i) => route({ city_to: `city-${i}`, destination_name: `City ${i}` }));
+
+      const [row] = buildMapButtons(routes);
+
+      expect(row.toJSON().components).toHaveLength(5);
+    });
+  });
+
+  describe('buildPurchaseConfirmRow', () => {
+    it('disables the purchase button when the item is already owned', () => {
+      const [buyButton] = buildPurchaseConfirmRow(true, true).toJSON().components as any[];
+
+      expect(buyButton.disabled).toBe(true);
+    });
+
+    it('disables the purchase button when the balance is insufficient', () => {
+      const [buyButton] = buildPurchaseConfirmRow(false, false).toJSON().components as any[];
+
+      expect(buyButton.disabled).toBe(true);
+    });
+
+    it('enables the purchase button when affordable and not owned', () => {
+      const [buyButton] = buildPurchaseConfirmRow(false, true).toJSON().components as any[];
+
+      expect(buyButton.disabled).toBe(false);
+    });
+  });
+
+  describe('buildInventoryButtons', () => {
+    it('shows only the background action when only backgrounds are owned', () => {
+      const rows = buildInventoryButtons(true, false);
+
+      expect(rows).toHaveLength(1);
+      expect((rows[0].toJSON().components[0] as any).custom_id).toBe('equip_background');
+    });
+
+    it('shows badge actions (equip + unequip) when only badges are owned', () => {
+      const rows = buildInventoryButtons(false, true);
+      const ids = (rows[0].toJSON().components as any[]).map(c => c.custom_id);
+
+      expect(ids).toEqual(['equip_badge', 'unequip_badge']);
+    });
+
+    it('falls back to a disabled shop link when the inventory is empty', () => {
+      const rows = buildInventoryButtons(false, false);
+      const button = rows[0].toJSON().components[0] as any;
+
+      expect(button.custom_id).toBe('goto_shop');
+      expect(button.disabled).toBe(true);
+    });
+  });
+
+  describe('buildBackgroundSelectMenu', () => {
+    it('marks the currently equipped background in its label and description', () => {
+      const backgrounds = [item({ item_id: 'bg_blue', name: 'Blue' }), item({ item_id: 'bg_red', name: 'Red' })];
+
+      const menu = buildBackgroundSelectMenu(backgrounds, 'bg_blue').toJSON().components[0] as any;
+      const [blue, red] = menu.options;
+
+      expect(blue.label).toBe('Blue (équipé)');
+      expect(blue.description).toBe('✅ Actuellement équipé');
+      expect(red.label).toBe('Red');
+    });
+  });
+
+  describe('buildSlotSelectMenu', () => {
+    it('shows a slot as empty when no badge occupies it', () => {
+      const menu = buildSlotSelectMenu('badge_new', [], []).toJSON().components[0] as any;
+
+      expect(menu.options[0].description).toBe('Vide');
+      expect(menu.options[0].emoji.name).toBe('⚫');
+    });
+
+    it('shows the occupying badge name when a slot is already used', () => {
+      const badge = item({ item_id: 'badge_founder', item_type: 'badge', name: 'Founder', emoji: '👑' });
+
+      const menu = buildSlotSelectMenu('badge_new', [badge], ['badge_founder']).toJSON().components[0] as any;
+
+      expect(menu.options[0].description).toContain('Founder');
+      expect(menu.options[0].description).toContain('sera remplacé');
+    });
+
+    it('always exposes exactly 6 slots', () => {
+      const menu = buildSlotSelectMenu('badge_new', [], []).toJSON().components[0] as any;
+
+      expect(menu.options).toHaveLength(6);
+    });
+  });
+
+  describe('buildUnequipSelectMenu', () => {
+    it('only lists slots that are actually occupied', () => {
+      const badge = item({ item_id: 'badge_founder', item_type: 'badge', name: 'Founder' });
+
+      const menu = buildUnequipSelectMenu(['badge_founder', '', '', '', '', ''], [badge]).toJSON().components[0] as any;
+
+      expect(menu.options).toHaveLength(1);
+      expect(menu.options[0].label).toContain('Founder');
+    });
+
+    it('produces no options when nothing is equipped', () => {
+      const menu = buildUnequipSelectMenu(['', '', '', '', '', ''], []).toJSON().components[0] as any;
+
+      expect(menu.options ?? []).toHaveLength(0);
+    });
+  });
+});

--- a/bot/src/commands/mazworld/utils/cooldownManager.spec.ts
+++ b/bot/src/commands/mazworld/utils/cooldownManager.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { checkCooldown, setCooldown, resetCooldown, formatTimeRemaining, COOLDOWN_DURATIONS } from './cooldownManager';
+
+describe('cooldownManager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  describe('checkCooldown', () => {
+    it('reports no cooldown for a user who never used the command', () => {
+      const result = checkCooldown('daily', 'user-never-used', COOLDOWN_DURATIONS.DAILY);
+
+      expect(result.isOnCooldown).toBe(false);
+      expect(result.timeLeft).toBe(0);
+      expect(result.formattedTime).toBe('');
+    });
+
+    it('reports an active cooldown right after use', () => {
+      setCooldown('work', 'user-1');
+
+      const result = checkCooldown('work', 'user-1', COOLDOWN_DURATIONS.WORK);
+
+      expect(result.isOnCooldown).toBe(true);
+      expect(result.timeLeft).toBe(COOLDOWN_DURATIONS.WORK);
+    });
+
+    it('reports the cooldown as expired once the duration has elapsed', () => {
+      setCooldown('coinflip', 'user-2');
+
+      vi.advanceTimersByTime(COOLDOWN_DURATIONS.COINFLIP + 1);
+
+      const result = checkCooldown('coinflip', 'user-2', COOLDOWN_DURATIONS.COINFLIP);
+
+      expect(result.isOnCooldown).toBe(false);
+    });
+
+    it('keeps cooldowns isolated per command type for the same user', () => {
+      setCooldown('daily', 'user-3');
+
+      const workResult = checkCooldown('work', 'user-3', COOLDOWN_DURATIONS.WORK);
+
+      expect(workResult.isOnCooldown).toBe(false);
+    });
+
+    it('keeps cooldowns isolated per user for the same command', () => {
+      setCooldown('daily', 'user-4');
+
+      const otherUserResult = checkCooldown('daily', 'user-5', COOLDOWN_DURATIONS.DAILY);
+
+      expect(otherUserResult.isOnCooldown).toBe(false);
+    });
+  });
+
+  describe('resetCooldown', () => {
+    it('clears an active cooldown so the user can act again immediately', () => {
+      setCooldown('daily', 'user-6');
+      resetCooldown('daily', 'user-6');
+
+      const result = checkCooldown('daily', 'user-6', COOLDOWN_DURATIONS.DAILY);
+
+      expect(result.isOnCooldown).toBe(false);
+    });
+
+    it('does nothing when the user has no cooldown recorded', () => {
+      expect(() => resetCooldown('daily', 'user-never-set')).not.toThrow();
+    });
+  });
+
+  describe('formatTimeRemaining', () => {
+    it('formats hours, minutes and seconds together', () => {
+      const ms = (2 * 3600 + 15 * 60 + 30) * 1000;
+
+      expect(formatTimeRemaining(ms)).toBe('2h 15m 30s');
+    });
+
+    it('omits zero-value units except when everything is zero', () => {
+      expect(formatTimeRemaining(45 * 1000)).toBe('45s');
+      expect(formatTimeRemaining(5 * 60 * 1000)).toBe('5m');
+      expect(formatTimeRemaining(0)).toBe('0s');
+    });
+
+    it('omits seconds when hours and minutes are both present but seconds are zero', () => {
+      const ms = (1 * 3600 + 30 * 60) * 1000;
+
+      expect(formatTimeRemaining(ms)).toBe('1h 30m');
+    });
+  });
+});

--- a/bot/src/commands/mazworld/utils/embeds.spec.ts
+++ b/bot/src/commands/mazworld/utils/embeds.spec.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildTravelInProgressEmbed,
+  buildMapEmbed,
+  buildTravelConfirmEmbed,
+  buildCityinfoEmbed,
+  buildDailyAlreadyClaimedEmbed,
+  buildCoinflipResultEmbed,
+  buildShopItemConfirmEmbed,
+  buildShopPurchaseResultEmbed,
+  buildInventoryEmbed,
+  buildSlotMenuEmbed,
+} from './embeds';
+import type { MapRoute, MapResponse, ShopItem, ProfileData } from '../data';
+
+const AVATAR = 'https://cdn.discordapp.com/avatars/1/1.png';
+
+function route(overrides: Partial<MapRoute> = {}): MapRoute {
+  return {
+    city_to: 'riverside',
+    destination_name: 'Riverside',
+    destination_emoji: '🏞️',
+    cost: 100,
+    duration: 600,
+    visited: false,
+    effective_cost: 100,
+    ...overrides,
+  };
+}
+
+describe('embeds', () => {
+  describe('buildTravelInProgressEmbed', () => {
+    it('computes remaining hours and minutes from arrival_time', () => {
+      const now = Math.floor(Date.now() / 1000);
+      const status = {
+        traveling: true as const,
+        destination_emoji: '🏞️',
+        destination_name: 'Riverside',
+        arrival_time: now + 3600 + 15 * 60,
+      };
+
+      const embed = buildTravelInProgressEmbed(status as any, AVATAR);
+
+      expect(embed.data.fields?.[0].value).toContain('1h 15m');
+    });
+  });
+
+  describe('buildMapEmbed', () => {
+    it('marks already-visited routes as free and unvisited ones with their cost', () => {
+      const data: MapResponse = {
+        current_city: { city_id: 'a', name: 'Alpha', description: '...', emoji: '🏙️', theme: 'Village' },
+        coins: 500,
+        routes: [route({ visited: true, destination_name: 'Free City' }), route({ visited: false, destination_name: 'Paid City', effective_cost: 250 })],
+      };
+
+      const embed = buildMapEmbed(data, AVATAR);
+      const destinationsField = embed.data.fields?.find(f => f.name.includes('Destinations'));
+
+      expect(destinationsField?.value).toContain('Free City');
+      expect(destinationsField?.value).toContain('✅ Gratuit');
+      expect(destinationsField?.value).toContain('Paid City');
+      expect(destinationsField?.value).toContain('250€');
+    });
+
+    it('falls back to an explicit message when no route is available', () => {
+      const data: MapResponse = {
+        current_city: { city_id: 'a', name: 'Alpha', description: '...', emoji: '🏙️', theme: 'Village' },
+        coins: 0,
+        routes: [],
+      };
+
+      const embed = buildMapEmbed(data, AVATAR);
+      const destinationsField = embed.data.fields?.find(f => f.name.includes('Destinations'));
+
+      expect(destinationsField?.value).toBe('Aucune route disponible depuis cette ville.');
+    });
+  });
+
+  describe('buildTravelConfirmEmbed', () => {
+    it('shows the route as free when already visited', () => {
+      const embed = buildTravelConfirmEmbed(route({ visited: true }));
+
+      expect(embed.data.fields?.[0].value).toContain('Gratuit');
+      expect(embed.data.color).toBe(0x00ff00);
+    });
+
+    it('shows the effective cost when not yet visited', () => {
+      const embed = buildTravelConfirmEmbed(route({ visited: false, effective_cost: 150 }));
+
+      expect(embed.data.fields?.[0].value).toBe('150€');
+      expect(embed.data.color).toBe(0x5865f2);
+    });
+  });
+
+  describe('buildCityinfoEmbed', () => {
+    const baseData: MapResponse = {
+      current_city: { city_id: 'a', name: 'Alpha', description: '...', emoji: '🏙️', theme: 'Forêt' },
+      coins: 0,
+      routes: [],
+      jobs: [],
+    };
+
+    it('uses the theme color mapping when the theme is known', () => {
+      const embed = buildCityinfoEmbed(baseData, AVATAR);
+
+      expect(embed.data.color).toBe(0x4caf50);
+    });
+
+    it('falls back to the default color for an unmapped theme', () => {
+      const embed = buildCityinfoEmbed({ ...baseData, current_city: { ...baseData.current_city, theme: 'Inconnu' } }, AVATAR);
+
+      expect(embed.data.color).toBe(0x5865f2);
+    });
+
+    it('shows a fallback message when no job is available', () => {
+      const embed = buildCityinfoEmbed(baseData, AVATAR);
+      const jobsField = embed.data.fields?.find(f => f.name.includes('Métiers'));
+
+      expect(jobsField?.value).toBe('Aucun métier disponible dans cette ville.');
+    });
+
+    it('does not add a destinations field when there is no route', () => {
+      const embed = buildCityinfoEmbed(baseData, AVATAR);
+
+      expect(embed.data.fields?.some(f => f.name.includes('Destinations'))).toBe(false);
+    });
+  });
+
+  describe('buildDailyAlreadyClaimedEmbed', () => {
+    it('adds the next-claim field only when next_daily is provided', () => {
+      const withNext = buildDailyAlreadyClaimedEmbed({ success: false, message: 'déjà réclamé', next_daily: 12345 }, AVATAR);
+      const withoutNext = buildDailyAlreadyClaimedEmbed({ success: false, message: 'déjà réclamé' }, AVATAR);
+
+      expect(withNext.data.fields?.length).toBe(1);
+      expect(withoutNext.data.fields ?? []).toHaveLength(0);
+    });
+  });
+
+  describe('buildCoinflipResultEmbed', () => {
+    it('renders a victory embed with the pile result', () => {
+      const embed = buildCoinflipResultEmbed({ success: true, won: true, result: 'pile', amount: 100, coins: 600, message: 'Bravo' }, AVATAR);
+
+      expect(embed.data.title).toBe('🎉 VICTOIRE !');
+      expect(embed.data.color).toBe(0x00ff00);
+      expect(embed.data.fields?.[0].value).toContain('PILE');
+      expect(embed.data.fields?.[1].value).toBe('+100€');
+    });
+
+    it('renders a defeat embed with the face result', () => {
+      const embed = buildCoinflipResultEmbed({ success: true, won: false, result: 'face', amount: 50, coins: 450, message: 'Perdu' }, AVATAR);
+
+      expect(embed.data.title).toBe('💔 DÉFAITE');
+      expect(embed.data.color).toBe(0xff0000);
+      expect(embed.data.fields?.[0].value).toContain('FACE');
+      expect(embed.data.fields?.[1].value).toBe('-50€');
+    });
+  });
+
+  describe('buildShopItemConfirmEmbed', () => {
+    const item = (overrides: Partial<ShopItem> = {}): ShopItem => ({
+      item_id: 'bg_blue', item_type: 'background', name: 'Blue', price: 200, owned: false, equipped: false, ...overrides,
+    });
+
+    it('shows "already owned" regardless of balance', () => {
+      const embed = buildShopItemConfirmEmbed(item({ owned: true }), 0);
+
+      expect(embed.data.fields?.[2].value).toBe('✅ Déjà possédé');
+      expect(embed.data.color).toBe(0xffaa00);
+    });
+
+    it('shows purchasable when balance covers the price', () => {
+      const embed = buildShopItemConfirmEmbed(item({ price: 100 }), 150);
+
+      expect(embed.data.fields?.[2].value).toBe('✅ Vous pouvez acheter');
+      expect(embed.data.color).toBe(0x00ff00);
+    });
+
+    it('shows insufficient funds when balance is below the price', () => {
+      const embed = buildShopItemConfirmEmbed(item({ price: 100 }), 50);
+
+      expect(embed.data.fields?.[2].value).toBe('❌ Pas assez d\'argent');
+      expect(embed.data.color).toBe(0xff0000);
+    });
+  });
+
+  describe('buildShopPurchaseResultEmbed', () => {
+    it('adds the new balance field only on success', () => {
+      const success = buildShopPurchaseResultEmbed({ success: true, message: 'ok', new_balance: 300 });
+      const failure = buildShopPurchaseResultEmbed({ success: false, message: 'insuffisant' });
+
+      expect(success.data.title).toBe('✅ Achat réussi !');
+      expect(success.data.fields?.[0].value).toBe('300€');
+      expect(failure.data.title).toBe('❌ Achat échoué');
+      expect(failure.data.fields ?? []).toHaveLength(0);
+    });
+  });
+
+  describe('buildInventoryEmbed', () => {
+    const profile: ProfileData = {
+      user_id: '1', username: 'Maz', coins: 1000, equipped_background: 'bg_missing', equipped_badges: ['badge_1', '', '', '', '', ''],
+    };
+    const items: ShopItem[] = [
+      { item_id: 'badge_1', item_type: 'badge', name: 'Founder', emoji: '👑', price: 500, owned: true, equipped: true },
+    ];
+
+    it('falls back to "Défaut" when the equipped background is not found in allItems', () => {
+      const embed = buildInventoryEmbed(profile, [], [], items, 'Maz', AVATAR);
+      const bgField = embed.data.fields?.find(f => f.name.includes('actuel'));
+
+      expect(bgField?.value).toBe('⬜ Défaut');
+    });
+
+    it('renders known badge slots with their name and empty slots as "Vide"', () => {
+      const embed = buildInventoryEmbed(profile, [], [], items, 'Maz', AVATAR);
+      const badgesField = embed.data.fields?.find(f => f.name.includes('Badges équipés'));
+
+      expect(badgesField?.value).toContain('👑 Founder');
+      expect(badgesField?.value).toContain('⚫ Vide');
+    });
+
+    it('falls back to "Inconnu" for a badge id not present in allItems', () => {
+      const orphanProfile: ProfileData = { ...profile, equipped_badges: ['badge_ghost', '', '', '', '', ''] };
+      const embed = buildInventoryEmbed(orphanProfile, [], [], items, 'Maz', AVATAR);
+      const badgesField = embed.data.fields?.find(f => f.name.includes('Badges équipés'));
+
+      expect(badgesField?.value).toContain('❓ Inconnu');
+    });
+  });
+
+  describe('buildSlotMenuEmbed', () => {
+    it('uses the shop item name when found', () => {
+      const embed = buildSlotMenuEmbed({ item_id: 'badge_1', item_type: 'badge', name: 'Founder', emoji: '👑', price: 0, owned: true, equipped: false }, 'badge_1');
+
+      expect(embed.data.title).toContain('Founder');
+    });
+
+    it('falls back to the raw badge id when the shop item is not found', () => {
+      const embed = buildSlotMenuEmbed(undefined, 'badge_ghost');
+
+      expect(embed.data.title).toContain('badge_ghost');
+    });
+  });
+});

--- a/bot/src/commands/mazworld/utils/travelMiddleware.spec.ts
+++ b/bot/src/commands/mazworld/utils/travelMiddleware.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChatInputCommandInteraction } from 'discord.js';
+
+const { getMock } = vi.hoisted(() => ({ getMock: vi.fn() }));
+vi.mock('../../../api/client', () => ({ api: { get: getMock } }));
+
+import { checkTravelingStatus } from './travelMiddleware';
+
+function fakeInteraction() {
+  return {
+    user: { id: 'user-1', username: 'Maz' },
+    reply: vi.fn(),
+  } as unknown as ChatInputCommandInteraction & { reply: ReturnType<typeof vi.fn> };
+}
+
+describe('checkTravelingStatus', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    vi.useRealTimers();
+  });
+
+  it('returns false and does not reply when the user is not traveling', async () => {
+    getMock.mockResolvedValue({ traveling: false });
+    const interaction = fakeInteraction();
+
+    const result = await checkTravelingStatus(interaction);
+
+    expect(result).toBe(false);
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it('calls the API with the interacting user id and username', async () => {
+    getMock.mockResolvedValue({ traveling: false });
+    const interaction = fakeInteraction();
+
+    await checkTravelingStatus(interaction);
+
+    expect(getMock).toHaveBeenCalledWith('/api/travel/status', 'user-1', 'Maz');
+  });
+
+  it('returns true and replies with the destination when the user is traveling', async () => {
+    getMock.mockResolvedValue({
+      traveling: true,
+      destination_name: 'Riverside',
+      destination_emoji: '🏞️',
+      arrival_time: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const interaction = fakeInteraction();
+
+    const result = await checkTravelingStatus(interaction);
+
+    expect(result).toBe(true);
+    expect(interaction.reply).toHaveBeenCalledTimes(1);
+    const replyArg = interaction.reply.mock.calls[0][0];
+    expect(replyArg.content).toContain('Riverside');
+  });
+});

--- a/bot/tsconfig.json
+++ b/bot/tsconfig.json
@@ -8,5 +8,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["node_modules", "dist", "vitest.config.ts", "src/**/*.spec.ts"]
 }

--- a/bot/vitest.config.ts
+++ b/bot/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/**/*.spec.ts',
+        'src/index.ts',
+        '**/*.d.ts',
+      ],
+    },
+  },
+});

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,6 +17,15 @@ Le backend Symfony est couvert par deux catégories de tests clairement séparé
 
 Couverture : **74.32 % des lignes**, **81.34 % des méthodes** — 295 tests, 715 assertions (rapport HTML : `web/backend/coverage-reports/07-final/`, exclu du dépôt via `.gitignore`).
 
+**Couverture isolée par groupe** — le chiffre ci-dessus combine TU et TI. En isolant `--group unit` seul (`php bin/phpunit --group unit --coverage-text`), sans base de données :
+
+| Périmètre | Lignes | Méthodes | Classes |
+|---|---|---|---|
+| TU seul (`--group unit`) | 26.55 % | 50.70 % | 28.89 % |
+| TU + TI combinés | 74.32 % | 81.34 % | — |
+
+L'écart s'explique directement par le choix de conception ci-dessous : les 13 controllers et les 2 repositories à requêtes DQL custom, testés en intégration plutôt qu'en unitaire, représentent une part importante des lignes du code source. La couverture en lignes isolée passe sous 50 %, mais la couverture en méthodes reste au-dessus — les méthodes des couches non couvertes en TU sont en nombre plus faible que leur nombre de lignes (controllers avec peu de méthodes mais un corps HTTP verbeux).
+
 ---
 
 ### Prérequis
@@ -158,6 +167,8 @@ Couverture : **73.43 % des lignes** (481/655), **59.07 % des fonctions** (179/30
 
 > Le rapport inclut **tous** les fichiers sources (`src/app/**/*.ts`), y compris les composants de fonctionnalité non couverts (0 % de lignes). Les chiffres sont donc représentatifs de la couverture réelle de l’ensemble du codebase.
 
+**Pas de séparation TU/TI isolable côté frontend** — contrairement au backend (groupes PHPUnit `unit`/`integration` filtrables en une commande), Vitest/Angular ne propose ici aucun mécanisme de tag ou de projet séparant les tests. Les tests de composants passent tous par `TestBed`, y compris ceux qui ne dépendent d'aucune API (ex. les guards utilisent `TestBed.runInInjectionContext()`). Isoler un chiffre « TU pur » nécessiterait de reconstituer manuellement une liste de fichiers, sans commande unique pour le faire. Le chiffre combiné ci-dessus est donc présenté tel quel, en cohérence avec la nature des tests Angular modernes plutôt qu'en simulant une séparation qui n'existe pas dans l'outillage.
+
 ---
 
 ### Prérequis
@@ -280,3 +291,72 @@ Pour les Observables qui émettent une erreur, la conversion `lastValueFrom(obse
 | Stats (fmt() dupliqué, set atomique) | TU | `stats.component.spec.ts` |
 | Composants UI partagés (5 composants) | TI-comp | `shared/components/ui/*/` |
 | Composant racine (routing, accessibilité) | TI-comp | `app.spec.ts` |
+
+---
+
+## Bot Discord (Node/TypeScript)
+
+### Vue d'ensemble
+
+Le bot est couvert par des tests unitaires exécutés via **Vitest** (même outil que le frontend, pour une stack de test homogène) — **48 tests, 4 fichiers**, sur un périmètre volontairement restreint à la logique testable sans dépendance à une session Discord live (voir choix de conception ci-dessous). Contrairement au backend et au frontend, ce module n'a pas vocation à démontrer une couverture chiffrée globale : l'exigence RNCP de couverture majoritaire (> 50 %) est déjà remplie et documentée sur les deux autres modules. L'objectif ici est d'étendre la même méthodologie TU/TI à un troisième contexte technique, sur un périmètre choisi plutôt que subi.
+
+---
+
+### Prérequis
+
+- Node 22+ et `npm install` depuis `bot/`
+- Package `@vitest/coverage-v8` requis pour le rapport de couverture (déjà en devDependency)
+
+---
+
+### Commandes
+
+```bash
+# Depuis bot/
+
+# Suite complète
+npx vitest run
+
+# Avec rapport de couverture (texte)
+npx vitest run --coverage
+```
+
+---
+
+### Structure des tests
+
+```
+bot/src/commands/mazworld/utils/
+├── cooldownManager.spec.ts     # TU — calcul de cooldown, formatage du temps, isolation par user/commande
+├── components.spec.ts          # TU — boutons/menus Discord (état disabled, options dynamiques)
+├── embeds.spec.ts              # TU — construction d'embeds Discord (branches conditionnelles)
+└── travelMiddleware.spec.ts    # TU — appel API mocké + interaction Discord mockée
+```
+
+---
+
+### Choix de conception
+
+#### Pourquoi ce périmètre et pas plus ?
+
+Le code du bot se répartit en quatre catégories, avec une seule réellement pertinente à tester unitairement :
+
+- **Logique pure, testée** (`cooldownManager.ts`, `embeds.ts`, `components.ts`, `travelMiddleware.ts`) : aucune dépendance à une session Discord live. `EmbedBuilder`/`ActionRowBuilder`/`ButtonBuilder`/`StringSelectMenuBuilder` (`embeds.ts`, `components.ts`) sont de simples constructeurs d'objet, exécutables hors ligne ; `travelMiddleware.ts` ne dépend que d'un appel API et d'un objet `interaction`, tous deux mockables sans introduire de framework de test Discord.
+- **Commandes slash** (`commands/mazworld/*.ts`, ex. `coinflip.ts`, `shop.ts`) : orchestrent directement `interaction.reply()`/`interaction.deferReply()` et l'état complet d'une interaction Discord. Les tester unitairement reviendrait à re-simuler l'intégralité du cycle d'interaction Discord.js pour une valeur ajoutée faible — la logique métier qu'elles orchestrent (achat, pari, travail) est déjà couverte côté backend (`CommandsController`, `ShopController`). Non testées, à l'image des controllers Symfony qui ne sont pas testés en TU mais en TI.
+- **Rendu canvas** (`profileCard.ts`) : génère une image pixel par pixel. La tester reviendrait soit à comparer des snapshots d'image (fragile, faible valeur), soit à ne tester que les deux tables de correspondance couleur/emoji qu'elle contient, ce qui ne justifie pas un fichier de test dédié. Non testé, à l'image des repositories Doctrine sans DQL custom qui ne sont pas testés côté backend car cela reviendrait à tester l'ORM lui-même.
+- **Bootstrap et scripts utilitaires** (`index.ts`, `utils/rest.ts`, `utils/clean-commands.ts`, `handlers/*`) : câblage d'événements Discord et scripts d'enregistrement de commandes exécutés une fois au déploiement. Non testés pour la même raison que `public/index.php` ou `main.ts` ne le sont pas côté backend/frontend.
+
+#### Mock du client API et de l'interaction Discord
+
+`travelMiddleware.spec.ts` mocke le module `api/client` via `vi.mock()` (le même principe que `HttpTestingController` côté Angular) et fournit un objet `interaction` minimal (`{ user, reply: vi.fn() }`) plutôt que d'instancier un vrai `ChatInputCommandInteraction` — seules les propriétés réellement utilisées par la fonction testée sont simulées.
+
+---
+
+### Contexte RNCP — Compétence C2.2.2
+
+| Couche testée | Type | Preuve |
+|---------------|------|--------|
+| Gestion des cooldowns (calcul, isolation, formatage) | TU | `cooldownManager.spec.ts` |
+| Construction des embeds Discord (branches conditionnelles) | TU | `embeds.spec.ts` |
+| Boutons/menus Discord (état disabled, options dynamiques) | TU | `components.spec.ts` |
+| Middleware de vérification de voyage (API + interaction mockées) | TU | `travelMiddleware.spec.ts` |


### PR DESCRIPTION
## Contenu

Étend la méthodologie TU/TI déjà en place côté backend (PHPUnit) et frontend (Vitest) à un troisième contexte technique : le bot Discord.

- **48 tests, 4 fichiers**, ciblés sur la logique testable sans dépendance à une session Discord live :
  - `cooldownManager.spec.ts` — calcul de cooldown, isolation par user/commande, formatage du temps
  - `embeds.spec.ts` — construction d'embeds Discord (branches conditionnelles réelles)
  - `components.spec.ts` — boutons/menus Discord (état disabled, options dynamiques)
  - `travelMiddleware.spec.ts` — appel API et interaction Discord mockés
- Périmètre volontairement restreint et justifié dans `docs/TESTING.md` : commandes slash, rendu canvas (`profileCard.ts`) et bootstrap explicitement exclus, avec la même logique méthodologique que les exclusions déjà documentées côté backend.
- Pas de chiffre de couverture affiché pour ce module — l'exigence RNCP de couverture majoritaire est déjà remplie par backend + frontend, un chiffre bot serait mécaniquement bas par nature du périmètre choisi et n'apporterait rien.

## Corrections en cours de route

- `bot/src/commands/mazworld/utils/cooldownManager.spec.ts` appelait `setCooldown` avec un argument surnuméraire (la fonction n'en prend que 2) — corrigé.
- `bot/tsconfig.json` manquait une exclusion pour `vitest.config.ts`, en conflit avec `rootDir: "src"` — aurait cassé `npm run build`. Ajout d'un `exclude` explicite (config Vitest + fichiers `.spec.ts`).

## Test plan

- [x] `npx vitest run` — 48/48 tests passent
- [x] `npx tsc --noEmit` sur les 4 fichiers de test — aucune erreur de type
- [x] `npm run build` — build de production toujours fonctionnel après le correctif tsconfig